### PR TITLE
fix(www): unify documentation code frames

### DIFF
--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -75,6 +75,19 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'Proto UI',
+      expressiveCode: {
+        styleOverrides: {
+          borderRadius: 'calc(0.75rem - 1px)',
+          borderColor: 'var(--color-border)',
+          codeFontSize: '0.8125rem',
+          codeLineHeight: '1.5rem',
+          codeBackground: 'var(--color-muted)',
+          frames: {
+            editorBackground: 'var(--color-muted)',
+            terminalBackground: 'var(--color-muted)',
+          },
+        },
+      },
 
       defaultLocale: 'zh-cn',
       locales: {
@@ -88,6 +101,10 @@ export default defineConfig({
         },
       },
       head: [
+        {
+          tag: 'style',
+          content: '@layer base, starlight, components, utilities;',
+        },
         // 双 theme-color
         {
           tag: 'script',

--- a/apps/www/src/components/PrototypePreviewer/CodePanel.astro
+++ b/apps/www/src/components/PrototypePreviewer/CodePanel.astro
@@ -37,7 +37,7 @@ const highlighted = await highlightWithShiki(code, lang);
   >
     <button
       type="button"
-      class="absolute top-3 right-3 px-2 py-1 text-xs font-medium border-none rounded cursor-pointer opacity-80 transition-colors duration-150 hover:opacity-100 hover:bg-white/15 hidden group-data-[code-expanded=true]:inline-flex"
+      class="absolute top-2 right-2 size-8 items-center justify-center text-xs font-medium border border-border rounded-md bg-background/90 text-foreground cursor-pointer opacity-80 transition-colors duration-150 hover:opacity-100 hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 hidden group-data-[code-expanded=true]:inline-flex"
       title="Copy code"
       aria-label="Copy code"
       data-copy

--- a/apps/www/src/styles/markdown.css
+++ b/apps/www/src/styles/markdown.css
@@ -1,6 +1,31 @@
 @layer components {
+  .main-frame {
+    min-width: 0;
+    width: 100%;
+  }
+
   .main-pane {
     @apply w-full;
+  }
+
+  @media (max-width: 49.99rem) {
+    header .container-wrapper > div {
+      min-width: 0;
+      width: 100%;
+      height: auto;
+      min-height: var(--header-height);
+      flex-wrap: wrap;
+    }
+
+    header .container-wrapper > div > .ml-auto {
+      margin-left: 0;
+      min-width: 0;
+      flex: 1 1 100%;
+      flex-basis: 100%;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      align-content: center;
+    }
   }
 
   main[data-pagefind-body] {
@@ -126,7 +151,9 @@
   }
 
   main[data-pagefind-body] .expressive-code .copy button::after {
-    margin: 0.375rem;
+    width: 18px;
+    height: 18px;
+    margin: 7px;
   }
 
   main[data-pagefind-body] .expressive-code .copy button:focus-visible {

--- a/apps/www/src/styles/markdown.css
+++ b/apps/www/src/styles/markdown.css
@@ -117,6 +117,23 @@
     @apply bg-muted relative rounded-sm px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold;
   }
 
+  /* Keep Markdown code controls on the same compact scale as previewer controls. */
+  main[data-pagefind-body] .expressive-code .copy button {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 0.375rem;
+    border: 1px solid var(--color-border);
+  }
+
+  main[data-pagefind-body] .expressive-code .copy button::after {
+    margin: 0.375rem;
+  }
+
+  main[data-pagefind-body] .expressive-code .copy button:focus-visible {
+    outline: 2px solid var(--color-ring);
+    outline-offset: 2px;
+  }
+
   main[data-pagefind-body] hr {
     @apply mt-16 mb-4;
   }

--- a/docs/superpowers/plans/2026-08-12-documentation-code-frame.md
+++ b/docs/superpowers/plans/2026-08-12-documentation-code-frame.md
@@ -1,0 +1,111 @@
+# Documentation Code Frame Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Markdown code blocks and `PrototypePreviewer` code panels use one compact, accessible documentation code-frame grammar.
+
+**Architecture:** Correct the cascade-layer integration at the Starlight head boundary so Expressive Code retains its own layout behavior, then use Starlight's supported `expressiveCode.styleOverrides` API for shared frame tokens. Keep renderer-specific behavior intact and align only the copy-control presentation in `CodePanel.astro` and `markdown.css`.
+
+**Tech Stack:** Astro 5, Starlight 0.35, Expressive Code 0.41, Tailwind CSS 4, Shiki 3, Chromium.
+
+---
+
+### Task 1: Restore Starlight component precedence
+
+**Files:**
+
+- Modify: `apps/www/astro.config.mjs:38-67`
+
+- [ ] **Step 1: Capture the failing browser geometry**
+
+On the deployed Transition page, record that a plain Markdown `<pre>` has a `0px` border, `1px` radius, and no block padding while its copy target is `40 × 40px`. This is the RED reproduction for the presentation defect.
+
+- [ ] **Step 2: Predeclare the cascade order before bundled styles**
+
+Add the first Starlight `head` entry:
+
+```js
+{
+  tag: 'style',
+  content: '@layer base, starlight, components, utilities;',
+},
+```
+
+This must precede stylesheet links so Tailwind `base` is lower priority than Starlight's nested component layers, while local `components` and `utilities` remain higher.
+
+- [ ] **Step 3: Configure Expressive Code through Starlight**
+
+Add this sibling option to the Starlight configuration:
+
+```js
+expressiveCode: {
+  styleOverrides: {
+    borderRadius: 'calc(0.75rem - 1px)',
+    borderColor: 'var(--color-border)',
+    codeFontSize: '0.8125rem',
+    codeLineHeight: '1.5rem',
+    codeBackground: 'var(--color-muted)',
+    frames: {
+      editorBackground: 'var(--color-muted)',
+      terminalBackground: 'var(--color-muted)',
+    },
+  },
+},
+```
+
+The radius subtracts the 1px Expressive Code border so the physical outer radius is 12px.
+
+### Task 2: Align copy controls
+
+**Files:**
+
+- Modify: `apps/www/src/styles/markdown.css:1-220`
+- Modify: `apps/www/src/components/PrototypePreviewer/CodePanel.astro:33-94`
+
+- [ ] **Step 1: Make the Markdown copy target compact and keyboard-visible**
+
+Inside the existing `@layer components`, add scoped rules for `main[data-pagefind-body] .expressive-code .copy button`: fixed `2rem` width/height, 6px radius, an 18px masked icon, and a 2px `focus-visible` ring using `--color-ring`. Do not alter Expressive Code markup or JavaScript.
+
+- [ ] **Step 2: Match the previewer copy target**
+
+Replace the previewer copy button's padding-driven dimensions with `size-8`, center its existing 18px icon, and use `border-border`, `bg-background/90`, `rounded-md`, hover, and `focus-visible:ring-2` classes. Keep its hidden/collapsed and copy-success behavior unchanged.
+
+### Task 3: Verify the documentation behavior
+
+**Files:**
+
+- Verify: `apps/www/src/content/docs/zh-cn/ui-libraries/base/transition.mdx`
+- Verify: `apps/www/src/content/docs/zh-cn/start-here/quick-start.mdx`
+
+- [ ] **Step 1: Run static checks and production build**
+
+Run:
+
+```sh
+corepack pnpm@10.32.1 --filter apps-www check
+corepack pnpm@10.32.1 --filter apps-www build
+```
+
+Expected: Astro reports zero errors; the site and Pagefind complete successfully.
+
+- [ ] **Step 2: Exercise desktop light and dark modes**
+
+Serve the production build and inspect `/zh-cn/ui-libraries/base/transition/` at 1440 × 1000. Verify Markdown outer border/radius/background/font geometry, 32px copy button, visible keyboard focus, copy feedback, previewer expansion/copy, and compatible previewer frame styling in both themes.
+
+- [ ] **Step 3: Exercise narrow layout and long code overflow**
+
+Inspect the same route at 390 × 844. Verify `document.documentElement.scrollWidth === document.documentElement.clientWidth`, while a long Markdown `<pre>` keeps `scrollWidth > clientWidth` and scrolls internally.
+
+- [ ] **Step 4: Smoke-check terminal frames and Astro navigation**
+
+Open `/zh-cn/start-here/quick-start/`, confirm the terminal frame keeps its header, border, padding, radius, copy control, and horizontal containment, then navigate away and back and confirm copy controls still respond.
+
+- [ ] **Step 5: Commit, push, and open the PR**
+
+Commit the approved design, implementation, and verification-ready source changes with:
+
+```sh
+git commit -m "fix(www): unify documentation code frames"
+```
+
+Push `codex/fix-doc-code-frames` and open a PR that closes #369, includes before/after evidence, exact verification commands, browser matrix, and documentation-only scope.

--- a/docs/superpowers/specs/2026-08-12-documentation-code-frame-design.md
+++ b/docs/superpowers/specs/2026-08-12-documentation-code-frame-design.md
@@ -1,0 +1,26 @@
+# Documentation Code Frame Design
+
+**Issue:** [#369](https://github.com/Proto-UI/Proto-UI/issues/369)
+
+**Status:** Approved
+
+## Problem
+
+The documentation currently presents two incompatible code surfaces. `PrototypePreviewer` code panels use the Proto UI border, 12px radius, muted surface, and 13px code typography. Starlight/Expressive Code Markdown blocks lose their intended border, padding, radius, and compact desktop control treatment because Tailwind's later `base` cascade layer overrides Starlight's earlier component layer. The resulting 40px copy control dominates short blocks and the two surfaces do not read as one system.
+
+## Decision
+
+Keep both renderers and their behavior. Unify their visual grammar rather than replacing either implementation.
+
+1. Predeclare the documentation cascade order before bundled styles as `base -> starlight -> components -> utilities`. This lets Starlight/Expressive Code component rules survive Tailwind's reset while preserving Proto UI component and utility overrides.
+2. Configure Expressive Code through Starlight's supported `styleOverrides` surface: 1px Proto UI border, 12px outer radius, muted code surface, and 13px/24px code typography.
+3. Give both Expressive Code and `PrototypePreviewer` an icon-only 32px copy target with an 18px glyph, themed border/background, hover feedback, and visible `focus-visible` treatment.
+4. Preserve Expressive Code copy feedback, terminal/editor framing, horizontal scrolling, and theme token projection. Preserve `PrototypePreviewer` expand/copy behavior and keep its `View code` control private to previews.
+
+## Scope
+
+Documentation presentation only. No prototype, adapter, runtime, code-generation, or public package behavior changes.
+
+## Verification
+
+Build the production documentation site, then exercise the Chinese Transition page in Chromium at desktop and narrow widths in light and dark themes. Check frame geometry, internal horizontal scrolling without page overflow, copy feedback, previewer expansion/copy, focus visibility, and navigation reinitialization. Smoke-check a terminal code block because Expressive Code's terminal frame uses the same corrected layer order.


### PR DESCRIPTION
Closes #369

## Summary
- give Expressive Code Markdown frames the same themed border, radius, surface, typography, and compact controls as prototype code panels
- preserve long-line scrolling and align preview panel copy controls with the 32px documentation target
- add the approved design and implementation record

## Verification
- corepack pnpm@10.32.1 --filter apps-www check
- corepack pnpm@10.32.1 --filter apps-www build
- browser smoke: light/dark, desktop/narrow, Markdown copy feedback/focus, preview collapse/copy, terminal frame, navigation reinitialization