### PR TITLE
docs(release): reconcile 0.2.0 publication evidence

### DIFF
--- a/internal/records/2026-08-15-0.2.0-stable-release-evidence.zh-CN.md
+++ b/internal/records/2026-08-15-0.2.0-stable-release-evidence.zh-CN.md
@@ -1,0 +1,63 @@
+# 0.2.0 stable 发布证据与事实源收尾记录
+
+日期：2026-08-15
+
+## 结论
+
+Proto UI `0.2.0` 已完成稳定版全局精确版本发布。BOM 中 40 个公开 `@proto.ui/*` package 均存在精确版本 `0.2.0`，各 package 的 npm `latest` dist-tag 均指向该版本且均存在 registry integrity 与 40 位 shasum；216 个已发布的内部 dependency、peer dependency 与 optional dependency 引用也全部精确指向 `0.2.0`。`v0.2.0` Git tag、稳定版 GitHub Release 与不可变 spec snapshot 证据已生成并完成交叉校验。
+
+本记录为 #410 保存发布事实，并关闭 `V-PROTO-UI-0008` 与外部发行状态之间的漂移。它不改变 0.2.0 package surface，也不把稳定 package 发布等同于所有 draft spec 或 prototype entity 自动转为 active。
+
+## 发布链路
+
+- 稳定版准备 PR：<https://github.com/Proto-UI/Proto-UI/pull/366>
+- 发布前最终完整性修复 PR：<https://github.com/Proto-UI/Proto-UI/pull/373>
+- 合并与 tag commit：`70e2eb1a1bcd9264cf8c08e6ede210f96ee04606`
+- 发布 workflow：<https://github.com/Proto-UI/Proto-UI/actions/runs/31673592596>
+- workflow 状态：`success`
+- GitHub stable release：<https://github.com/Proto-UI/Proto-UI/releases/tag/v0.2.0>
+- GitHub Release 发布时间：`2026-08-13T06:31:58Z`
+
+发布 workflow 于 `2026-08-13T06:22:30Z` 从 `main` 手动触发，使用 `mode=publish-all`、`profile=workspace`、`resume_published=false` 与 `include_approved_candidates=false`，`headSha` 为上述 tag commit，并于 `2026-08-13T06:32:01Z` 成功结束。npm registry 显示首个 package 于 `2026-08-13T06:24:10.297Z` 写入，最后一个 package 于 `2026-08-13T06:31:53.896Z` 写入。
+
+Workflow 使用 pnpm `10.32.1` 与 npm `11.14.1`，并在发布前确认环境中不存在 `NODE_AUTH_TOKEN` 或 `NPM_TOKEN`。全部 40 个 package 均在第一次 publish attempt 成功，没有触发第二或第三次重试；这证明受保护 workflow 的 npm Trusted Publishing 路径完成了本次稳定版发布。
+
+## npm registry 证据
+
+- 受评审 BOM 的 `releaseVersion` 为 `0.2.0`、`gitTag` 为 `v0.2.0`、`npmDistTag` 为 `latest`，并包含 40 个公开 package。
+- 40/40 package 均存在精确版本 `0.2.0`。
+- 40/40 package 的 npm `latest` dist-tag 均指向 `0.2.0`；`next` 仍保留在 `0.2.0-rc.7`，不影响稳定版身份。
+- 40/40 package 均存在 `sha512-` registry integrity 与合法的 40 位 shasum。
+- 已发布 manifest 中 216 个指向公开 `@proto.ui/*` package 的 dependency、peer dependency 与 optional dependency 引用全部精确为 `0.2.0`。
+- Registry 核对未发现缺失版本、错误 dist-tag、缺失 digest 或内部版本漂移。
+
+## Git tag、Release 与不可变附件
+
+- `v0.2.0` 是直接指向 commit `70e2eb1a1bcd9264cf8c08e6ede210f96ee04606` 的 lightweight tag，与发布 workflow 的 `headSha` 完全一致。
+- GitHub Release ID 为 `369709095`，状态为非 draft、非 prerelease，标题为 `Proto UI 0.2.0`，包含四项预期附件。
+- package BOM：`package-bom-0.2.0.json`，大小 `16553` bytes，digest `sha256:0b10ab5f2b6643a0623ddea31456ad25f80f677a3c7f5620bcba3f13f584515c`
+- 中文说明：`release-notes-0.2.0.zh-CN.md`，大小 `3852` bytes，digest `sha256:641902738875f9167bd63dc039cd3886490b1c4b2ceacb5a7b9ef21e030827fd`
+- spec snapshot：`spec-snapshot-0.2.0.json`，大小 `2834049` bytes，digest `sha256:98c09de2502e85fe94259ba7f936f4a4350ef5374d2d638969118f3ed3428478`
+- checksum：`spec-snapshot-0.2.0.json.sha256`，大小 `91` bytes，asset digest `sha256:bed35123e84ed76a523022fcd92ea2a91162b72d0ec4b13a06398fe304ea6e4d`
+
+完整下载四项附件后重新计算的 SHA-256 与 GitHub asset metadata 全部一致。Checksum 文件内容为：
+
+```text
+98c09de2502e85fe94259ba7f936f4a4350ef5374d2d638969118f3ed3428478  spec-snapshot-0.2.0.json
+```
+
+该值与下载后重新计算的 snapshot SHA-256 一致。Snapshot 可解析为 JSON，内含 506 个实体、`0.2.0` stable release identity，以及 tag commit 时仍为 `draft` 的 `V-PROTO-UI-0008`。这是不可变发布快照的预期历史状态；本证据变更激活当前工作目录中的 V entity，但不得重新生成或替换 tag 所附 snapshot。
+
+下载的 BOM 与中文说明分别和 `v0.2.0` tag commit 中已评审的 `internal/releases/0.2.0/package-bom.json` 与 `release-notes.zh-CN.md` 逐字节一致。GitHub Release 正文同样取自 tag commit 中已评审的英文 release notes，因此在本证据变更合入前仍保留准备阶段措辞。
+
+## 事实源收尾
+
+- 将 `V-PROTO-UI-0008` 从 `draft` 转为 `active`，并回填发布时间、40 位 tag commit 与不可变 snapshot digest。
+- 将仓库维护的双语 release notes 从准备阶段措辞切换为已发布状态。
+- 保持 `VERSION`、40 个 package manifest、BOM 与不可变 Release assets 不变；本证据变更不重新发布 package，也不重新生成 snapshot。
+- 本证据变更合入后，应使用已合入的英文 release notes 同步 GitHub Release 正文。该可变文案同步不得替换或重新生成任何附件。
+- README、Quick Start、项目状态与 Prototype Library 等公共投影由 #409 的后续子 Issue 更新，不在本事实源变更中提前处理。
+
+`release.publishedAt` 使用 GitHub Release 的发布时间，表示全部 package、tag 与 release assets 已完成后的发行时刻。`release.specSnapshotDigest` 来自 tag 所附的不可变 draft snapshot，不能在 V 转为 `active` 后重新生成 snapshot 并用新 digest 覆盖该证据。
+
+本记录是发布事实的历史证据，不替代 `V-PROTO-UI-0008` 的规范状态。

