### PR TITLE
docs: record v0.3 prototype coverage plan

### DIFF
--- a/internal/records/2026-08-13-v0.3-prototype-coverage-and-shadcn-parity.zh-CN.md
+++ b/internal/records/2026-08-13-v0.3-prototype-coverage-and-shadcn-parity.zh-CN.md
@@ -1,0 +1,296 @@
+# 2026-08-13 v0.3 Prototype 扩充与 shadcn / Brutalist 覆盖规划
+
+> Internal record. Not normative. 本文记录 Proto UI 0.3 原型扩充的市场比较基线、分类治理与后续 Issue 发布方法。稳定语义仍以 `spec/**` 为准；本文不会把第三方组件名称、数量或 API 直接提升为 Proto UI 合同。
+
+---
+
+## 1）背景
+
+Proto UI 0.2 已完成 Prototypes 的第一轮 spec 编目，因此 0.3 可以开始扩充原型覆盖。同期的 Adapter、modules 与 host-cap 仍需完成各自的一轮编目；Adapter 扩充应等待该工作完成后再启动，不应因为原型候选增多而提前绕过这一门槛。
+
+0.3 对原型库有三个相互关联但不同的规划方向：
+
+- 扩充 Base 语义原型，覆盖已经形成跨宿主共识且具有独立信息路径的交互家族；
+- 扩充 shadcn 系列投影，并明确目录项中的 composition、provider/system 与 excluded 身份；
+- 把 Brutalist 作为独立的双轨设计系统：一条轨道投影成熟 Base 语义，另一条轨道容纳经过视觉合同准入的 direct styled-only 原型。
+
+现有开放提案已经覆盖两个方向：
+
+- [#349 Define the Base Radio and Radio Group semantic slice](https://github.com/Proto-UI/Proto-UI/issues/349)：2026-08-12 的 maintainer checkpoint 已批准，后续应另建有界 Base 实施 Issue；
+- [#374 Introduce the Base Image host-mediated semantic slice](https://github.com/Proto-UI/Proto-UI/issues/374)：仍处于 maintainer semantic checkpoint，Avatar 与设计语言投影不得越过该依赖先行发布。
+
+在继续发布 Issue 前，需要先回答：市场目录中的哪些名称代表真正的新语义原型，哪些只是现有原型的设计投影、direct styled-only 视觉原型、组合配方、provider 或应用级系统。
+
+## 2）比较基线
+
+### 2.1 基线日期与来源
+
+本轮比较冻结在 **2026-08-13**。第三方目录会持续变化，因此这些数字只用于当前分类，不构成长期兼容、实现数量或发版承诺。
+
+| 项目 | 快照规模 | 本轮用途 | 来源 |
+| --- | --: | --- | --- |
+| shadcn/ui | 64 个官方 Components 条目 | shadcn 系列目录名称与处置基线 | <https://ui.shadcn.com/docs/components> |
+| Base UI | 37 个 Components 条目 | Base 语义家族的主要 headless 对照 | <https://base-ui.com/llms.txt> |
+| Radix Primitives | 30 个 Components 条目 | 稳定交互原语与 anatomy 对照 | <https://www.radix-ui.com/primitives/docs/components> |
+| React Aria | 官方表述为 50+ 个组件 | 日期、集合、输入、国际化与高级交互的广度参照 | <https://react-aria.adobe.com/> |
+| WAI-ARIA APG | 语义模式目录，不按组件库数量计 | 判断交互模式、角色关系和键盘行为是否已有公共基线 | <https://www.w3.org/WAI/ARIA/apg/patterns/> |
+
+这些目录的计数口径并不相同：Radix 和 Base UI 主要列举 headless 交互原语；React Aria 还包含更广的输入、日期和集合能力；shadcn/ui 同时列举行为组件、被动样式组件、组合配方、provider 和应用级系统。因此不能直接把 shadcn 的 64 个名称转换成 64 个 Base 原型。
+
+### 2.2 Proto UI 当前覆盖
+
+`packages/prototypes/base/src/index.ts` 当前导出约 16 个顶层原型家族：
+
+- Button、Toggle、Switch、Checkbox、Tabs
+- Dialog、Dropdown Menu、Select、Hover Card、Tooltip
+- Separator、Scroll Area、Textarea
+- Transition、Live Region、Async Region
+
+`packages/prototypes/shadcn/src/index.ts` 当前覆盖 8 个 shadcn 家族：
+
+- Button
+- Dialog
+- Dropdown Menu
+- Hover Card
+- Select
+- Switch
+- Tabs
+- Toggle
+
+因此，以 shadcn 目录条目为粗略分母，当前直接覆盖为 `8 / 64`。这个比例只反映系列投影的数量缺口，不能用来衡量 Proto UI 已有语义能力，因为 Checkbox、Scroll Area、Separator、Textarea 和 Tooltip 已具备 Base 原型，只是尚未建立 shadcn 投影。
+
+`packages/prototypes/brutalist/src/index.ts` 当前导出的 Brutalist 家族分成两个账本：
+
+- Semantic projection：Button、Toggle、Switch、Tabs、HoverCard、Dropdown、Select、Dialog、ScrollArea、Textarea、Separator；
+- Direct styled-only：Skeleton、Badge、Card。
+
+这两个账本分别标识、分别计数。Brutalist 不是 shadcn 的镜像，也不会因为 Base 或 shadcn 出现一个名称就自动增加同名原型。
+
+### 2.3 当前 catalog 门槛
+
+与下一轮候选高度相关的 module 与 host-cap 已经进入 spec，但多数仍为 `draft`，包括：
+
+- `M-A11Y-0001` / `HC-A11Y-0001`
+- `M-COLLECTION-0001`
+- `M-POSITIONING-0001` / `HC-ANCHORED-POSITION-0001`
+- `M-SCROLL-0001` / `HC-SCROLL-SURFACE-0001`
+- `M-TEXT-CONTROL-0001` / `HC-TEXT-CONTROL-0001`
+- `HC-MOVE-GESTURE-0001`
+
+其中 Text Control 当前明确描述 multiline plain-text editor。Input 不能在没有审计的情况下直接复用 Textarea 合同，并假定 single-line、selection、composition、submit/default action 等差异已经被覆盖。
+
+## 3）问题定义
+
+如果只按照第三方组件名称或数量补覆盖，会产生几种风险：
+
+1. 为 Card、Typography、Direction、Sidebar 等条目制造并不存在的独立 Base 交互语义；
+2. 把 Date Picker、Data Table 等多原型组合错误压缩成单一原型；
+3. 在 module 或 host-cap 边界尚未完成编目时，通过 prototype 实现隐式发明宿主能力；
+4. 让持续变化的 shadcn 官方目录成为无法冻结的发版门槛；
+5. 让 Brutalist 退化为 shadcn 的附属镜像，或为没有独立视觉表面的 Base 协议制造薄包装；
+6. 按 64 个名称机械发布 Issue，形成大量缺乏人工分类与依赖边界的任务；
+7. 提前进入 Adapter 扩充，破坏 0.3 的工作顺序。
+
+本轮需要的不是一张简单的“缺失组件列表”，而是一套可以指导分类、Issue 发布、依赖排序和状态报告的治理方法。
+
+## 4）三账本一矩阵
+
+### 4.1 总 Coverage Matrix
+
+建立一个权威 Coverage Matrix。每一行代表一个冻结市场目录项或 Proto UI 自主候选，至少记录：
+
+- 候选名称与快照来源；
+- 唯一主身份：`existing`、`semantic`、`projection`、`styled-only`、`composition`、`provider/system` 或 `excluded`；
+- Base、shadcn、Brutalist 三条线分别如何处置；
+- 前置 prototype、module、host-cap 与 test entity；
+- owner、难度、目标波次、当前状态和已有 Issue/PR；
+- 已有证据与仍待调研问题。
+
+冻结快照中的 64 个 shadcn 条目都必须得到人工确认的唯一主分类和明确去向。**分类闭环不等于实现闭环**：矩阵必须把 `implemented`、`ready`、`research`、`blocked`、`deferred`、`composition/provider/system` 与 `excluded` 分开报告，不能把它们折叠成一个“覆盖数量”。
+
+### 4.2 Base 语义账本
+
+Base 只收录拥有独立、可测试、跨宿主信息路径的语义协议。准入必须同时满足：
+
+1. **独立信息路径**：拥有可测试、跨宿主的状态、事件或可访问性通道。anatomy 名、空 props、源文件或 `asHook` 入口本身都不是协议；
+2. **module/host-cap 就绪**：所需底层能力已经 active，或其 draft 已明确可依赖边界；不能在 prototype 内隐式发明宿主能力；
+3. **无更简单归属**：若候选只是现有协议的组合或视觉投影，就不应建立独立 Base。
+
+Base UI / Radix 约 30–37 个家族只提供市场量级观察。把 Base 从当前约 16 个家族扩展到约 30–35 个不是准入条件或 release gate，不得为了达到区间而建立薄协议。
+
+### 4.3 shadcn 处置账本
+
+目标是解释冻结的 64 个目录项，而不是复制 64 套 API。Composition 不冒充独立 semantic primitive；provider 和 application system 也不冒充 prototype。
+
+`51`、`63 / 64` 或 `51 + 12 + 1 = 64` 只能描述特定快照下的观察或分类结果，不能成为包、导出、spec entity、实施数量或发版门槛。快照之后的新目录项进入 review queue，不自动改变 0.3 范围。
+
+### 4.4 Brutalist 双轨账本
+
+**第 1 轨 — Semantic projection**
+
+- 消费已经成立且足够成熟的 Base 协议；
+- 该协议还必须具有可观察、可设计的宿主表面；
+- 只负责 Brutalist 视觉语法，不重定义状态、事件、可访问性或宿主能力；
+- Transition、Live Region、Async Region 默认不建立薄包装：它们没有独立 Brutalist 视觉表面，应由实际 styled prototype 消费。
+
+**第 2 轨 — Direct styled-only**
+
+- 不虚构 Base carrier 或交互语义；
+- 必须拥有清晰、稳定、可复用、可测试的视觉/anatomy/API 合同；
+- 同一合同必须至少在两种真实组合中成立；
+- 不能只是一串共享 class 或应用内容片段；
+- 必须写出可执行的正向和缺席证据，以及 accessibility、async、activation、layout、announcement 的所有权边界。
+
+所有进入 Brutalist 双轨的实施候选，都必须经过 Brutalist 领域共同负责人对身份、视觉合同、利旧范围和难度的确认。共同签字前只能保留在 research queue 或 Matrix，不发布实施 Issue。
+
+## 5）2026-08-13 shadcn 快照分类
+
+以下分组完整覆盖冻结快照中的 64 个条目；分组是调研入口，不替代 Matrix 中的逐行唯一主身份。
+
+| 分组 | 数量 | 条目 | 初始处置 |
+| --- | --: | --- | --- |
+| 已覆盖 | 8 | Button、Dialog、Dropdown Menu、Hover Card、Select、Switch、Tabs、Toggle | 保持并补齐质量与文档 |
+| A：投影与被动候选 | 18 | Checkbox、Scroll Area、Separator、Textarea、Tooltip、Alert、Aspect Ratio、Badge、Breadcrumb、Button Group、Card、Empty、Item、Kbd、Skeleton、Spinner、Table、Typography | 既有 Base 投影、direct styled-only 调研、结构/内容组合或 Table 结构语义提案 |
+| B：核心语义候选 | 14 | Accordion、Alert Dialog、Avatar、Collapsible、Field、Input、Label、Native Select、Popover、Progress、Radio Group、Slider、Toast、Toggle Group | 逐项建立语义边界与依赖，不承诺全部在 0.3 实现 |
+| C：高级交互 | 11 | Calendar、Carousel、Combobox、Command、Context Menu、Drawer、Input OTP、Menubar、Navigation Menu、Pagination、Resizable | 等待相关 module/host-cap 编目达到可依赖状态 |
+| D：组合与系统 | 12 | Attachment、Bubble、Data Table、Date Picker、Direction、Input Group、Marker、Message、Message Scroller、Questionnaire、Sheet、Sidebar | composition、provider/system、内容组件或应用级配方 |
+| 明确排除 | 1 | Chart | 复杂图表领域，不进入本轮对齐范围 |
+
+### 5.1 近期真实投影缺口
+
+已有 Base 语义且具有可设计表面的近期缺口是：
+
+- shadcn：Checkbox、Scroll Area、Separator、Textarea、Tooltip；
+- Brutalist：Checkbox、Tooltip。
+
+Radio Group 的 Brutalist 投影必须等待 #349 已批准的 Base 合同真正实现并合入；工作分支不能被当作当前稳定事实。
+
+### 5.2 Brutalist direct styled-only research queue
+
+第一批只调研 Alert、Spinner、Kbd：
+
+- Alert：验证稳定 visual anatomy 与 tone，并明确被动 surface 不拥有 Live Region 或 Toast 的动态公告语义；
+- Spinner：验证可复用视觉/动效合同；busy、loading 与 announcement 仍由父级异步边界拥有；
+- Kbd：验证键帽展示语法是否形成独立 anatomy/API，而不只是共享 class。
+
+它们当前只是 research candidates，不是准入或实施结果。当前不进入该队列：
+
+- Avatar：先完成 Image→Avatar 语义依赖研究；
+- Typography：作为 shared style/content 处理；
+- Empty / Placeholder：当前只支持内容组合；
+- Item / Breadcrumb：当前只支持组合或结构组件；
+- Button Group：先作为 Button / Toggle / Toolbar 组合问题研究；
+- Table：进入 Base 结构语义账本，不走 styled-only。
+
+### 5.3 Base Table 边界
+
+Base Table 的提案必须先证明独立跨宿主信息路径。若准入，Base 只拥有：
+
+- table / caption / header / body / row / header-cell / cell 的结构关系；
+- 这些关系的跨宿主可访问性投影；
+- 结构有效性与 anatomy/cardinality 边界。
+
+sorting、selection、pagination、virtualization、column resize/reorder、editing 和 data fetching 均属于 Data Table composition。Data Table 组合 Table、Collection、Selection、Pagination 等能力；不建立同名 `BaseDataTable`，也不让 Base Table 隐式吸收数据操作状态。
+
+## 6）依赖排序
+
+| 波次 | 内容 | 发布门槛 |
+| --- | --- | --- |
+| W0 | 在 #375 合入前补入本治理修改；随后建立总 Coverage Matrix | 先统一记录方向，再发布工作 |
+| W1 | shadcn Checkbox / Scroll Area / Separator / Textarea / Tooltip；Brutalist Checkbox / Tooltip | Base 已存在且宿主表面可设计 |
+| W2 | 调研 Brutalist Alert / Spinner / Kbd styled-only 准入 | 两种真实组合、精确视觉合同、可执行证据与领域共同签字 |
+| W3 | Image→Avatar；Radio Group（#349 checkpoint 已批准） | 先完成并合入 Base，再建立设计投影 |
+| W4 | Disclosure→Accordion；Input / Label / Field / Native Select；Base Table 结构语义 | 先锁定语义、信息路径和底层依赖；Table 不吸收数据操作 |
+| W5 | Popover、Progress / Meter、Slider、Toast、Toggle Group / Toolbar | overlay、positioning、move-gesture、A11y 等能力边界足够明确 |
+| W6 | Calendar、Carousel、Combobox、Command、Context Menu、Drawer、Input OTP、Menubar、Navigation Menu、Pagination、Resizable | 每项列出前置 spec entity；不完整 draft 先完成编目或明确缩小范围 |
+
+Adapter 扩充继续等待 Adapter、modules、host-cap 第一轮 spec 编目完成。新增 prototype 可以暴露并记录底层缺口，但不能绕过该门槛。
+
+## 7）Issue 发布方式
+
+先建立一项 v0.3 Prototype Coverage Matrix 总控 Issue，再发布工作 Issue。禁止按全部 64 个名称机械逐项发布。
+
+首批控制在约 10–12 个经过人工确认的节点，只包括：
+
+- 已批准 checkpoint 的有界 Base 实施；
+- 真实且独立可交付的设计投影缺口；
+- 尚未决定的 semantic / styled-only proposal；
+- 已有提案的依赖链接。
+
+每个 Issue 只能有一个主身份：
+
+- tracking：维护分类、状态和链接，不拥有实现合同；
+- proposal：解决未定语义或准入边界，以 maintainer checkpoint 为终点；
+- implementation：实现已批准合同，以合入 PR 为终点；
+- projection：消费现有 Base 合同，不改变 Base 语义。
+
+Proposal 不得在原 Issue 中悄悄变成 implementation。Checkpoint 批准后应建立链接的实施 Issue、记录批准边界，再关闭 proposal。高级语义 Issue 必须先写依赖、非目标和验收标准；C 组 Issue 必须列出前置 spec entity。
+
+难度标注遵循完整交付面而非源文件大小：
+
+- 纯设计投影且 Base 边界已充分明确：可供一般贡献者承接；
+- 新 Base semantic slice：至少 maintainer-guided；
+- 会改变 module、host-cap 或跨宿主协议：只建议核心贡献者或组织成员承接。
+
+## 8）0.3 建议验收口径
+
+在不把本文提升为规范承诺的前提下，路线图验收只要求：
+
+- 冻结快照中的 64 个 shadcn 条目全部得到人工确认的唯一主分类与明确去向；
+- `implemented`、`ready`、`research`、`blocked`、`deferred`、`composition/provider/system` 和 `excluded` 分开报告；
+- 实际交付数量只作为版本快照报告，不是 release gate；
+- Chart 在 2026-08-13 快照中保持唯一明确排除项；
+- 新 B/C 原型 Issue 记录 prototype、module、host-cap、test 与 adapter 依赖；
+- Brutalist semantic projection 同时满足 Base 足够成熟与存在可设计宿主表面；direct styled-only 只收录通过视觉合同门槛并获得领域共同签字的候选；
+- Adapter 扩充继续等待既定编目门槛。
+
+不以 `51`、`63 / 64`、`Base 30–35` 或任何滚动官网数量强迫实现薄投影或空协议。**覆盖分类闭环不等于实现闭环。**
+
+## 9）暂不采用的方案
+
+### 9.1 为 shadcn 的每个条目建立同名 Base 或 Brutalist 原型
+
+不采用。它会混淆 semantic primitive、styled projection、direct styled-only、composition 和 application system，并制造不必要的语义或视觉身份。
+
+### 9.2 直接复制 Radix、Base UI 或 shadcn 的公开 API
+
+不采用。第三方 API 是宿主和框架条件下的实现证据，不自动等于 Proto UI 的跨宿主协议。
+
+### 9.3 用市场数量作为绝对发版阻塞项
+
+不采用。0.3 使用固定日期快照完成分类；快照之后的新组件进入 review queue，不自动改变版本范围。
+
+### 9.4 在原型扩充时同步启动新 Adapter 扩充
+
+不采用。新原型可以暴露并记录 module/host-cap 缺口，但 Adapter 的扩充顺序仍服从既定 spec 编目门槛。
+
+## 10）非目标
+
+本文不负责：
+
+- 定义任何新原型的稳定 props、events、states 或 anatomy；
+- 修改现有 spec entity 的生命周期或版本范围；
+- 承诺 0.3 的发布日期或任何固定实施数量；
+- 决定各平台 Adapter 的实现顺序；
+- 承诺 Chart、可视化引擎或第三方图表库集成；
+- 把 shadcn 页面数量等同于 Proto UI 的长期产品规模；
+- 把跨 Web Component / React / Vue 的 Web 证据描述为多宿主完成。
+
+## 11）复查触发条件
+
+出现以下情况时，应增加较新的 record，而不是回写本文制造历史一致性：
+
+- shadcn/ui 官方目录发生显著增删或分类变化；
+- Base UI、Radix 或 React Aria 发布改变原语边界的主要版本；
+- collection、positioning、text-control、move-gesture 等相关 spec 从 draft 进入 active，或其边界发生变化；
+- 0.3 进入 beta 范围冻结；
+- Coverage Matrix 显示数量目标正在迫使项目制造不成立的 Base 语义、无视觉表面的 Brutalist 包装或低质量 Issue。
+
+## 12）后续工作
+
+1. 在 #375 合入前确认并补入本治理修改；
+2. 建立权威 v0.3 Prototype Coverage Matrix；
+3. 由 Brutalist 领域共同负责人确认相关行的身份、视觉合同与难度；
+4. 发布首轮约 10–12 个经过人工确认的 proposal、implementation 或 projection Issue，并关联 #349 与 #374；
+5. 完成依赖后再按 W3–W6 顺序发布后续工作；
+6. 在 0.3 beta 冻结前重新核对第三方目录，并用新 record 记录范围变化。


### PR DESCRIPTION
## What changed

- add a dated, non-normative record for the Proto UI 0.3 prototype expansion plan
- freeze the 2026-08-13 comparison baseline across shadcn/ui, Base UI, Radix Primitives, React Aria, and WAI-ARIA APG
- classify all 64 current shadcn component entries as existing coverage, low-risk projection, core semantics, advanced interaction, composition/system, or excluded
- define the proposed Base semantic-family target, shadcn coverage metric, dependency gates, contribution difficulty, and post-merge Issue strategy
- connect the roadmap to the existing Radio proposal (#349) and Image proposal (#374)

## Why

0.3 intends to expand prototype coverage while Adapter expansion remains gated on the first Adapter/module/host-cap catalog pass. A recorded classification is needed before creating many individual Issues so that styled projections and compositions are not mistaken for independent Base semantics.

## Impact

This PR changes documentation only. After it merges, the plan is to create a coverage-matrix tracking Issue and then publish the first 10–12 semantic slices or task groups described by the record.

## Validation

- `corepack pnpm@10.32.1 check:agent-doc`
- `corepack pnpm@10.32.1 spec:docs:agent`
- `git diff --check`