### PR TITLE
fix(www): restore mobile documentation shell

### DIFF
--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -75,6 +75,7 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'Proto UI',
+      customCss: ['./src/styles/global.css'],
 
       defaultLocale: 'zh-cn',
       locales: {

--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -671,6 +671,8 @@ export default defineConfig({
         PageTitle: './src/components/override/PageTitle.astro',
         MarkdownContent: './src/components/override/MarkdownContent.astro',
         LanguageSelect: './src/components/override/LanguageSelect.astro',
+        MobileMenuToggle: './src/components/override/MobileMenuToggle.astro',
+        MobileMenuFooter: './src/components/override/MobileMenuFooter.astro',
       },
     }),
     mdx(),

--- a/apps/www/src/components/override/AdapterSelect.astro
+++ b/apps/www/src/components/override/AdapterSelect.astro
@@ -11,37 +11,14 @@ const options = [
 ];
 ---
 
-<div class="adapter-select-wrapper relative inline-flex items-center">
-  <label class="sr-only" for="adapter-select">选择适配器</label>
+<div class="adapter-select-wrapper relative inline-flex items-center" data-adapter-select>
   <select
-    id="adapter-select"
     class="adapter-select appearance-none inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all outline-none h-8 rounded-md gap-1.5 px-3 pr-8 cursor-pointer bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
     aria-label="选择适配器"
     autocomplete="off"
   >
     {options.map((opt) => <option value={opt.value}>{opt.label}</option>)}
   </select>
-  <script is:inline define:vars={{ PREFERRED_KEY, DEFAULT_ADAPTER, AdapterIds }}>
-    (function () {
-      var select = document.getElementById('adapter-select');
-      if (!select) return;
-
-      try {
-        let SelectedAdapter = localStorage.getItem(PREFERRED_KEY);
-        if (SelectedAdapter && AdapterIds.indexOf(SelectedAdapter) !== -1)
-          select.value = SelectedAdapter;
-      } catch (e) {}
-
-      select.addEventListener('change', function () {
-        try {
-          localStorage.setItem(PREFERRED_KEY, select.value);
-        } catch (e) {}
-        document.dispatchEvent(
-          new CustomEvent('proto-adapter:change', { detail: { adapter: select.value } })
-        );
-      });
-    })();
-  </script>
   <svg
     class="adapter-select-arrow absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-foreground opacity-60 transition-opacity w-4 h-4"
     width="16"