--- a/internal/releases/0.2.0/release-notes.md
+++ b/internal/releases/0.2.0/release-notes.md
@@ -1,6 +1,6 @@
 # Proto UI 0.2.0
 
-> Draft stable release notes. Proto UI 0.2.0 is prepared for the npm `latest` channel but has not been published. Until publication evidence is verified, `0.2.0-rc.7` remains the reproducible public trial release.
+> Published on August 13, 2026 under the npm `latest` channel. All 40 public packages, the `v0.2.0` tag, the stable GitHub Release, and the immutable spec snapshot share this exact release identity.
 
 Proto UI 0.2.0 promotes the complete 40-package rc.7 ecosystem surface to the first stable release on the 0.2 line. It keeps the global exact-version rule: applications should use the same `0.2.0` version for every public `@proto.ui/*` package.
 
@@ -45,4 +45,4 @@ Proto UI 0.2.0 promotes the complete 40-package rc.7 ecosystem surface to the fi
 
 ## Release validation
 
-Before publication, the reviewed preparation commit must pass the repository's full `release:rehearse` gate, agent projection check, and clean-diff check. After publication, a separate evidence PR will verify all 40 npm versions and `latest` tags, the `v0.2.0` commit, GitHub Release assets, and the immutable snapshot digest before this release is marked active.
+The protected `publish-all` workflow published all 40 public packages from the reviewed `70e2eb1a1bcd9264cf8c08e6ede210f96ee04606` commit through npm Trusted Publishing. Independent registry verification confirms all 40 exact versions, all 40 `latest` tags, integrity and shasum records for every package, and 216 exact internal dependency references. The workflow then created the `v0.2.0` tag, the stable GitHub Release, and the immutable spec snapshot whose SHA-256 digest is `98c09de2502e85fe94259ba7f936f4a4350ef5374d2d638969118f3ed3428478`.

