### PR TITLE
fix(docs): make the mobile shell usable

### DIFF
--- a/apps/www/src/components/SpecContractPreview.astro
+++ b/apps/www/src/components/SpecContractPreview.astro
@@ -153,6 +153,8 @@ const labels =
     z-index: 35;
     display: grid;
     gap: 0.7rem;
+    grid-template-columns: minmax(0, 1fr);
+    overflow-wrap: anywhere;
     width: min(29rem, calc(100vw - 2rem));
     border: 1px solid color-mix(in oklab, var(--color-border) 86%, transparent);
     border-radius: 0.5rem;
@@ -182,6 +184,10 @@ const labels =
     translate: -50% 0;
   }
 
+  .spec-contract-preview__panel > * {
+    min-width: 0;
+  }
+
   .spec-contract-preview__eyebrow,
   .spec-contract-preview__label,
   .spec-contract-preview__meta span,
@@ -206,6 +212,10 @@ const labels =
     color: var(--color-muted-foreground);
     font-size: 0.84rem;
     line-height: 1.55;
+  }
+
+  .spec-contract-preview__source code {
+    overflow-wrap: anywhere;
   }
 
   .spec-contract-preview__panel p {

--- a/apps/www/src/components/override/Header.astro
+++ b/apps/www/src/components/override/Header.astro
@@ -2,6 +2,7 @@
 import config from 'virtual:starlight/user-config';
 import context from 'virtual:starlight/project-context';
 import { localizedUrl } from '../../utils/localizedUrl';
+import MobileMenuToggle from '@astrojs/starlight/components/MobileMenuToggle.astro';
 
 import LanguageSelect from './LanguageSelect.astro';
 import Search from './Search.astro';
@@ -24,56 +25,66 @@ const localizedPath = (path: string) =>
 
 <div class="container-wrapper 3xl:fixed:px-0 px-6">
   <div
-    class="3xl:fixed:container flex h-(--header-height) items-center gap-2 **:data-[slot=separator]:!h-4"
+    class="3xl:fixed:container grid h-(--header-height) min-w-0 grid-cols-[minmax(0,1fr)_auto] grid-rows-[3.5rem_2.5rem] items-center gap-x-2 **:data-[slot=separator]:!h-4 lg:flex lg:gap-2"
   >
-    <div class="title-wrapper sl-flex -ml-2">
+    <div class="title-wrapper sl-flex -ml-2 min-w-0">
       <SiteTitle />
     </div>
     <a
-      class="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5"
+      class="hidden items-center justify-center whitespace-nowrap text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5 lg:inline-flex"
       data-slot="button"
       href={localizedPath('/start-here/what-you-saw/')}
     >
       Docs
     </a>
     <a
-      class="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5"
+      class="hidden items-center justify-center whitespace-nowrap text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5 lg:inline-flex"
       data-slot="button"
       href={localizedPath('/ui-libraries/')}
     >
       Prototypes
     </a>
     <a
-      class="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5"
+      class="hidden items-center justify-center whitespace-nowrap text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5 lg:inline-flex"
       data-slot="button"
       href={localizedPath('/whitepaper/component-as-protocol/')}
     >
       Whitepaper
     </a>
 
-    <div class="ml-auto flex items-center gap-2 md:flex-1 md:justify-end">
+    <div
+      class="col-start-2 row-start-1 mr-12 flex items-center justify-end gap-2 lg:col-auto lg:row-auto lg:mr-0 lg:ml-auto lg:flex-1"
+    >
       <div class="sl-flex print:hidden">
         {shouldRenderSearch && <Search />}
       </div>
-      <SocialIcons />
-      <div
-        data-orientation="vertical"
-        role="none"
-        data-slot="separator"
-        class="bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px"
-      >
+      <div class="hidden items-center gap-2 lg:flex">
+        <SocialIcons />
+        <div
+          data-orientation="vertical"
+          role="none"
+          data-slot="separator"
+          class="bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px"
+        >
+        </div>
       </div>
       <ThemeToggle />
+      <div class="mobile-menu-control lg:hidden">
+        <MobileMenuToggle />
+      </div>
+    </div>
+
+    <div
+      class="col-span-2 row-start-2 flex min-w-0 items-center justify-end gap-2 lg:col-auto lg:row-auto"
+    >
       <div
         data-orientation="vertical"
         role="none"
         data-slot="separator"
-        class="bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px"
+        class="bg-border hidden shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px lg:block"
       >
       </div>
-
       <LanguageSelect />
-
       <div
         data-orientation="vertical"
         role="none"
@@ -86,4 +97,11 @@ const localizedPath = (path: string) =>
   </div>
 </div>
 
-<style></style>
+<style>
+  @media (max-width: 63.999rem) {
+    .mobile-menu-control :global(starlight-menu-button button) {
+      display: flex;
+      z-index: 60;
+    }
+  }
+</style>

--- a/apps/www/src/components/override/LanguageSelect.astro
+++ b/apps/www/src/components/override/LanguageSelect.astro
@@ -34,12 +34,11 @@ localeOptions.forEach((opt) => {
 });
 ---
 
-<div class="language-select-wrapper relative inline-flex items-center">
-  <label class="sr-only" for="language-select">选择语言 / Select Language</label>
+<label class="language-select-wrapper relative inline-flex items-center">
+  <span class="sr-only">选择语言 / Select Language</span>
   <select
-    id="language-select"
     class="language-select appearance-none inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all outline-none h-8 rounded-md gap-1.5 px-3 pr-8 cursor-pointer bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
-    aria-label="选择语言 / Select Language"
+    data-language-select
     autocomplete="off"
     data-current-locale={currentLocale || ''}
     data-locale-paths={JSON.stringify(localePaths)}
@@ -69,7 +68,7 @@ localeOptions.forEach((opt) => {
       stroke-linecap="round"
       stroke-linejoin="round"></path>
   </svg>
-</div>
+</label>
 
 <style>
   .language-select-wrapper:hover .language-select-arrow {
@@ -125,9 +124,8 @@ localeOptions.forEach((opt) => {
       return match ? decodeURIComponent(match[1]) : '';
     }
 
-    function initLanguageSelect() {
-      const select = document.getElementById('language-select');
-      if (!select) return;
+    function initLanguageSelect(select) {
+      if (select.dataset.languageSelectInitialized === 'true') return;
 
       const currentLocale = select.dataset.currentLocale || '';
       let localePaths = {};
@@ -159,14 +157,19 @@ localeOptions.forEach((opt) => {
         // ignore storage errors
       }
 
+      select.dataset.languageSelectInitialized = 'true';
       select.addEventListener('change', handleLanguageChange);
+    }
+
+    function initLanguageSelects() {
+      document.querySelectorAll('select[data-language-select]').forEach(initLanguageSelect);
     }
 
     // Ensure DOM is ready
     if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', initLanguageSelect);
+      document.addEventListener('DOMContentLoaded', initLanguageSelects, { once: true });
     } else {
-      initLanguageSelect();
+      initLanguageSelects();
     }
   })();
 </script>

--- a/apps/www/src/components/override/LanguageSelect.test.ts
+++ b/apps/www/src/components/override/LanguageSelect.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const source = readFileSync(
+  resolve(process.cwd(), 'apps/www/src/components/override/LanguageSelect.astro'),
+  'utf8'
+);
+const inlineScript = source.match(/<script is:inline>([\s\S]*?)<\/script>/)?.[1];
+
+if (!inlineScript) {
+  throw new Error('LanguageSelect.astro must include an inline initialization script');
+}
+
+const languageSelect = () => `
+  <label class="language-select-wrapper">
+    <span>Select language</span>
+    <select
+      class="language-select"
+      data-language-select
+      data-current-locale="en"
+      data-locale-paths='{"en":"/en/docs/","zh-cn":"/zh-cn/docs/"}'
+    >
+      <option value="en" selected>English</option>
+      <option value="zh-cn">简体中文</option>
+    </select>
+  </label>
+`;
+
+describe('documentation language selector', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.cookie = 'preferred-locale=; Max-Age=0; path=/';
+    window.history.replaceState(null, '', '/en/docs/');
+    document.body.innerHTML = `${languageSelect()}${languageSelect()}`;
+  });
+
+  it('binds every rendered selector instance exactly once', () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+
+    window.eval(inlineScript);
+    window.eval(inlineScript);
+
+    const selects = document.querySelectorAll<HTMLSelectElement>('.language-select');
+    expect(selects).toHaveLength(2);
+    expect(
+      [...selects].every((select) => select.dataset.languageSelectInitialized === 'true')
+    ).toBe(true);
+
+    selects[1].value = 'zh-cn';
+    selects[1].dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(window.location.pathname).toBe('/zh-cn/docs/');
+    expect(localStorage.getItem('preferred-locale')).toBe('zh-cn');
+    expect(setItem).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/www/src/components/override/PageFrame.astro
+++ b/apps/www/src/components/override/PageFrame.astro
@@ -1,33 +1,40 @@
 ---
-import MobileMenuToggle from '@astrojs/starlight/components/MobileMenuToggle.astro';
+import context from 'virtual:starlight/project-context';
+import { localizedUrl } from '../../utils/localizedUrl';
 import '../../styles/global.css';
 
-const { hasSidebar } = Astro.locals.starlightRoute;
+const { hasSidebar, locale } = Astro.locals.starlightRoute;
+const localizedPath = (path: string) =>
+  localizedUrl(new URL(path, Astro.url), locale || 'en', context.trailingSlash).pathname;
 ---
 
 <div
-  class="bg-background text-foreground group/body overscroll-none font-sans antialiased [--footer-height:calc(var(--spacing)*14)] [--header-height:calc(var(--spacing)*14)] xl:[--footer-height:calc(var(--spacing)*24)]"
+  class="bg-background text-foreground group/body overscroll-none font-sans antialiased [--footer-height:calc(var(--spacing)*14)] [--header-height:calc(var(--spacing)*24)] lg:[--header-height:calc(var(--spacing)*14)] xl:[--footer-height:calc(var(--spacing)*24)]"
 >
   <div class="bg-background container-wrapper flex flex-1 flex-col px-2">
     <header class="bg-background sticky top-0 z-50 w-full"><slot name="header" /></header>
     <div
-      class="bg-background group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex w-full 3xl:fixed:container 3xl:fixed:px-3 min-h-min flex-1 items-start px-0 [--sidebar-width:220px] [--top-spacing:0] lg:grid lg:grid-cols-[var(--sidebar-width)_minmax(0,1fr)] lg:[--sidebar-width:240px] lg:[--top-spacing:calc(var(--spacing)*4)]"
+      class="bg-background group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-w-0 w-full 3xl:fixed:container 3xl:fixed:px-3 min-h-min flex-1 items-start px-0 [--sidebar-width:220px] [--top-spacing:0] lg:grid lg:grid-cols-[var(--sidebar-width)_minmax(0,1fr)] lg:[--sidebar-width:240px] lg:[--top-spacing:calc(var(--spacing)*4)]"
     >
       {
         hasSidebar && (
           <>
             <nav
-              class="no-scrollbar overflow-scroll text-sidebar-foreground w-(--sidebar-width) flex-col sticky top-[calc(var(--header-height)+1px)] z-30 hidden h-[calc(100svh-var(--header-height))] bg-transparent lg:flex"
+              class="docs-sidebar text-sidebar-foreground"
               aria-label={Astro.locals.t('sidebarNav.accessibleLabel')}
             >
-              <MobileMenuToggle />
-              <div id="starlight__sidebar" class="sidebar-pane">
-                <div class="sidebar-content sl-flex">
+              <div id="starlight__sidebar" class="mobile-sidebar-pane sidebar-pane">
+                <div class="mobile-sidebar-content sidebar-content sl-flex">
+                  <div class="mobile-primary-links" aria-label="Primary">
+                    <a href={localizedPath('/start-here/what-you-saw/')}>Docs</a>
+                    <a href={localizedPath('/ui-libraries/')}>Prototypes</a>
+                    <a href={localizedPath('/whitepaper/component-as-protocol/')}>Whitepaper</a>
+                  </div>
                   <slot name="sidebar" />
                 </div>
               </div>
             </nav>
-            <div class="main-frame">
+            <div class="main-frame min-w-0 w-full">
               <slot />
             </div>
           </>
@@ -36,12 +43,162 @@ const { hasSidebar } = Astro.locals.starlightRoute;
     </div>
     {
       !hasSidebar && (
-        <div class="main-frame">
-          <slot />
-        </div>
+        <>
+          <nav class="docs-sidebar primary-only-sidebar" aria-label="Primary navigation">
+            <div id="starlight__sidebar" class="mobile-sidebar-pane sidebar-pane">
+              <div class="mobile-sidebar-content sidebar-content sl-flex">
+                <div class="mobile-primary-links" aria-label="Primary">
+                  <a href={localizedPath('/start-here/what-you-saw/')}>Docs</a>
+                  <a href={localizedPath('/ui-libraries/')}>Prototypes</a>
+                  <a href={localizedPath('/whitepaper/component-as-protocol/')}>Whitepaper</a>
+                </div>
+              </div>
+            </div>
+          </nav>
+          <div class="main-frame min-w-0 w-full">
+            <slot />
+          </div>
+        </>
       )
     }
   </div>
 </div>
 
-<style></style>
+<script>
+  const menuHost = document.querySelector('starlight-menu-button');
+  const menuControl = menuHost?.querySelector('button');
+
+  if (menuHost && menuControl) {
+    const syncExpandedState = () => {
+      menuControl.setAttribute(
+        'aria-expanded',
+        menuHost.getAttribute('aria-expanded') === 'true' ? 'true' : 'false'
+      );
+    };
+    const collapseMenu = (restoreFocus = false) => {
+      menuHost.setAttribute('aria-expanded', 'false');
+      document.body.removeAttribute('data-mobile-menu-expanded');
+      syncExpandedState();
+      if (restoreFocus) menuControl.focus();
+    };
+    const desktopQuery = window.matchMedia('(min-width: 64rem)');
+    const collapseOnDesktop = () => {
+      if (desktopQuery.matches) collapseMenu();
+    };
+
+    new MutationObserver(syncExpandedState).observe(menuHost, {
+      attributes: true,
+      attributeFilter: ['aria-expanded'],
+    });
+    desktopQuery.addEventListener('change', collapseOnDesktop);
+    syncExpandedState();
+    collapseOnDesktop();
+
+    document.addEventListener('keyup', (event) => {
+      if (event.key !== 'Escape') return;
+      if (!document.body.hasAttribute('data-mobile-menu-expanded')) return;
+      collapseMenu(true);
+    });
+  }
+</script>
+
+<style>
+  .docs-sidebar {
+    width: 0;
+    flex: none;
+  }
+
+  .mobile-sidebar-pane {
+    position: fixed;
+    z-index: 40;
+    inset: var(--header-height) 0 0;
+    display: none;
+    width: 100%;
+    padding: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    background: var(--color-background);
+  }
+
+  :global([data-mobile-menu-expanded]) .mobile-sidebar-pane {
+    display: flex;
+  }
+
+  @media (max-width: 63.999rem) {
+    :global(body[data-mobile-menu-expanded]) {
+      overflow: hidden;
+    }
+  }
+
+  .mobile-sidebar-content {
+    width: 100%;
+    min-height: max-content;
+    padding: 1rem var(--sl-sidebar-pad-x, 1rem) 2rem;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .mobile-primary-links {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .mobile-primary-links a {
+    display: inline-flex;
+    min-height: 2.5rem;
+    align-items: center;
+    justify-content: center;
+    padding-inline: 0.5rem;
+    border-radius: var(--radius-md);
+    color: var(--color-foreground);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    text-decoration: none;
+  }
+
+  .mobile-primary-links a:hover,
+  .mobile-primary-links a:focus-visible {
+    background: var(--color-accent);
+    color: var(--color-accent-foreground);
+  }
+
+  @media (min-width: 64rem) {
+    .docs-sidebar {
+      position: sticky;
+      z-index: 30;
+      top: calc(var(--header-height) + 1px);
+      display: flex;
+      width: var(--sidebar-width);
+      height: calc(100svh - var(--header-height));
+      flex-direction: column;
+      overflow-y: auto;
+      background: transparent;
+      scrollbar-width: none;
+    }
+
+    .mobile-sidebar-pane {
+      position: static;
+      z-index: auto;
+      display: flex;
+      width: var(--sidebar-width);
+      padding-block: 1rem 3rem;
+      overflow: visible;
+      background: transparent;
+    }
+
+    .mobile-sidebar-content {
+      padding: 0;
+    }
+
+    .mobile-primary-links {
+      display: none;
+    }
+
+    .docs-sidebar.primary-only-sidebar {
+      display: none;
+    }
+  }
+</style>

--- a/apps/www/src/components/override/PageFrame.astro
+++ b/apps/www/src/components/override/PageFrame.astro
@@ -13,7 +13,38 @@ const localizedPath = (path: string) =>
 >
   <div class="bg-background container-wrapper flex flex-1 flex-col px-2">
     <header class="bg-background sticky top-0 z-50 w-full"><slot name="header" /></header>
+    <noscript>
+      <style is:inline>
+        @media (max-width: 63.999rem) {
+          [data-page-frame-layout] {
+            flex-direction: column !important;
+          }
+
+          .docs-sidebar {
+            width: 100% !important;
+          }
+
+          .mobile-sidebar-pane {
+            position: static !important;
+            inset: auto !important;
+            display: flex !important;
+            width: 100% !important;
+            max-height: min(60svh, 32rem);
+            border-bottom: 1px solid var(--color-border);
+          }
+
+          .main-frame {
+            width: 100% !important;
+          }
+
+          starlight-menu-button {
+            display: none !important;
+          }
+        }
+      </style>
+    </noscript>
     <div
+      data-page-frame-layout
       class="bg-background group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-w-0 w-full 3xl:fixed:container 3xl:fixed:px-3 min-h-min flex-1 items-start px-0 [--sidebar-width:220px] [--top-spacing:0] lg:grid lg:grid-cols-[var(--sidebar-width)_minmax(0,1fr)] lg:[--sidebar-width:240px] lg:[--top-spacing:calc(var(--spacing)*4)]"
     >
       {

--- a/apps/www/src/components/override/SiteTitle.astro
+++ b/apps/www/src/components/override/SiteTitle.astro
@@ -5,7 +5,7 @@ const { siteTitle, siteTitleHref } = Astro.locals.starlightRoute;
 
 <a
   href={siteTitleHref}
-  class="items-center justify-center gap-2 whitespace-nowrap rounded-md text-md font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 hidden h-8 px-2 lg:flex"
+  class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-md font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 h-8 px-2"
 >
   <span class:list={{ 'sr-only': config.logo?.replacesTitle }} translate="no">
     {siteTitle}

--- a/apps/www/src/styles/markdown.css
+++ b/apps/www/src/styles/markdown.css
@@ -36,12 +36,19 @@
     @apply leading-[1.625] [&:not(:first-child)]:mt-4;
   }
 
+  main[data-pagefind-body] a {
+    overflow-wrap: anywhere;
+  }
+
   main[data-pagefind-body] blockquote {
     @apply mt-4 border-l-2 pl-6 italic;
   }
 
   main[data-pagefind-body] table {
     @apply mt-6 w-full text-sm border border-border rounded-lg overflow-hidden bg-background;
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
     border-collapse: separate;
     border-spacing: 0;
   }
@@ -106,6 +113,28 @@
   }
   main[data-pagefind-body] .pagination-links a:hover {
     @apply shadow-none;
+  }
+
+  @media (max-width: 40rem) {
+    footer .pagination-links a,
+    main[data-pagefind-body] footer .pagination-links a {
+      width: auto;
+      min-width: 0;
+      max-width: calc(50% - 0.25rem);
+      height: auto;
+      min-height: 1.75rem;
+      white-space: normal;
+    }
+
+    footer .pagination-links a:only-child,
+    main[data-pagefind-body] footer .pagination-links a:only-child {
+      max-width: 100%;
+    }
+
+    footer .pagination-links a > span:first-of-type .link-title,
+    main[data-pagefind-body] footer .pagination-links a > span:first-of-type .link-title {
+      overflow-wrap: anywhere;
+    }
   }
 
   main[data-pagefind-body] ul {


### PR DESCRIPTION
## Summary
- reorganize the documentation header into a two-row mobile layout while preserving the desktop shell
- reuse Starlight's menu control for a full-width, keyboard-operable mobile navigation pane with Escape/focus restoration, background scroll locking, and breakpoint-state cleanup
- contain contract previews, code blocks, tables, long links, and pagination labels so representative docs remain within phone viewports

## Verification
- browser matrix: 60 checks across 320/360/375/390/844 px, six EN/ZH routes, and light/dark themes; zero document-level overflow failures
- mobile menu opened and closed at every target width; `aria-expanded`, body lock, pane width, Escape focus restoration, and 64rem breakpoint reset verified
- Search, theme, locale, adapter, focus order, and real menu-link navigation verified at 320 px
- desktop shell verified at 1024 and 1440 px across docs and Brutalist routes
- `corepack pnpm@10.32.1 --filter apps-www check`
- `corepack pnpm@10.32.1 --filter apps-www build` (190 pages; 188 Pagefind pages)

## Follow-up
- #404 tracks the independent hard-coded Scroll Area demo width

Closes #348