@@ -58,6 +35,45 @@ const options = [
       stroke-linecap="round"
       stroke-linejoin="round"></path>
   </svg>
+  <script is:inline define:vars={{ PREFERRED_KEY, DEFAULT_ADAPTER, AdapterIds }}>
+    (function () {
+      var script = document.currentScript;
+      var root = script && script.parentElement;
+      var select = root && root.querySelector('select');
+      if (!(select instanceof HTMLSelectElement) || select.dataset.adapterSelectReady === 'true')
+        return;
+
+      select.dataset.adapterSelectReady = 'true';
+      var supportedAdapters = AdapterIds;
+
+      try {
+        var selectedAdapter = localStorage.getItem(PREFERRED_KEY);
+        select.value =
+          selectedAdapter && supportedAdapters.indexOf(selectedAdapter) !== -1
+            ? selectedAdapter
+            : DEFAULT_ADAPTER;
+      } catch (error) {
+        select.value = DEFAULT_ADAPTER;
+      }
+
+      select.addEventListener('change', function () {
+        try {
+          localStorage.setItem(PREFERRED_KEY, select.value);
+        } catch (error) {}
+        document.dispatchEvent(
+          new CustomEvent('proto-adapter:change', { detail: { adapter: select.value } })
+        );
+      });
+
+      document.addEventListener('proto-adapter:change', function (event) {
+        var detail = event && event.detail;
+        var adapter = detail && detail.adapter;
+        if (typeof adapter === 'string' && supportedAdapters.indexOf(adapter) !== -1) {
+          select.value = adapter;
+        }
+      });
+    })();
+  </script>
 </div>
 
 <style>

--- a/apps/www/src/components/override/Header.astro
+++ b/apps/www/src/components/override/Header.astro
@@ -18,72 +18,125 @@ const shouldRenderSearch =
   config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
 
 const currentLocale = Astro.locals.starlightRoute.locale || 'en';
+const primaryNavigationLabel = currentLocale === 'zh-cn' ? '主要导航' : 'Primary navigation';
 const localizedPath = (path: string) =>
   localizedUrl(new URL(path, Astro.url), currentLocale, context.trailingSlash).pathname;
 ---
 
-<div class="container-wrapper 3xl:fixed:px-0 px-6">
-  <div
-    class="3xl:fixed:container flex h-(--header-height) items-center gap-2 **:data-[slot=separator]:!h-4"
-  >
-    <div class="title-wrapper sl-flex -ml-2">
-      <SiteTitle />
-    </div>
+<div class="shell-header">
+  <div class="title-wrapper sl-flex">
+    <SiteTitle />
+  </div>
+  <nav class="shell-primary-nav" aria-label={primaryNavigationLabel}>
     <a
-      class="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5"
-      data-slot="button"
+      class="shell-primary-link inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 h-8 rounded-md px-3"
       href={localizedPath('/start-here/what-you-saw/')}
     >
       Docs
     </a>
     <a
-      class="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5"
-      data-slot="button"
+      class="shell-primary-link inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 h-8 rounded-md px-3"
       href={localizedPath('/ui-libraries/')}
     >
       Prototypes
     </a>
     <a
-      class="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5"
-      data-slot="button"
+      class="shell-primary-link inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 h-8 rounded-md px-3"
       href={localizedPath('/whitepaper/component-as-protocol/')}
     >
       Whitepaper
     </a>
+  </nav>
 
-    <div class="ml-auto flex items-center gap-2 md:flex-1 md:justify-end">
-      <div class="sl-flex print:hidden">
-        {shouldRenderSearch && <Search />}
-      </div>
+  <div class="shell-actions">
+    <div class="shell-search sl-flex print:hidden">
+      {shouldRenderSearch && <Search />}
+    </div>
+    <div class="shell-social">
       <SocialIcons />
-      <div
-        data-orientation="vertical"
-        role="none"
-        data-slot="separator"
-        class="bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px"
-      >
-      </div>
+    </div>
+    <div class="shell-preferences">
+      <span data-slot="separator" aria-hidden="true"></span>
       <ThemeToggle />
-      <div
-        data-orientation="vertical"
-        role="none"
-        data-slot="separator"
-        class="bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px"
-      >
-      </div>
-
+      <span data-slot="separator" aria-hidden="true"></span>
       <LanguageSelect />
-
-      <div
-        data-orientation="vertical"
-        role="none"
-        data-slot="separator"
-        class="bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px"
-      >
-      </div>
+      <span data-slot="separator" aria-hidden="true"></span>
       <AdapterSelect />
     </div>
   </div>
 </div>
 
-<style></style>
+<style>
+  @layer components {
+    .shell-header {
+      display: flex;
+      width: 100%;
+      min-width: 0;
+      height: var(--header-height);
+      align-items: center;
+      gap: 0.5rem;
+      padding-inline: 0.75rem;
+      border-bottom: 1px solid var(--color-border);
+    }
+
+    :global([data-has-sidebar]) .shell-header {
+      padding-inline-end: 4rem;
+    }
+
+    .title-wrapper,
+    .shell-actions,
+    .shell-search {
+      min-width: 0;
+      align-items: center;
+    }
+
+    .shell-primary-nav,
+    .shell-social,
+    .shell-preferences {
+      display: none;
+    }
+
+    .shell-actions {
+      display: flex;
+      margin-inline-start: auto;
+      gap: 0.5rem;
+    }
+
+    .shell-preferences {
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    [data-slot='separator'] {
+      width: 1px;
+      height: 1rem;
+      flex: 0 0 auto;
+      background: var(--color-border);
+    }
+
+    @media (min-width: 50rem) {
+      .shell-header,
+      :global([data-has-sidebar]) .shell-header {
+        padding-inline: 1rem;
+      }
+
+      .shell-preferences {
+        display: flex;
+      }
+    }
+
+    @media (min-width: 64rem) {
+      .shell-primary-nav {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+      }
+    }
+
+    @media (min-width: 80rem) {
+      .shell-social {
+        display: block;
+      }
+    }
+  }
+</style>

--- a/apps/www/src/components/override/LanguageSelect.astro
+++ b/apps/www/src/components/override/LanguageSelect.astro
@@ -34,10 +34,8 @@ localeOptions.forEach((opt) => {
 });
 ---
 
-<div class="language-select-wrapper relative inline-flex items-center">
-  <label class="sr-only" for="language-select">选择语言 / Select Language</label>
+<div class="language-select-wrapper relative inline-flex items-center" data-language-select>
   <select
-    id="language-select"
     class="language-select appearance-none inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all outline-none h-8 rounded-md gap-1.5 px-3 pr-8 cursor-pointer bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
     aria-label="选择语言 / Select Language"
     autocomplete="off"
@@ -69,6 +67,61 @@ localeOptions.forEach((opt) => {
       stroke-linecap="round"
       stroke-linejoin="round"></path>
   </svg>
+  <script is:inline>
+    (function () {
+      var script = document.currentScript;
+      var root = script && script.parentElement;
+      var select = root && root.querySelector('select');
+      if (!(select instanceof HTMLSelectElement) || select.dataset.languageSelectReady === 'true')
+        return;
+
+      select.dataset.languageSelectReady = 'true';
+      var storageKey = 'preferred-locale';
+      var currentLocale = select.dataset.currentLocale || '';
+      var localePaths = {};
+
+      try {
+        localePaths = JSON.parse(select.dataset.localePaths || '{}');
+      } catch (error) {
+        console.error('[Language Select] Failed to parse locale paths:', error);
+        return;
+      }
+
+      function setPreference(locale) {
+        try {
+          localStorage.setItem(storageKey, locale);
+        } catch (error) {}
+
+        var expires = new Date();
+        expires.setFullYear(expires.getFullYear() + 1);
+        document.cookie =
+          'preferred-locale=' +
+          encodeURIComponent(locale) +
+          '; path=/; expires=' +
+          expires.toUTCString() +
+          '; SameSite=Lax';
+      }
+
+      function getCookieValue(name) {
+        var match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+        return match ? decodeURIComponent(match[1]) : '';
+      }
+
+      select.addEventListener('change', function () {
+        var newLocale = select.value;
+        var newPath = localePaths[newLocale];
+        if (newPath && newLocale && newLocale !== currentLocale) {
+          setPreference(newLocale);
+          window.location.pathname = newPath;
+        }
+      });
+
+      try {
+        var stored = localStorage.getItem(storageKey);
+        if (stored && stored !== getCookieValue(storageKey)) setPreference(stored);
+      } catch (error) {}
+    })();
+  </script>
 </div>
 
 <style>
@@ -102,71 +155,3 @@ localeOptions.forEach((opt) => {
     }
   }
 </style>
-
-<script is:inline>
-  (function () {
-    const STORAGE_KEY = 'preferred-locale';
-
-    function setPreference(locale) {
-      try {
-        localStorage.setItem(STORAGE_KEY, locale);
-      } catch (e) {
-        // ignore storage errors (e.g. private mode)
-      }
-
-      // Save user's language preference to Cookie (valid for 1 year)
-      const expires = new Date();
-      expires.setFullYear(expires.getFullYear() + 1);
-      document.cookie = `preferred-locale=${locale}; path=/; expires=${expires.toUTCString()}; SameSite=Lax`;
-    }
-
-    function getCookieValue(name) {
-      const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
-      return match ? decodeURIComponent(match[1]) : '';
-    }
-
-    function initLanguageSelect() {
-      const select = document.getElementById('language-select');
-      if (!select) return;
-
-      const currentLocale = select.dataset.currentLocale || '';
-      let localePaths = {};
-      try {
-        localePaths = JSON.parse(select.dataset.localePaths || '{}');
-      } catch (e) {
-        console.error('[Language Select] Failed to parse locale paths:', e);
-        return;
-      }
-
-      function handleLanguageChange() {
-        const newLocale = select.value;
-        const newPath = localePaths[newLocale];
-
-        if (newPath && newLocale && newLocale !== currentLocale) {
-          setPreference(newLocale);
-          console.log('[Language Switch] Saved locale preference:', newLocale);
-          window.location.pathname = newPath;
-        }
-      }
-
-      // If localStorage has a preferred locale, keep cookie in sync
-      try {
-        const stored = localStorage.getItem(STORAGE_KEY);
-        if (stored && stored !== getCookieValue(STORAGE_KEY)) {
-          setPreference(stored);
-        }
-      } catch (e) {
-        // ignore storage errors
-      }
-
-      select.addEventListener('change', handleLanguageChange);
-    }
-
-    // Ensure DOM is ready
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', initLanguageSelect);
-    } else {
-      initLanguageSelect();
-    }
-  })();
-</script>

--- a/apps/www/src/components/override/MobileMenuFooter.astro
+++ b/apps/www/src/components/override/MobileMenuFooter.astro
@@ -1,0 +1,42 @@
+---
+import AdapterSelect from './AdapterSelect.astro';
+import LanguageSelect from './LanguageSelect.astro';
+import SocialIcons from './SocialIcons.astro';
+import ThemeToggle from './ThemeToggle.astro';
+---
+
+<div class="mobile-preferences">
+  <div class="mobile-preferences__social">
+    <SocialIcons />
+  </div>
+  <div class="mobile-preferences__controls">
+    <ThemeToggle />
+    <LanguageSelect />
+    <AdapterSelect />
+  </div>
+</div>
+
+<style>
+  @layer components {
+    .mobile-preferences {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      margin-top: 1rem;
+      padding: 1rem 0 0.5rem;
+      border-top: 1px solid var(--color-border);
+    }
+
+    .mobile-preferences__social,
+    .mobile-preferences__controls {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .mobile-preferences__controls {
+      justify-content: space-between;
+    }
+  }
+</style>

--- a/apps/www/src/components/override/MobileMenuToggle.astro
+++ b/apps/www/src/components/override/MobileMenuToggle.astro
@@ -1,0 +1,147 @@
+<starlight-menu-button class="print:hidden">
+  <button
+    type="button"
+    aria-expanded="false"
+    aria-label={Astro.locals.t('menuButton.accessibleLabel')}
+    aria-controls="starlight__sidebar"
+  >
+    <svg class="open-menu" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M4 6h16M4 12h16M4 18h16"></path>
+    </svg>
+    <svg class="close-menu" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="m6 6 12 12M18 6 6 18"></path>
+    </svg>
+  </button>
+</starlight-menu-button>
+
+<script>
+  class ProtoUiMobileMenuButton extends HTMLElement {
+    private button: HTMLButtonElement | null = null;
+    private readonly desktopMedia = window.matchMedia('(min-width: 50rem)');
+    private initialized = false;
+
+    private readonly handleClick = () => {
+      this.setExpanded(this.getAttribute('aria-expanded') !== 'true');
+    };
+
+    private readonly handleKeydown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && this.getAttribute('aria-expanded') === 'true') {
+        this.setExpanded(false);
+        this.button?.focus();
+      }
+    };
+
+    private readonly handleViewportChange = (event: MediaQueryListEvent) => {
+      if (event.matches) this.setExpanded(false);
+    };
+
+    connectedCallback() {
+      if (this.initialized) return;
+      this.button = this.querySelector('button');
+      if (!this.button) return;
+
+      this.initialized = true;
+      this.button.addEventListener('click', this.handleClick);
+      document.addEventListener('keydown', this.handleKeydown);
+      this.desktopMedia.addEventListener('change', this.handleViewportChange);
+      this.setExpanded(false);
+    }
+
+    disconnectedCallback() {
+      this.button?.removeEventListener('click', this.handleClick);
+      document.removeEventListener('keydown', this.handleKeydown);
+      this.desktopMedia.removeEventListener('change', this.handleViewportChange);
+      if (this.getAttribute('aria-expanded') === 'true') {
+        document.body.removeAttribute('data-mobile-menu-expanded');
+      }
+      this.initialized = false;
+    }
+
+    private setExpanded(expanded: boolean) {
+      const value = String(expanded);
+      this.setAttribute('aria-expanded', value);
+      this.button?.setAttribute('aria-expanded', value);
+      document.body.toggleAttribute('data-mobile-menu-expanded', expanded);
+    }
+  }
+
+  if (!customElements.get('starlight-menu-button')) {
+    customElements.define('starlight-menu-button', ProtoUiMobileMenuButton);
+  }
+</script>
+
+<style>
+  @layer components {
+    starlight-menu-button {
+      display: block;
+    }
+
+    button {
+      position: fixed;
+      inset-block-start: calc((var(--header-height) - 2.5rem) / 2);
+      inset-inline-end: 0.75rem;
+      z-index: 60;
+      display: flex;
+      width: 2.5rem;
+      height: 2.5rem;
+      align-items: center;
+      justify-content: center;
+      padding: 0;
+      border: 1px solid var(--color-border);
+      border-radius: 0.5rem;
+      background: var(--color-foreground);
+      color: var(--color-background);
+      box-shadow: var(--shadow-sm);
+      cursor: pointer;
+    }
+
+    button:hover {
+      background: color-mix(in oklab, var(--color-foreground) 88%, var(--color-background));
+    }
+
+    button:focus-visible {
+      outline: 2px solid var(--color-ring);
+      outline-offset: 2px;
+    }
+
+    svg {
+      width: 1.25rem;
+      height: 1.25rem;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 2;
+      stroke-linecap: round;
+    }
+
+    [aria-expanded='true'] button {
+      background: var(--color-muted);
+      color: var(--color-foreground);
+      box-shadow: none;
+    }
+
+    [aria-expanded='true'] .open-menu,
+    :not([aria-expanded='true']) .close-menu {
+      display: none !important;
+    }
+
+    @media (min-width: 50rem) {
+      starlight-menu-button {
+        display: none;
+      }
+    }
+  }
+</style>
+
+<style is:global>
+  @layer components {
+    body[data-mobile-menu-expanded] {
+      overflow: hidden;
+    }
+
+    @media (min-width: 50rem) {
+      body[data-mobile-menu-expanded] {
+        overflow: auto;
+      }
+    }
+  }
+</style>

--- a/apps/www/src/components/override/PageFrame.astro
+++ b/apps/www/src/components/override/PageFrame.astro
@@ -1,47 +1,100 @@
 ---
-import MobileMenuToggle from '@astrojs/starlight/components/MobileMenuToggle.astro';
+import MobileMenuToggle from './MobileMenuToggle.astro';
 import '../../styles/global.css';
 
 const { hasSidebar } = Astro.locals.starlightRoute;
 ---
 
 <div
-  class="bg-background text-foreground group/body overscroll-none font-sans antialiased [--footer-height:calc(var(--spacing)*14)] [--header-height:calc(var(--spacing)*14)] xl:[--footer-height:calc(var(--spacing)*24)]"
+  class="page-shell bg-background text-foreground group/body overscroll-none font-sans antialiased [--footer-height:calc(var(--spacing)*14)] [--header-height:calc(var(--spacing)*14)] xl:[--footer-height:calc(var(--spacing)*24)]"
 >
-  <div class="bg-background container-wrapper flex flex-1 flex-col px-2">
-    <header class="bg-background sticky top-0 z-50 w-full"><slot name="header" /></header>
-    <div
-      class="bg-background group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex w-full 3xl:fixed:container 3xl:fixed:px-3 min-h-min flex-1 items-start px-0 [--sidebar-width:220px] [--top-spacing:0] lg:grid lg:grid-cols-[var(--sidebar-width)_minmax(0,1fr)] lg:[--sidebar-width:240px] lg:[--top-spacing:calc(var(--spacing)*4)]"
-    >
-      {
-        hasSidebar && (
-          <>
-            <nav
-              class="no-scrollbar overflow-scroll text-sidebar-foreground w-(--sidebar-width) flex-col sticky top-[calc(var(--header-height)+1px)] z-30 hidden h-[calc(100svh-var(--header-height))] bg-transparent lg:flex"
-              aria-label={Astro.locals.t('sidebarNav.accessibleLabel')}
-            >
-              <MobileMenuToggle />
-              <div id="starlight__sidebar" class="sidebar-pane">
-                <div class="sidebar-content sl-flex">
-                  <slot name="sidebar" />
-                </div>
-              </div>
-            </nav>
-            <div class="main-frame">
-              <slot />
-            </div>
-          </>
-        )
-      }
-    </div>
+  <header class="shell-header bg-background sticky top-0 z-50 w-full">
+    <slot name="header" />
+  </header>
+  <div
+    class="shell-layout bg-background 3xl:fixed:container 3xl:fixed:px-3 [--sidebar-width:220px] lg:[--sidebar-width:240px]"
+  >
     {
-      !hasSidebar && (
-        <div class="main-frame">
-          <slot />
-        </div>
+      hasSidebar && (
+        <nav
+          class="sidebar-nav no-scrollbar text-sidebar-foreground"
+          aria-label={Astro.locals.t('sidebarNav.accessibleLabel')}
+        >
+          <MobileMenuToggle />
+          <div id="starlight__sidebar" class="sidebar-pane">
+            <div class="sidebar-content">
+              <slot name="sidebar" />
+            </div>
+          </div>
+        </nav>
       )
     }
+    <div class="main-frame">
+      <slot />
+    </div>
   </div>
 </div>
 
-<style></style>
+<noscript>
+  <style is:inline>
+    @media (max-width: 49.999rem) {
+      starlight-menu-button {
+        display: none !important;
+      }
+
+      .shell-layout {
+        display: block !important;
+      }
+
+      .sidebar-nav,
+      .sidebar-pane {
+        position: static !important;
+        width: 100% !important;
+        height: auto !important;
+        visibility: visible !important;
+      }
+    }
+  </style>
+</noscript>
+
+<style>
+  @layer components {
+    .page-shell {
+      width: 100%;
+      min-width: 0;
+      min-height: 100vh;
+    }
+
+    .shell-layout {
+      display: flex;
+      width: 100%;
+      min-width: 0;
+      align-items: flex-start;
+    }
+
+    .sidebar-nav {
+      width: 0;
+      min-width: 0;
+    }
+
+    .main-frame {
+      width: 100%;
+      min-width: 0;
+    }
+
+    @media (min-width: 50rem) {
+      .shell-layout {
+        display: grid;
+        grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+      }
+
+      .sidebar-nav {
+        position: sticky;
+        inset-block-start: var(--header-height);
+        width: var(--sidebar-width);
+        height: calc(100svh - var(--header-height));
+        overflow-y: auto;
+      }
+    }
+  }
+</style>

--- a/apps/www/src/components/override/PageFrame.astro
+++ b/apps/www/src/components/override/PageFrame.astro
@@ -1,6 +1,5 @@
 ---
 import MobileMenuToggle from './MobileMenuToggle.astro';
-import '../../styles/global.css';
 
 const { hasSidebar } = Astro.locals.starlightRoute;
 ---
@@ -12,7 +11,10 @@ const { hasSidebar } = Astro.locals.starlightRoute;
     <slot name="header" />
   </header>
   <div
-    class="shell-layout bg-background 3xl:fixed:container 3xl:fixed:px-3 [--sidebar-width:220px] lg:[--sidebar-width:240px]"
+    class:list={[
+      'shell-layout bg-background 3xl:fixed:container 3xl:fixed:px-3 [--sidebar-width:220px] lg:[--sidebar-width:240px]',
+      hasSidebar && 'has-sidebar',
+    ]}
   >
     {
       hasSidebar && (
@@ -85,6 +87,10 @@ const { hasSidebar } = Astro.locals.starlightRoute;
     @media (min-width: 50rem) {
       .shell-layout {
         display: grid;
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      .shell-layout.has-sidebar {
         grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
       }
 

--- a/apps/www/src/components/override/SiteTitle.astro
+++ b/apps/www/src/components/override/SiteTitle.astro
@@ -5,7 +5,7 @@ const { siteTitle, siteTitleHref } = Astro.locals.starlightRoute;
 
 <a
   href={siteTitleHref}
-  class="items-center justify-center gap-2 whitespace-nowrap rounded-md text-md font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 hidden h-8 px-2 lg:flex"
+  class="flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-md font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 h-8 px-2"
 >
   <span class:list={{ 'sr-only': config.logo?.replacesTitle }} translate="no">
     {siteTitle}

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -1,3 +1,5 @@
+@layer base, starlight, components, utilities;
+
 @import './tailwindcss.css';
 @import './proto-ui-style.css';
 @import './search-trigger.css';

--- a/apps/www/src/styles/markdown.css
+++ b/apps/www/src/styles/markdown.css
@@ -1,6 +1,6 @@
 @layer components {
   .main-pane {
-    @apply w-full;
+    @apply w-full min-w-0;
   }
 
   main[data-pagefind-body] {
@@ -41,7 +41,10 @@
   }
 
   main[data-pagefind-body] table {
-    @apply mt-6 w-full text-sm border border-border rounded-lg overflow-hidden bg-background;
+    @apply mt-6 w-full text-sm border border-border rounded-lg bg-background;
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
     border-collapse: separate;
     border-spacing: 0;
   }
@@ -115,6 +118,19 @@
   /* 仅对行内 code 应用样式，排除 pre>code 代码块（如 Shiki 高亮），避免暗色模式下黑色矩形 */
   main[data-pagefind-body] :not(pre) > code {
     @apply bg-muted relative rounded-sm px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold;
+  }
+
+  main[data-pagefind-body] :not(pre) > code {
+    overflow-wrap: anywhere;
+  }
+
+  main[data-pagefind-body] pre,
+  main[data-pagefind-body] .expressive-code {
+    max-width: 100%;
+  }
+
+  main[data-pagefind-body] pre {
+    overflow-x: auto;
   }
 
   main[data-pagefind-body] hr {
@@ -212,8 +228,8 @@
 
     main[data-pagefind-body]
       .enhanced-image-wrapper:has(.enhanced-image[src$='/diagrams/information-flow-model.svg']) {
-      width: calc(100vw - 4rem);
-      max-width: calc(100vw - 4rem);
+      width: 100%;
+      max-width: 100%;
       margin-inline: 0;
     }
 

--- a/apps/www/src/styles/sidebar.css
+++ b/apps/www/src/styles/sidebar.css
@@ -1,18 +1,30 @@
 @layer components {
   .sidebar-pane {
-    @apply pt-4 pb-12 text-sidebar-foreground w-(--sidebar-width) flex-col z-30 hidden bg-transparent lg:flex;
+    position: fixed;
+    inset-block: var(--header-height) 0;
+    inset-inline: 0;
+    z-index: 40;
+    display: flex;
+    width: 100%;
+    visibility: hidden;
+    flex-direction: column;
+    overflow-y: auto;
+    background: var(--color-background);
+    color: var(--color-sidebar-foreground);
+  }
+
+  starlight-menu-button[aria-expanded='true'] ~ .sidebar-pane {
+    visibility: visible;
   }
 
   .sidebar-pane .sidebar-content {
-    @apply w-full;
-  }
-
-  .sidebar-pane .sidebar-content {
-    @apply w-full;
+    width: 100%;
+    min-height: max-content;
+    padding: 0.75rem 1rem 1.5rem;
   }
 
   .sidebar-pane .top-level {
-    @apply w-full;
+    width: 100%;
   }
 
   .sidebar-pane summary {
@@ -27,16 +39,19 @@
   .sidebar-pane details {
     @apply p-2;
   }
+
   .sidebar-pane details ul {
     @apply flex flex-col gap-0.5;
   }
 
   .sidebar-pane a {
-    @apply h-7.5 flex items-center font-medium flex justify-between;
+    @apply h-7.5 flex items-center font-medium justify-between;
   }
+
   .sidebar-pane a span {
     @apply px-2 h-full rounded-sm flex items-center border-transparent text-[13px] leading-5;
   }
+
   .sidebar-pane a:hover span {
     @apply bg-muted border-muted;
   }
@@ -49,5 +64,20 @@
   :where(a)[aria-current='page']:hover,
   :where(a)[aria-current='page']:focus {
     background: transparent;
+  }
+
+  @media (min-width: 50rem) {
+    .sidebar-pane {
+      position: static;
+      width: 100%;
+      height: 100%;
+      visibility: visible;
+      overflow: visible;
+      background: transparent;
+    }
+
+    .sidebar-pane .sidebar-content {
+      padding: 1rem 0 3rem;
+    }
   }
 }


### PR DESCRIPTION
Closes #348

## Summary
- replace the hidden narrow-screen sidebar entry with an accessible Starlight-compatible menu button and full-width navigation drawer
- keep search in the compact header while moving theme, locale, adapter, and social controls into the mobile navigation footer
- constrain shell, Markdown tables, inline code, code blocks, and Expressive Code surfaces so wide content scrolls locally
- preserve a semantic no-script navigation fallback and the existing desktop information hierarchy

## Verification
- `corepack pnpm@10.32.1 --filter apps-www check` — 136 Astro files, 0 errors/warnings/hints
- `corepack pnpm@10.32.1 --filter apps-www build` — 190 pages built; 188 pages indexed
- `git diff --check`

## Manual browser coverage
Chromium:
- `/en/start-here/what-you-saw/` at 360×800, 390×844, 799×900, 800×900, and 1440×900
- `/en/specifications/anatomy/` at 768×1024
- `/zh-cn/ui-libraries/base/transition/` at 360×800
- `/en/ui-libraries/brutalist/components/card/` at 1024×900

Exercised menu open/close, Escape focus return, search open/close, theme, locale navigation, adapter synchronization, desktop breakpoints, long-code local scrolling, and no-script navigation. At 360, 390, 768, 799, 800, 1024, and 1440 pixels, `documentElement.scrollWidth === clientWidth` on the tested pages.