--- a/internal/releases/0.2.0/release-notes.zh-CN.md
+++ b/internal/releases/0.2.0/release-notes.zh-CN.md
@@ -1,6 +1,6 @@
 # Proto UI 0.2.0
 
-> 稳定版发行说明草稿。Proto UI 0.2.0 正在为 npm `latest` channel 做准备，但尚未发布。在发行证据完成核验前，`0.2.0-rc.7` 仍是可复现的公开试用版本。
+> 已于 2026 年 8 月 13 日通过 npm `latest` channel 发布。全部 40 个公开 package、`v0.2.0` tag、稳定版 GitHub Release 与不可变 spec snapshot 共享这一精确发行身份。
 
 Proto UI 0.2.0 将完整的 40-package rc.7 生态 surface 晋升为 0.2 release line 的首个稳定版。它继续遵守全局精确版本规则：应用中的全部公开 `@proto.ui/*` package 都应使用相同的 `0.2.0` 版本。
 
@@ -45,4 +45,4 @@ Proto UI 0.2.0 将完整的 40-package rc.7 生态 surface 晋升为 0.2 release
 
 ## 发版验证
 
-发布前，已评审的准备 commit 必须通过仓库完整 `release:rehearse` 门禁、Agent 投影检查与 clean-diff 检查。发布后将通过独立证据 PR 核验全部 40 个 npm 版本与 `latest` tag、`v0.2.0` commit、GitHub Release assets 和不可变 snapshot digest，之后才能把本版本标记为 active。
+受保护的 `publish-all` workflow 已通过 npm Trusted Publishing 从受评审的 `70e2eb1a1bcd9264cf8c08e6ede210f96ee04606` commit 发布全部 40 个公开 package。独立 registry 核对确认 40 个精确版本、40 个 `latest` tag、每个 package 的 integrity 与 shasum 记录，以及 216 个精确内部 dependency 引用均完整。Workflow 随后创建 `v0.2.0` tag、稳定版 GitHub Release 与不可变 spec snapshot；该 snapshot 的 SHA-256 digest 为 `98c09de2502e85fe94259ba7f936f4a4350ef5374d2d638969118f3ed3428478`。

--- a/spec/versions/V-PROTO-UI-0008.yaml
+++ b/spec/versions/V-PROTO-UI-0008.yaml
@@ -1,12 +1,12 @@
 id: V-PROTO-UI-0008
 type: version
 title: Proto UI 0.2.0
-status: draft
+status: active
 since: 0.2.0
