### PR TITLE
fix: preserve Tabs roving focus targets

### DIFF
--- a/internal/records/2026-08-12-tabs-roving-web-focus-projection.zh-CN.md
+++ b/internal/records/2026-08-12-tabs-roving-web-focus-projection.zh-CN.md
@@ -1,0 +1,20 @@
+# Tabs roving 的 Web 程序化聚焦投射修复
+
+日期：2026-08-12
+
+发布归属：计划随 `0.2.0` 正式版本发布；本修复 PR 不单独修改全局版本或创建新的 release train。
+
+## 试用观察
+
+`0.2.0-rc.7` 发布后试用发现，Tabs demo 的 trigger 无法通过方向键切换焦点。Base Tabs 的 Focus Roving 语义与候选解析都已生效，但 Web Component、React、Vue adapter 会为非当前 trigger 完全移除 `tabindex`。这些 trigger 在 Web 上不是原生可聚焦元素，因此 roving request 能选中下一个成员，却无法把 native focus 应用到该 target。
+
+## 收口
+
+`C-AS-FOCUSABLE-0001-F` 已要求 `navParticipation: none` 只退出自然 Tab 顺序，不得阻止显式 focus request；`C-AS-FOCUS-ROVING-0001-G` 同样要求其余 eligible item 仍可被程序化聚焦。本次修复不改变 Tabs 组件语义，而是让 Focus host capability 显式区分：
+
+- 非 focusable surface 继续不投射 `tabindex`；
+- enabled focusable 在参与自然 Tab 顺序时投射 `tabindex="0"`；
+- enabled focusable 在退出自然 Tab 顺序时仍投射 `tabindex="-1"`，保留程序化聚焦能力；
+- disabled target 继续不可接受 focus request。
+
+Web Component、React、Vue adapter 统一遵守该投射。Base Tabs 与真实 demo renderer journey 增加回归覆盖，验证 ArrowRight 会把 focus 和 automatic selection 从 Account 移到 Password。