-summary: First stable release on the 0.2 line, promoting the rc.7 ecosystem surface after its public trial and immutable release evidence.
+summary: First stable release on the 0.2 line, promoting the complete rc.7 ecosystem surface after its public trial and preserving one globally exact identity across all 40 public packages and the immutable spec snapshot.
 statement:
-  en: Proto UI 0.2.0 will be one stable ecosystem release identity shared exactly by every public @proto.ui package and the corresponding immutable spec snapshot once published.
-  zh-CN: Proto UI 0.2.0 将在发布后成为由全部公开 @proto.ui package 与对应不可变 spec snapshot 精确共享的一次稳定生态发行身份。
+  en: Proto UI 0.2.0 is one stable ecosystem release identity shared exactly by every public @proto.ui package and the corresponding immutable spec snapshot.
+  zh-CN: Proto UI 0.2.0 是由全部公开 @proto.ui package 与对应不可变 spec snapshot 精确共享的一次稳定生态发行身份。
 release:
   version: 0.2.0
   channel: stable
@@ -14,6 +14,9 @@ release:
   npmDistTag: latest
   packageVersionPolicy: exact
   packageScope: public-@proto.ui
+  publishedAt: 2026-08-13T06:31:58Z
+  commit: 70e2eb1a1bcd9264cf8c08e6ede210f96ee04606
+  specSnapshotDigest: sha256:98c09de2502e85fe94259ba7f936f4a4350ef5374d2d638969118f3ed3428478
 dependsOn:
   decisions:
     - D-GLOBAL-RELEASE-VERSION-0001
@@ -38,11 +41,15 @@ sources:
   - path: internal/releases/0.2.0/package-bom.json
   - path: internal/releases/0.2.0/release-notes.md
   - path: internal/releases/0.2.0/release-notes.zh-CN.md
+  - path: internal/records/2026-08-15-0.2.0-stable-release-evidence.zh-CN.md
 openQuestions: []
 revisions:
   - version: 0.2.0
     change: introduced
     summary: Opened the stable 0.2.0 release train over the published rc.7 ecosystem surface while keeping publication evidence pending.
+  - version: 0.2.0
+    change: updated
+    summary: Activated after publishing all 40 packages under npm latest, the v0.2.0 Git tag, the stable GitHub Release, and the immutable spec snapshot evidence.
 tags:
   - release
   - stable


### PR DESCRIPTION
## Summary

- activate `V-PROTO-UI-0008` and record the published timestamp, tag commit, and immutable spec snapshot digest
- update the bilingual 0.2.0 release notes from preparation language to verified publication facts
- add a dated evidence record covering the protected workflow, npm registry verification, Git tag, GitHub Release, and immutable assets

## Why

Proto UI 0.2.0 was successfully published, but the repository truth still described it as pending and kept the version entity in `draft`. This closes that drift at the source-of-truth layer so the remaining #409 documentation projections can proceed from a verified active release identity.

## Verified evidence

- 40/40 public packages exist at exact version `0.2.0`
- 40/40 npm `latest` tags point to `0.2.0`
- integrity and shasum records are present for all 40 packages
- 216 internal dependency references resolve exactly to `0.2.0`
- `v0.2.0`, workflow head, and release commit all resolve to `70e2eb1a1bcd9264cf8c08e6ede210f96ee04606`
- immutable snapshot digest: `sha256:98c09de2502e85fe94259ba7f936f4a4350ef5374d2d638969118f3ed3428478`

## Validation

- `corepack pnpm@10.32.1 exec vitest run packages/spec/fixtures/test/version-release-schema.test.ts packages/spec/fixtures/test/workspace-relations.test.ts`
- `corepack pnpm@10.32.1 check:release-version`
- `corepack pnpm@10.32.1 release:assets:check`
- `corepack pnpm@10.32.1 check:agent-doc`
- `corepack pnpm@10.32.1 check:types`
- Prettier check for the four changed files
- `git diff --check`

## Post-merge

Sync the mutable GitHub Release body from the merged English release notes. Do not replace or regenerate any release attachment.

Closes #410