--- a/packages/adapters/react/src/runtime/modules.ts
+++ b/packages/adapters/react/src/runtime/modules.ts
@@ -265,9 +265,9 @@ export function createReactModules<Props extends PropsBaseType>(args: {
       [FOCUS_IS_NATIVELY_FOCUSABLE_CAP, isNativelyFocusable],
       [
         FOCUS_SET_FOCUSABLE_CAP,
-        (target: HTMLElement, enabled: boolean) => {
+        (target: HTMLElement, enabled: boolean, options?: { programmatic?: boolean }) => {
           const surface = getLogicalTriggerSurfaceRoot(instanceToken);
-          projectFocusable(target, enabled && (!surface || surface === target));
+          projectFocusable(target, enabled && (!surface || surface === target), options);
         },
       ],
       [
@@ -389,11 +389,15 @@ function isNativelyFocusable(el: HTMLElement): boolean {
   return false;
 }
 
-function projectFocusable(target: HTMLElement, enabled: boolean): void {
+function projectFocusable(
+  target: HTMLElement,
+  enabled: boolean,
+  options?: { programmatic?: boolean }
+): void {
   if (enabled) {
-    target.tabIndex = 0;
-  } else if (isNativelyFocusable(target)) {
-    target.tabIndex = -1;
+    target.setAttribute('tabindex', '0');
+  } else if (options?.programmatic || isNativelyFocusable(target)) {
+    target.setAttribute('tabindex', '-1');
   } else {
     target.removeAttribute('tabindex');
   }

--- a/packages/adapters/react/test/tabs.test.ts
+++ b/packages/adapters/react/test/tabs.test.ts
@@ -10,7 +10,7 @@ function appendHost(parent: HTMLElement): HTMLElement {
 }
 
 describe('adapter-react: base tabs compound protocol', () => {
-  it('coordinates tabs context, anatomy, a11y label, and trigger activation', () => {
+  it('coordinates tabs context, anatomy, a11y label, trigger activation, and roving focus', () => {
     const root = createMountedReactAdapter(tabsRoot, { defaultValue: 'a' });
     const rootEl = root.root as HTMLElement;
     const list = createMountedReactAdapterInto(tabsList, appendHost(rootEl), {
@@ -34,14 +34,21 @@ describe('adapter-react: base tabs compound protocol', () => {
     expect(root.ref.current?.getExposes().value.get()).toBe('a');
     expect(triggerA.ref.current?.getExposes().selected.get()).toBe(true);
     expect(contentA.ref.current?.getExposes().current.get()).toBe(true);
+    expect(triggerB.root?.getAttribute('tabindex')).toBe('-1');
 
-    triggerB.root?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    triggerA.root?.focus();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
 
+    expect(document.activeElement).toBe(triggerB.root);
     expect(root.ref.current?.getExposes().value.get()).toBe('b');
-    expect(triggerA.ref.current?.getExposes().selected.get()).toBe(false);
-    expect(triggerB.ref.current?.getExposes().selected.get()).toBe(true);
-    expect(contentA.ref.current?.getExposes().current.get()).toBe(false);
-    expect(contentB.ref.current?.getExposes().current.get()).toBe(true);
+
+    triggerA.root?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(root.ref.current?.getExposes().value.get()).toBe('a');
+    expect(triggerA.ref.current?.getExposes().selected.get()).toBe(true);
+    expect(triggerB.ref.current?.getExposes().selected.get()).toBe(false);
+    expect(contentA.ref.current?.getExposes().current.get()).toBe(true);
+    expect(contentB.ref.current?.getExposes().current.get()).toBe(false);
 
     contentB.unmount();
     contentA.unmount();

--- a/packages/adapters/vue/src/runtime/modules.ts
+++ b/packages/adapters/vue/src/runtime/modules.ts
@@ -265,9 +265,9 @@ export function createVueModules<Props extends PropsBaseType>(args: {
       [FOCUS_IS_NATIVELY_FOCUSABLE_CAP, isNativelyFocusable],
       [
         FOCUS_SET_FOCUSABLE_CAP,
-        (target: HTMLElement, enabled: boolean) => {
+        (target: HTMLElement, enabled: boolean, options?: { programmatic?: boolean }) => {
           const surface = getLogicalTriggerSurfaceRoot(instanceToken);
-          projectFocusable(target, enabled && (!surface || surface === target));
+          projectFocusable(target, enabled && (!surface || surface === target), options);
         },
       ],
       [
@@ -391,11 +391,15 @@ function isNativelyFocusable(el: HTMLElement): boolean {
 
   return false;
 }
-function projectFocusable(target: HTMLElement, enabled: boolean): void {
+function projectFocusable(
+  target: HTMLElement,
+  enabled: boolean,
+  options?: { programmatic?: boolean }
+): void {
   if (enabled) {
-    target.tabIndex = 0;
-  } else if (isNativelyFocusable(target)) {
-    target.tabIndex = -1;
+    target.setAttribute('tabindex', '0');
+  } else if (options?.programmatic || isNativelyFocusable(target)) {
+    target.setAttribute('tabindex', '-1');
   } else {
     target.removeAttribute('tabindex');
   }

--- a/packages/adapters/vue/test/tabs.test.ts
+++ b/packages/adapters/vue/test/tabs.test.ts
@@ -5,7 +5,7 @@ import { VueAny, flushVue } from './utils/vue';
 import { createVueAdapter } from '../src/adapt';
 
 describe('adapter-vue: base tabs compound protocol', () => {
-  it('coordinates tabs context, anatomy, a11y label, and trigger activation', async () => {
+  it('coordinates tabs context, anatomy, a11y label, trigger activation, and roving focus', async () => {
     const adapter = createVueAdapter(VueAny);
     const Root = adapter(tabsRoot);
     const List = adapter(tabsList);
@@ -54,23 +54,31 @@ describe('adapter-vue: base tabs compound protocol', () => {
     expect(refs.contentA?.getExposes().current.get()).toBe(true);
     expect(host.textContent).not.toContain('B panel');
     expect(host.textContent).toContain('C panel');
+    expect(refs.triggerB?.$el.getAttribute('tabindex')).toBe('-1');
 
-    refs.triggerB?.$el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    await flushVue();
+    refs.triggerA?.$el.focus();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
     await flushVue();
 
+    expect(document.activeElement).toBe(refs.triggerB?.$el);
     expect(refs.root?.getExposes().value.get()).toBe('b');
-    expect(refs.triggerA?.getExposes().selected.get()).toBe(false);
-    expect(refs.triggerB?.getExposes().selected.get()).toBe(true);
-    expect(refs.contentA?.getExposes().current.get()).toBe(false);
-    expect(refs.contentB?.getExposes().current.get()).toBe(true);
-    expect(host.textContent).toContain('B panel');
 
     refs.triggerA?.$el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await flushVue();
     await flushVue();
 
+    expect(refs.root?.getExposes().value.get()).toBe('a');
+    expect(refs.triggerA?.getExposes().selected.get()).toBe(true);
+    expect(refs.triggerB?.getExposes().selected.get()).toBe(false);
+    expect(refs.contentA?.getExposes().current.get()).toBe(true);
+    expect(refs.contentB?.getExposes().current.get()).toBe(false);
     expect(host.textContent).not.toContain('B panel');
+
+    refs.triggerB?.$el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await flushVue();
+    await flushVue();
+
+    expect(host.textContent).toContain('B panel');
     expect(host.textContent).toContain('C panel');
 
     app.unmount();

--- a/packages/adapters/web-component/src/runtime/modules.ts
+++ b/packages/adapters/web-component/src/runtime/modules.ts
@@ -364,9 +364,9 @@ export function createWebComponentModules<Props extends PropsBaseType>(args: {
       [FOCUS_IS_NATIVELY_FOCUSABLE_CAP, (target: HTMLElement) => isNativelyFocusable(target)],
       [
         FOCUS_SET_FOCUSABLE_CAP,
-        (target: HTMLElement, enabled: boolean) => {
+        (target: HTMLElement, enabled: boolean, options?: { programmatic?: boolean }) => {
           const surface = physicalControl() ?? getLogicalTriggerSurfaceRoot(instanceToken);
-          projectFocusable(target, enabled && (!surface || surface === target));
+          projectFocusable(target, enabled && (!surface || surface === target), options);
         },
       ],
       [
@@ -549,11 +549,15 @@ function isNativelyFocusable(el: HTMLElement): boolean {
   return false;
 }
 
-function projectFocusable(target: HTMLElement, enabled: boolean): void {
+function projectFocusable(
+  target: HTMLElement,
+  enabled: boolean,
+  options?: { programmatic?: boolean }
+): void {
   if (enabled) {
-    target.tabIndex = 0;
-  } else if (isNativelyFocusable(target)) {
-    target.tabIndex = -1;
+    target.setAttribute('tabindex', '0');
+  } else if (options?.programmatic || isNativelyFocusable(target)) {
+    target.setAttribute('tabindex', '-1');
   } else {
     target.removeAttribute('tabindex');
   }

--- a/packages/adapters/web-component/test/previewer.demo-renderer.test.ts
+++ b/packages/adapters/web-component/test/previewer.demo-renderer.test.ts
@@ -146,7 +146,8 @@ describe('PrototypePreviewer demo-renderer / wc', () => {
 
     const root = host.querySelector('wc-shadcn-tabs-root') as HTMLElement | null;
     const list = host.querySelector('wc-shadcn-tabs-list') as HTMLElement | null;
-    const trigger = host.querySelector('wc-shadcn-tabs-trigger') as HTMLElement | null;
+    const triggers = Array.from(host.querySelectorAll('wc-shadcn-tabs-trigger')) as HTMLElement[];
+    const trigger = triggers[0] ?? null;
     const content = host.querySelector('wc-shadcn-tabs-content') as HTMLElement | null;
 
     expect(root).not.toBeNull();
@@ -161,8 +162,18 @@ describe('PrototypePreviewer demo-renderer / wc', () => {
     expect(styleContains(list, 'h-9')).toBe(true);
     expect(styleContains(trigger, 'rounded-md')).toBe(true);
     expect(styleContains(trigger, 'flex-1')).toBe(true);
+    expect(triggers[1]?.getAttribute('tabindex')).toBe('-1');
     expect(styleContains(content, 'flex-1')).toBe(true);
     expect(styleContains(content, 'outline-none')).toBe(true);
+
+    trigger?.focus();
+    trigger?.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true })
+    );
+    await settle();
+
+    expect(document.activeElement).toBe(triggers[1]);
+    expect(triggers[1]?.getAttribute('aria-selected')).toBe('true');
 
     await session.destroy();
     host.remove();

--- a/packages/modules/focus/src/caps.ts
+++ b/packages/modules/focus/src/caps.ts
@@ -9,7 +9,11 @@ export type FocusTargetReadySubscriber = (listener: () => void) => () => void;
 
 export type FocusIsNativelyFocusable = (target: HTMLElement) => boolean;
 
-export type FocusSetFocusable = (target: HTMLElement, enabled: boolean) => void;
+export type FocusSetFocusable = (
+  target: HTMLElement,
+  enabled: boolean,
+  options?: { programmatic?: boolean }
+) => void;
 
 export type FocusRequestFocus = (
   target: HTMLElement,

--- a/packages/modules/focus/src/create.ts
+++ b/packages/modules/focus/src/create.ts
@@ -363,7 +363,9 @@ class FocusModuleImpl extends ModuleBase {
       : false;
 
     if (this.caps.has(FOCUS_SET_FOCUSABLE_CAP)) {
-      this.caps.get(FOCUS_SET_FOCUSABLE_CAP)(target, enabled);
+      this.caps.get(FOCUS_SET_FOCUSABLE_CAP)(target, enabled, {
+        programmatic: this.focusableDeclared && !this.focusableConfig.disabled,
+      });
       return;
     }
 

--- a/packages/prototypes/base/test/tabs.test.ts
+++ b/packages/prototypes/base/test/tabs.test.ts
@@ -268,6 +268,7 @@ describe('prototypes/base: tabs', () => {
 
     expect(triggerA.tabIndex).toBe(0);
     expect(triggerB.tabIndex).toBe(-1);
+    expect(triggerB.getAttribute('tabindex')).toBe('-1');
 
     triggerA.focus();
     // T-BASE-TABS-TRIGGER-0001-CASE-KEYBOARD

--- a/spec/contracts/C-AS-FOCUSABLE-0001.yaml
+++ b/spec/contracts/C-AS-FOCUSABLE-0001.yaml
@@ -36,8 +36,8 @@ criteria:
       en: A disabled focusable must not accept focus requests that activate focus facts.
   - id: C-AS-FOCUSABLE-0001-F
     text:
-      zh-CN: '`asFocusable()` 必须允许运行时切换自然导航参与状态；`navParticipation: none` 应将 target 排除出宿主顺序焦点导航，但不得等同于 disabled，也不得阻止显式 focus request。'
-      en: '`asFocusable()` must allow runtime switching of natural navigation participation; `navParticipation: none` should remove the target from host sequential focus navigation, but must not be equivalent to disabled and must not block explicit focus requests.'
+      zh-CN: '`asFocusable()` 必须允许运行时切换自然导航参与状态；`navParticipation: none` 应将 target 排除出宿主顺序焦点导航，但不得等同于 disabled，也不得阻止显式或 roving focus request。对于非原生可聚焦 target，支持该投射的 Web host 必须保留程序化聚焦能力，例如使用 `tabindex="-1"`，而不得通过完全移除 `tabindex` 使请求失效。'
+      en: '`asFocusable()` must allow runtime switching of natural navigation participation; `navParticipation: none` should remove the target from host sequential focus navigation, but must not be equivalent to disabled or block explicit or roving focus requests. For a target that is not natively focusable, a Web host supporting this projection must preserve programmatic focusability, for example with `tabindex="-1"`, rather than removing `tabindex` entirely and making the request inapplicable.'
   - id: C-AS-FOCUSABLE-0001-G
     text:
       zh-CN: 当合法的 logical focus request 发生时 host target 尚未完成 projection，Focus 必须只保留最新 pending request，并在该实例后续 commit/mounted readiness 使 target 与 logical parent 可用后重新经过 Focus Center policy 再兑现；host focus capability 必须能够拒绝当前尚不可应用的 target，且拒绝不得被解释为成功或产生 facts。当宿主的 connected 与 focus-ready 不是同一时刻时，adapter 必须通过窄化的 target-readiness host capability 发出就绪信号。retained view detach 仅结束当前 host view epoch，不得丢弃 logical owner 的 pending request；若 Portal 或后续 retained view epoch 移动或替换 native target，同一就绪信号必须把 pending 或既有 focus owner 投射到新 target，而不得伪造或改写 semantic facts。`preventScroll` request policy 必须由支持该能力的宿主投射为保持 viewport 的原生 focus option，不支持的宿主可以忽略该 policy，但不得拒绝 logical focus。pending 期间不得伪造 focus facts，blur、disabled、更新的 request、logical instance 的 terminal unmount 或 dispose 必须取消或取代旧 request。
@@ -106,6 +106,9 @@ revisions:
   - version: 0.1.9
     change: refined
     summary: Added host projection semantics for scroll-preserving focus requests.
+  - version: 0.1.10
+    change: refined
+    summary: Required navParticipation none to preserve programmatic focusability for non-native Web targets.
 tags:
   - focus
   - as-hook

--- a/spec/tests/T-BASE-TABS-LIST-0001.yaml
+++ b/spec/tests/T-BASE-TABS-LIST-0001.yaml
@@ -67,6 +67,8 @@ implementations:
     path: packages/adapters/react/test/tabs.test.ts
     required: true
     consumesCases:
+      - T-BASE-TABS-LIST-0001-CASE-ROVING-AUTOMATIC
+      - T-BASE-TABS-LIST-0001-CASE-TAB-SEQUENTIAL
       - T-BASE-TABS-LIST-0001-CASE-A11Y-LABEL
     exercises:
       - P-BASE-TABS-LIST
@@ -76,6 +78,8 @@ implementations:
     path: packages/adapters/vue/test/tabs.test.ts
     required: true
     consumesCases:
+      - T-BASE-TABS-LIST-0001-CASE-ROVING-AUTOMATIC
+      - T-BASE-TABS-LIST-0001-CASE-TAB-SEQUENTIAL
       - T-BASE-TABS-LIST-0001-CASE-A11Y-LABEL
     exercises:
       - P-BASE-TABS-LIST
@@ -108,6 +112,9 @@ revisions:
   - version: 0.1.3
     change: refined
     summary: Added coverage that vertical Tabs List delegates arrow-key roving navigation to Focus Roving.
+  - version: 0.1.4
+    change: refined
+    summary: Added regression coverage that inactive Web trigger surfaces retain tabindex minus one for arrow-key focus movement.
 tags:
   - prototype
   - base

--- a/spec/tests/T-FOCUS-0001.yaml
+++ b/spec/tests/T-FOCUS-0001.yaml
@@ -61,10 +61,10 @@ cases:
       - C-AS-FOCUSABLE-0001-E
     expectation: disabled-focus-request-rejected
   - id: T-FOCUS-0001-CASE-NAV-PARTICIPATION
-    title: Runtime navParticipation can remove a focusable from sequential navigation without disabling explicit focus requests
+    title: Runtime navParticipation removes a focusable from sequential navigation while preserving explicit and roving focus requests
     covers:
       - C-AS-FOCUSABLE-0001-F
-    expectation: nav-participation-none-does-not-disable-explicit-focus
+    expectation: nav-participation-none-preserves-programmatic-focusability
   - id: T-FOCUS-0001-CASE-PENDING-HOST-TARGET
     title: A focus request waits for host target projection without fabricating facts
     covers:
@@ -134,6 +134,13 @@ implementations:
     required: false
     consumesCases:
       - T-FOCUS-0001-CASE-UNIQUE-OWNER
+  - id: prototypes-base-tabs-nav-participation
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/tabs.test.ts
+    required: true
+    consumesCases:
+      - T-FOCUS-0001-CASE-NAV-PARTICIPATION
 verifies:
   contracts:
     - id: C-FOCUS-0001
@@ -204,6 +211,9 @@ revisions:
   - version: 0.1.11
     change: refined
     summary: Added native projection coverage for scroll-preserving focus requests.
+  - version: 0.1.12
+    change: refined
+    summary: Added Web projection coverage that sequentially excluded roving members remain programmatically focusable.
 tags:
   - focus
   - as-focusable


### PR DESCRIPTION
## Summary

- Preserve programmatic focusability for enabled focus targets that are excluded from sequential navigation.
- Project consistent `tabindex` behavior across the Web Component, React, and Vue adapters.
- Add regression coverage for Tabs keyboard navigation in the base prototype, adapters, and demo renderer.
- Refine the focusability contract and test mappings, with a dated engineering record.

## Root cause

Inactive Tabs triggers declare `navParticipation: none`. The web adapters previously removed `tabindex` from non-native trigger surfaces, so the focus module could resolve the next eligible trigger but the browser could not focus it programmatically.

## User impact

Tabs demos can once again move focus between triggers with the appropriate arrow keys. Selection follows focus as specified, across Web Component, React, and Vue projections.

## Release target

This fix is intended to ship with the **0.2.0 stable release**. This PR does not bump the repository version or create the global release train; those remain part of the dedicated release workflow.

## Validation

- `corepack pnpm@10.32.1 check:prototype-catalog`
- `corepack pnpm@10.32.1 check:agent-doc`
- `corepack pnpm@10.32.1 check:types`
- Focused Vitest suite: 13 files, 70 tests passed
- Manual browser verification of the Tabs demos for Web Component, React, and Vue
