### PR TITLE
fix(web-component): project text control focus onto host boundary

### DIFF
--- a/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
@@ -209,6 +209,46 @@ async function applyColorScheme(page: Page, colorScheme: ColorScheme): Promise<v
     { timeout: 10_000 }
   );
 }
+type TextareaFocusSnapshot = {
+  active: boolean;
+  focused: boolean;
+  focusVisible: boolean;
+  hostFocused: boolean;
+  hostFocusVisible: boolean;
+  surfaceFocusVisible: boolean;
+  hostTabIndex: string | null;
+  surfaceTabIndex: number;
+  textareaCount: number;
+  boxShadow: string;
+};
+
+async function wcTextareaFocusSnapshot(previewer: Locator): Promise<TextareaFocusSnapshot> {
+  return previewer.evaluate((root) => {
+    const host = root.querySelector<HTMLElement>('.host [data-pui-root]');
+    const textarea = root.querySelector<HTMLTextAreaElement>('textarea');
+    if (!host || !textarea) throw new Error('Web Component Textarea projection is missing.');
+    const exposes = (
+      host as HTMLElement & {
+        getExposes(): {
+          focused: { get(): boolean };
+          focusVisible: { get(): boolean };
+        };
+      }
+    ).getExposes();
+    return {
+      active: document.activeElement === textarea,
+      focused: exposes.focused.get(),
+      focusVisible: exposes.focusVisible.get(),
+      hostFocused: host.hasAttribute('data-focused'),
+      hostFocusVisible: host.hasAttribute('data-focus-visible'),
+      surfaceFocusVisible: textarea.hasAttribute('data-focus-visible'),
+      hostTabIndex: host.getAttribute('tabindex'),
+      surfaceTabIndex: textarea.tabIndex,
+      textareaCount: root.querySelectorAll('textarea').length,
+      boxShadow: getComputedStyle(textarea).boxShadow,
+    };
+  });
+}
 
 /**
  * Resolves each demo surface's text colour and nearest opaque backdrop through a
@@ -522,6 +562,89 @@ describe.sequential('Brutalist control documentation browser regressions', () =>
 
       expect(Math.max(...widths) - Math.min(...widths)).toBeLessThanOrEqual(GEOMETRY_EPSILON);
     } finally {
+      await context.close();
+    }
+  }, 90_000);
+
+  it('projects one native WC Textarea focus target and its Brutalist ring by modality', async () => {
+    const { context, page, previewer } = await openRoute(TEXTAREA_ROUTE, {
+      width: 1440,
+      height: 900,
+    });
+
+    try {
+      await previewer.scrollIntoViewIfNeeded();
+      await selectRuntime(page, previewer, 'wc', 'textarea', 1);
+      const runtimeSelect = previewer.locator('select.adapter-select');
+      const textarea = previewer.locator('textarea');
+
+      const initial = await wcTextareaFocusSnapshot(previewer);
+      expect(initial.textareaCount).toBe(1);
+      expect(initial.hostTabIndex).toBeNull();
+      expect(initial.surfaceTabIndex).toBe(0);
+
+      for (const colorScheme of COLOR_SCHEMES) {
+        await applyColorScheme(page, colorScheme);
+        await runtimeSelect.focus();
+        await page.keyboard.press('Tab');
+        await page.waitForFunction(
+          () => {
+            const root = document.querySelector<HTMLElement>(
+              '[data-previewer-id] .host [data-pui-root]'
+            );
+            return (
+              root?.hasAttribute('data-focused') === true && root.hasAttribute('data-focus-visible')
+            );
+          },
+          undefined,
+          { timeout: 10_000 }
+        );
+
+        const keyboard = await wcTextareaFocusSnapshot(previewer);
+        expect(keyboard.active, `${colorScheme}/keyboard active target`).toBe(true);
+        expect(keyboard.focused, `${colorScheme}/keyboard focused expose`).toBe(true);
+        expect(keyboard.focusVisible, `${colorScheme}/keyboard focusVisible expose`).toBe(true);
+        expect(keyboard.hostFocused, `${colorScheme}/keyboard host focused marker`).toBe(true);
+        expect(keyboard.hostFocusVisible, `${colorScheme}/keyboard host marker`).toBe(true);
+        expect(keyboard.surfaceFocusVisible, `${colorScheme}/keyboard surface marker`).toBe(true);
+
+        expect(keyboard.boxShadow, `${colorScheme}/physical ring inner edge`).toContain(
+          '0px 0px 0px 2px'
+        );
+        expect(keyboard.boxShadow, `${colorScheme}/physical ring outer edge`).toContain(
+          '0px 0px 0px 4px'
+        );
+        await textarea.evaluate((element) => (element as HTMLTextAreaElement).blur());
+        await page.waitForFunction(
+          () =>
+            !document
+              .querySelector<HTMLElement>('[data-previewer-id] .host [data-pui-root]')
+              ?.hasAttribute('data-focused')
+        );
+        const blurred = await wcTextareaFocusSnapshot(previewer);
+        expect(blurred.focused, `${colorScheme}/blur focused expose`).toBe(false);
+        expect(blurred.focusVisible, `${colorScheme}/blur focusVisible expose`).toBe(false);
+
+        await textarea.click();
+        await page.waitForFunction(
+          () =>
+            document
+              .querySelector<HTMLElement>('[data-previewer-id] .host [data-pui-root]')
+              ?.hasAttribute('data-focused') === true
+        );
+        const pointer = await wcTextareaFocusSnapshot(previewer);
+        expect(pointer.active, `${colorScheme}/pointer active target`).toBe(true);
+        expect(pointer.focused, `${colorScheme}/pointer focused expose`).toBe(true);
+        expect(pointer.focusVisible, `${colorScheme}/pointer focusVisible expose`).toBe(false);
+        expect(pointer.hostFocusVisible, `${colorScheme}/pointer host marker`).toBe(false);
+        expect(pointer.surfaceFocusVisible, `${colorScheme}/pointer surface marker`).toBe(false);
+        expect(pointer.boxShadow, `${colorScheme}/modality-specific ring`).not.toBe(
+          keyboard.boxShadow
+        );
+        await textarea.evaluate((element) => (element as HTMLTextAreaElement).blur());
+      }
+    } finally {
+      await applyColorScheme(page, 'light');
       await context.close();
     }
   }, 90_000);

--- a/packages/adapters/base/src/events/web-event-router.ts
+++ b/packages/adapters/base/src/events/web-event-router.ts
@@ -444,6 +444,10 @@ export function createWebProtoEventRouter(opt: {
     /** Inject these into EVENT_*_TARGET_CAP */
     rootTarget: rootProxy as EventTarget,
     globalTarget: globalProxy as EventTarget,
+    /** Adapter-private ingress for a trusted physical host target. */
+    dispatchHostRootEvent(type: string, event: Event) {
+      rootProxy.__dispatchHost(type, event);
+    },
 
     dispose() {
       if (activeRouterByRoot.get(rootEl) === routerIdentity) activeRouterByRoot.delete(rootEl);
@@ -571,6 +575,13 @@ function createProxyTarget(args: {
       return args.protoBus.dispatchEvent(ev);
     },
 
+    /** Private adapter ingress; does not emit another public DOM event. */
+    __dispatchHost(type: string, event: Event) {
+      for (const listener of hostListeners) {
+        if (listener.type !== type) continue;
+        listener.wrapped?.(event);
+      }
+    },
     // best-effort cleanup (not required by EventTarget)
     __dispose() {
       // 主动解绑所有已懒绑定的 host listener，避免残留

--- a/packages/adapters/web-component/src/adapt.ts
+++ b/packages/adapters/web-component/src/adapt.ts
@@ -353,15 +353,16 @@ export function AdaptToWebComponent<TProto extends Prototype<any, any>>(
         this._applier = applier;
         let disposeFocusBridge: (() => void) | null = null;
         if (this._textControlTarget) {
-          // Native focus/blur do not bubble from the physical text control, so
-          // project them onto the custom-element boundary where host-bound
-          // focus listeners are attached.
+          // Native focus/blur do not bubble from the physical text control.
+          // Route the trusted physical event through the adapter-private host
+          // ingress: Proto focus facts update without emitting a second public
+          // native-looking event from the custom-element boundary.
           const control = this._textControlTarget;
-          const onFocusIn = (e: FocusEvent) => {
-            if (e.target === control) thisEl.dispatchEvent(new FocusEvent('focus'));
+          const onFocusIn = (event: FocusEvent) => {
+            if (event.target === control) router.dispatchHostRootEvent('focus', event);
           };
-          const onFocusOut = (e: FocusEvent) => {
-            if (e.target === control) thisEl.dispatchEvent(new FocusEvent('blur'));
+          const onFocusOut = (event: FocusEvent) => {
+            if (event.target === control) router.dispatchHostRootEvent('blur', event);
           };
           thisEl.addEventListener('focusin', onFocusIn);
           thisEl.addEventListener('focusout', onFocusOut);

--- a/packages/adapters/web-component/src/adapt.ts
+++ b/packages/adapters/web-component/src/adapt.ts
@@ -358,11 +358,21 @@ export function AdaptToWebComponent<TProto extends Prototype<any, any>>(
           // ingress: Proto focus facts update without emitting a second public
           // native-looking event from the custom-element boundary.
           const control = this._textControlTarget;
+          const projectFocus = (type: 'focus' | 'blur', nativeEvent: FocusEvent) => {
+            const normalized = new FocusEvent(type, {
+              relatedTarget: nativeEvent.relatedTarget,
+            });
+            Object.defineProperty(normalized, 'nativeEvent', {
+              value: nativeEvent,
+              enumerable: false,
+            });
+            router.dispatchHostRootEvent(type, normalized);
+          };
           const onFocusIn = (event: FocusEvent) => {
-            if (event.target === control) router.dispatchHostRootEvent('focus', event);
+            if (event.target === control) projectFocus('focus', event);
           };
           const onFocusOut = (event: FocusEvent) => {
-            if (event.target === control) router.dispatchHostRootEvent('blur', event);
+            if (event.target === control) projectFocus('blur', event);
           };
           thisEl.addEventListener('focusin', onFocusIn);
           thisEl.addEventListener('focusout', onFocusOut);

--- a/packages/adapters/web-component/src/adapt.ts
+++ b/packages/adapters/web-component/src/adapt.ts
@@ -351,6 +351,25 @@ export function AdaptToWebComponent<TProto extends Prototype<any, any>>(
         currentEventGate = eventGate;
         currentRouter = router;
         this._applier = applier;
+        let disposeFocusBridge: (() => void) | null = null;
+        if (this._textControlTarget) {
+          // Native focus/blur do not bubble from the physical text control, so
+          // project them onto the custom-element boundary where host-bound
+          // focus listeners are attached.
+          const control = this._textControlTarget;
+          const onFocusIn = (e: FocusEvent) => {
+            if (e.target === control) thisEl.dispatchEvent(new FocusEvent('focus'));
+          };
+          const onFocusOut = (e: FocusEvent) => {
+            if (e.target === control) thisEl.dispatchEvent(new FocusEvent('blur'));
+          };
+          thisEl.addEventListener('focusin', onFocusIn);
+          thisEl.addEventListener('focusout', onFocusOut);
+          disposeFocusBridge = () => {
+            thisEl.removeEventListener('focusin', onFocusIn);
+            thisEl.removeEventListener('focusout', onFocusOut);
+          };
+        }
 
         let disposed = false;
         const disposeView = () => {
@@ -360,6 +379,8 @@ export function AdaptToWebComponent<TProto extends Prototype<any, any>>(
           eventGate.dispose();
           unbindLogicalEventTarget(this._instanceToken, router.rootTarget);
           router.dispose();
+          disposeFocusBridge?.();
+          disposeFocusBridge = null;
           applier.clear();
           releaseRenderedChildren();
           if (currentEventGate === eventGate) currentEventGate = null;

--- a/packages/adapters/web-component/src/adapt.ts
+++ b/packages/adapters/web-component/src/adapt.ts
@@ -358,27 +358,22 @@ export function AdaptToWebComponent<TProto extends Prototype<any, any>>(
           // ingress: Proto focus facts update without emitting a second public
           // native-looking event from the custom-element boundary.
           const control = this._textControlTarget;
-          const projectFocus = (type: 'focus' | 'blur', nativeEvent: FocusEvent) => {
-            const normalized = new FocusEvent(type, {
-              relatedTarget: nativeEvent.relatedTarget,
-            });
-            Object.defineProperty(normalized, 'nativeEvent', {
-              value: nativeEvent,
-              enumerable: false,
-            });
-            router.dispatchHostRootEvent(type, normalized);
+          // Bind native focus/blur directly on the known control so the
+          // callback receives the real DOM event object with target/currentTarget
+          // intact. The private transport preserves both the declared type and
+          // the physical event identity without dispatching a second public
+          // boundary event.
+          const onFocus = (event: FocusEvent) => {
+            if (event.target === control) router.dispatchHostRootEvent('focus', event);
           };
-          const onFocusIn = (event: FocusEvent) => {
-            if (event.target === control) projectFocus('focus', event);
+          const onBlur = (event: FocusEvent) => {
+            if (event.target === control) router.dispatchHostRootEvent('blur', event);
           };
-          const onFocusOut = (event: FocusEvent) => {
-            if (event.target === control) projectFocus('blur', event);
-          };
-          thisEl.addEventListener('focusin', onFocusIn);
-          thisEl.addEventListener('focusout', onFocusOut);
+          control.addEventListener('focus', onFocus);
+          control.addEventListener('blur', onBlur);
           disposeFocusBridge = () => {
-            thisEl.removeEventListener('focusin', onFocusIn);
-            thisEl.removeEventListener('focusout', onFocusOut);
+            control.removeEventListener('focus', onFocus);
+            control.removeEventListener('blur', onBlur);
           };
         }
 

--- a/packages/adapters/web-component/test/text-control.integration.test.ts
+++ b/packages/adapters/web-component/test/text-control.integration.test.ts
@@ -59,10 +59,10 @@ const focusTextareaPrototype = definePrototype({
       focusable.focusSelf(options)
     );
     def.event.on('host:focus', (_run, event) => {
-      projectedHostFocusTypes.push(String(event?.type));
+      projectedHostFocusTypes.push(String((event as any)?.type));
     });
     def.event.on('host:blur', (_run, event) => {
-      projectedHostFocusTypes.push(String(event?.type));
+      projectedHostFocusTypes.push(String((event as any)?.type));
     });
     const sync = (props: Readonly<ControlProps>) => {
       control.sync({

--- a/packages/adapters/web-component/test/text-control.integration.test.ts
+++ b/packages/adapters/web-component/test/text-control.integration.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { definePrototype, type DefHandle, type TextControlPatch } from '@proto.ui/core';
+import {
+  definePrototype,
+  type DefHandle,
+  type FocusRequestOptions,
+  type TextControlPatch,
+} from '@proto.ui/core';
 import { asFocusable, asTextControl } from '@proto.ui/hooks';
 import { declareTextControl } from '@proto.ui/module-text-control';
 import { AdaptToWebComponent, setElementProps, type WebComponentAdapterElement } from '../src';
@@ -49,6 +54,9 @@ const focusTextareaPrototype = definePrototype({
     focusable.configure({ disabled: false });
     def.expose.state('focused', focusable.focused);
     def.expose.state('focusVisible', focusable.focusVisible);
+    def.expose.method('focusSelf', (options: FocusRequestOptions | undefined) =>
+      focusable.focusSelf(options)
+    );
     const sync = (props: Readonly<ControlProps>) => {
       control.sync({
         valueMode: 'uncontrolled',
@@ -204,5 +212,95 @@ describe('adapter-web-component text control', () => {
     const countAfterDispose = projectedFocusCount;
     remountedTextarea.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
     expect(projectedFocusCount).toBe(countAfterDispose);
+  });
+
+  it('breaks the host focus path when the focusin bridge is intercepted', async () => {
+    // End-to-end failing-before evidence: the bridge is load-bearing.
+    // Native focus/blur do not bubble from the physical control, so without
+    // the bridge the boundary never sees focus projection. Intercepting the
+    // bubbling focusin before it reaches the custom-element boundary
+    // simulates the pre-fix world: focus lands on the control (activeElement
+    // changes), but the boundary receives no projected event and states stay
+    // false.
+    const shell = document.createElement('x-wc-text-control-focus') as WebComponentAdapterElement<
+      typeof focusTextareaPrototype
+    >;
+    setElementProps(shell, { defaultValue: '', placeholder: 'Write', rows: 4 });
+    let projectedFocusCount = 0;
+    shell.addEventListener('focus', () => {
+      projectedFocusCount += 1;
+    });
+    document.body.appendChild(shell);
+    await flush();
+
+    const textarea = shell.querySelector('textarea');
+    if (!textarea) throw new Error('physical textarea was not materialized');
+    const exposes = shell.getExposes() as {
+      focused: { get(): boolean };
+      focusVisible: { get(): boolean };
+    };
+
+    // Swallow the bridge signal: focusin on the control never reaches the
+    // boundary, so the bridge never re-dispatches focus/blur.
+    const swallowFocusIn = (e: FocusEvent) => {
+      if (e.target === textarea) e.stopImmediatePropagation();
+    };
+    document.addEventListener('focusin', swallowFocusIn, true);
+    try {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+      textarea.focus();
+      await flush();
+      expect(document.activeElement).toBe(textarea);
+      expect(projectedFocusCount).toBe(0);
+      expect(exposes.focused.get()).toBe(false);
+      expect(exposes.focusVisible.get()).toBe(false);
+      expect(shell.hasAttribute('data-focus-visible')).toBe(false);
+    } finally {
+      document.removeEventListener('focusin', swallowFocusIn, true);
+    }
+
+    // After unblocking, the bridge path restores.
+    textarea.blur();
+    await flush();
+    textarea.focus();
+    await flush();
+    expect(exposes.focused.get()).toBe(true);
+
+    shell.remove();
+  });
+
+  it('projects focusSelf bidirectionally between host method and physical control', async () => {
+    const shell = document.createElement('x-wc-text-control-focus') as WebComponentAdapterElement<
+      typeof focusTextareaPrototype
+    >;
+    setElementProps(shell, { defaultValue: '', placeholder: 'Write', rows: 4 });
+    document.body.appendChild(shell);
+    await flush();
+
+    const textarea = shell.querySelector('textarea');
+    if (!textarea) throw new Error('physical textarea was not materialized');
+    const exposes = shell.getExposes() as {
+      focused: { get(): boolean };
+      focusSelf: (options?: { reason?: string }) => void;
+    };
+
+    // focusSelf focuses the physical control and syncs the focused state.
+    exposes.focusSelf({ reason: 'programmatic' });
+    await flush();
+    expect(document.activeElement).toBe(textarea);
+    expect(exposes.focused.get()).toBe(true);
+
+    // Blur un-syncs.
+    textarea.blur();
+    await flush();
+    expect(exposes.focused.get()).toBe(false);
+
+    // focusSelf re-focuses after blur.
+    exposes.focusSelf({ reason: 'programmatic' });
+    await flush();
+    expect(document.activeElement).toBe(textarea);
+    expect(exposes.focused.get()).toBe(true);
+
+    shell.remove();
   });
 });

--- a/packages/adapters/web-component/test/text-control.integration.test.ts
+++ b/packages/adapters/web-component/test/text-control.integration.test.ts
@@ -131,11 +131,15 @@ describe('adapter-web-component text control', () => {
     expect(moduleInputValues).toEqual(['edited']);
   });
 
-  it('projects physical textarea focus onto host focus states', async () => {
+  it('projects native text-control focus across modality, remount, and teardown', async () => {
     const shell = document.createElement('x-wc-text-control-focus') as WebComponentAdapterElement<
       typeof focusTextareaPrototype
     >;
     setElementProps(shell, { defaultValue: '', placeholder: 'Write', rows: 4 });
+    let projectedFocusCount = 0;
+    shell.addEventListener('focus', () => {
+      projectedFocusCount += 1;
+    });
     document.body.appendChild(shell);
     await flush();
 
@@ -145,24 +149,60 @@ describe('adapter-web-component text control', () => {
       focused: { get(): boolean };
       focusVisible: { get(): boolean };
     };
+    expect(shell.hasAttribute('tabindex')).toBe(false);
+    expect(textarea.tabIndex).toBe(0);
     expect(exposes.focused.get()).toBe(false);
     expect(exposes.focusVisible.get()).toBe(false);
 
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
-    textarea.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    textarea.focus();
+    expect(document.activeElement).toBe(textarea);
+    expect(projectedFocusCount).toBe(1);
     expect(exposes.focused.get()).toBe(true);
     expect(exposes.focusVisible.get()).toBe(true);
     expect(shell.hasAttribute('data-focus-visible')).toBe(true);
+    expect(textarea.hasAttribute('data-focus-visible')).toBe(true);
 
-    textarea.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+    textarea.blur();
+    expect(document.activeElement).not.toBe(textarea);
     expect(exposes.focused.get()).toBe(false);
     expect(exposes.focusVisible.get()).toBe(false);
     expect(shell.hasAttribute('data-focus-visible')).toBe(false);
+    expect(textarea.hasAttribute('data-focus-visible')).toBe(false);
+
+    textarea.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, composed: true }));
+    textarea.focus();
+    expect(document.activeElement).toBe(textarea);
+    expect(projectedFocusCount).toBe(2);
+    expect(exposes.focused.get()).toBe(true);
+    expect(exposes.focusVisible.get()).toBe(false);
+    expect(shell.hasAttribute('data-focus-visible')).toBe(false);
+    expect(textarea.hasAttribute('data-focus-visible')).toBe(false);
+    textarea.blur();
 
     shell.remove();
     await flush();
-    expect(() =>
-      textarea.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
-    ).not.toThrow();
+    const countAfterDetach = projectedFocusCount;
+    textarea.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(projectedFocusCount).toBe(countAfterDetach);
+
+    document.body.appendChild(shell);
+    await flush();
+    const remountedTextarea = shell.querySelector('textarea');
+    if (!remountedTextarea) throw new Error('remounted physical textarea was not materialized');
+    const remountedExposes = shell.getExposes() as typeof exposes;
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+    remountedTextarea.focus();
+    expect(document.activeElement).toBe(remountedTextarea);
+    expect(projectedFocusCount).toBe(countAfterDetach + 1);
+    expect(remountedExposes.focused.get()).toBe(true);
+    expect(remountedExposes.focusVisible.get()).toBe(true);
+    remountedTextarea.blur();
+
+    shell.remove();
+    await flush();
+    const countAfterDispose = projectedFocusCount;
+    remountedTextarea.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(projectedFocusCount).toBe(countAfterDispose);
   });
 });

--- a/packages/adapters/web-component/test/text-control.integration.test.ts
+++ b/packages/adapters/web-component/test/text-control.integration.test.ts
@@ -165,7 +165,7 @@ describe('adapter-web-component text control', () => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
     textarea.focus();
     expect(document.activeElement).toBe(textarea);
-    expect(projectedFocusCount).toBe(1);
+    expect(projectedFocusCount).toBe(0);
     expect(exposes.focused.get()).toBe(true);
     expect(exposes.focusVisible.get()).toBe(true);
     expect(shell.hasAttribute('data-focus-visible')).toBe(true);
@@ -181,7 +181,7 @@ describe('adapter-web-component text control', () => {
     textarea.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, composed: true }));
     textarea.focus();
     expect(document.activeElement).toBe(textarea);
-    expect(projectedFocusCount).toBe(2);
+    expect(projectedFocusCount).toBe(0);
     expect(exposes.focused.get()).toBe(true);
     expect(exposes.focusVisible.get()).toBe(false);
     expect(shell.hasAttribute('data-focus-visible')).toBe(false);
@@ -202,7 +202,7 @@ describe('adapter-web-component text control', () => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
     remountedTextarea.focus();
     expect(document.activeElement).toBe(remountedTextarea);
-    expect(projectedFocusCount).toBe(countAfterDetach + 1);
+    expect(projectedFocusCount).toBe(countAfterDetach);
     expect(remountedExposes.focused.get()).toBe(true);
     expect(remountedExposes.focusVisible.get()).toBe(true);
     remountedTextarea.blur();

--- a/packages/adapters/web-component/test/text-control.integration.test.ts
+++ b/packages/adapters/web-component/test/text-control.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { definePrototype, type DefHandle, type TextControlPatch } from '@proto.ui/core';
-import { asTextControl } from '@proto.ui/hooks';
+import { asFocusable, asTextControl } from '@proto.ui/hooks';
 import { declareTextControl } from '@proto.ui/module-text-control';
 import { AdaptToWebComponent, setElementProps, type WebComponentAdapterElement } from '../src';
 
@@ -34,6 +34,36 @@ const textareaPrototype = definePrototype({
 });
 
 AdaptToWebComponent(textareaPrototype);
+
+const focusTextareaPrototype = definePrototype({
+  name: 'x-wc-text-control-focus',
+  modules: [declareTextControl({ content: 'plain-text', lineMode: 'multiline', engine: 'host' })],
+  setup(def: DefHandle<ControlProps>) {
+    def.props.define({
+      defaultValue: { type: 'string', empty: 'fallback' },
+      placeholder: { type: 'string', empty: 'fallback' },
+      rows: { type: 'number', empty: 'fallback' },
+    });
+    const control = asTextControl<ControlProps>();
+    const focusable = asFocusable<ControlProps>();
+    focusable.configure({ disabled: false });
+    def.expose.state('focused', focusable.focused);
+    def.expose.state('focusVisible', focusable.focusVisible);
+    const sync = (props: Readonly<ControlProps>) => {
+      control.sync({
+        valueMode: 'uncontrolled',
+        defaultValue: props.defaultValue,
+        placeholder: props.placeholder,
+        rows: props.rows,
+      });
+    };
+    def.lifecycle.onCreated((run) => sync(run.props.get()));
+    def.props.watchAll((_run, next) => sync(next));
+    return () => null;
+  },
+});
+
+AdaptToWebComponent(focusTextareaPrototype);
 
 async function flush(): Promise<void> {
   await Promise.resolve();
@@ -99,5 +129,40 @@ describe('adapter-web-component text control', () => {
     textarea.value = 'after-detach';
     textarea.dispatchEvent(new InputEvent('input', { bubbles: true }));
     expect(moduleInputValues).toEqual(['edited']);
+  });
+
+  it('projects physical textarea focus onto host focus states', async () => {
+    const shell = document.createElement('x-wc-text-control-focus') as WebComponentAdapterElement<
+      typeof focusTextareaPrototype
+    >;
+    setElementProps(shell, { defaultValue: '', placeholder: 'Write', rows: 4 });
+    document.body.appendChild(shell);
+    await flush();
+
+    const textarea = shell.querySelector('textarea');
+    if (!textarea) throw new Error('physical textarea was not materialized');
+    const exposes = shell.getExposes() as {
+      focused: { get(): boolean };
+      focusVisible: { get(): boolean };
+    };
+    expect(exposes.focused.get()).toBe(false);
+    expect(exposes.focusVisible.get()).toBe(false);
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+    textarea.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(exposes.focused.get()).toBe(true);
+    expect(exposes.focusVisible.get()).toBe(true);
+    expect(shell.hasAttribute('data-focus-visible')).toBe(true);
+
+    textarea.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+    expect(exposes.focused.get()).toBe(false);
+    expect(exposes.focusVisible.get()).toBe(false);
+    expect(shell.hasAttribute('data-focus-visible')).toBe(false);
+
+    shell.remove();
+    await flush();
+    expect(() =>
+      textarea.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+    ).not.toThrow();
   });
 });

--- a/packages/adapters/web-component/test/text-control.integration.test.ts
+++ b/packages/adapters/web-component/test/text-control.integration.test.ts
@@ -10,6 +10,7 @@ import { declareTextControl } from '@proto.ui/module-text-control';
 import { AdaptToWebComponent, setElementProps, type WebComponentAdapterElement } from '../src';
 
 const moduleInputValues: string[] = [];
+const projectedHostFocusTypes: string[] = [];
 type ControlProps = { defaultValue?: string; placeholder?: string; rows?: number };
 
 const textareaPrototype = definePrototype({
@@ -57,6 +58,12 @@ const focusTextareaPrototype = definePrototype({
     def.expose.method('focusSelf', (options: FocusRequestOptions | undefined) =>
       focusable.focusSelf(options)
     );
+    def.event.on('host:focus', (_run, event) => {
+      projectedHostFocusTypes.push(String(event?.type));
+    });
+    def.event.on('host:blur', (_run, event) => {
+      projectedHostFocusTypes.push(String(event?.type));
+    });
     const sync = (props: Readonly<ControlProps>) => {
       control.sync({
         valueMode: 'uncontrolled',
@@ -140,6 +147,7 @@ describe('adapter-web-component text control', () => {
   });
 
   it('projects native text-control focus across modality, remount, and teardown', async () => {
+    projectedHostFocusTypes.length = 0;
     const shell = document.createElement('x-wc-text-control-focus') as WebComponentAdapterElement<
       typeof focusTextareaPrototype
     >;
@@ -166,6 +174,7 @@ describe('adapter-web-component text control', () => {
     textarea.focus();
     expect(document.activeElement).toBe(textarea);
     expect(projectedFocusCount).toBe(0);
+    expect(projectedHostFocusTypes).toEqual(['focus']);
     expect(exposes.focused.get()).toBe(true);
     expect(exposes.focusVisible.get()).toBe(true);
     expect(shell.hasAttribute('data-focus-visible')).toBe(true);
@@ -173,6 +182,7 @@ describe('adapter-web-component text control', () => {
 
     textarea.blur();
     expect(document.activeElement).not.toBe(textarea);
+    expect(projectedHostFocusTypes).toEqual(['focus', 'blur']);
     expect(exposes.focused.get()).toBe(false);
     expect(exposes.focusVisible.get()).toBe(false);
     expect(shell.hasAttribute('data-focus-visible')).toBe(false);

--- a/packages/adapters/web-component/test/text-control.integration.test.ts
+++ b/packages/adapters/web-component/test/text-control.integration.test.ts
@@ -252,10 +252,10 @@ describe('adapter-web-component text control', () => {
 
     // Swallow the bridge signal: focusin on the control never reaches the
     // boundary, so the bridge never re-dispatches focus/blur.
-    const swallowFocusIn = (e: FocusEvent) => {
+    const swallowFocus = (e: FocusEvent) => {
       if (e.target === textarea) e.stopImmediatePropagation();
     };
-    document.addEventListener('focusin', swallowFocusIn, true);
+    textarea.addEventListener('focus', swallowFocus, true);
     try {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
       textarea.focus();
@@ -266,7 +266,7 @@ describe('adapter-web-component text control', () => {
       expect(exposes.focusVisible.get()).toBe(false);
       expect(shell.hasAttribute('data-focus-visible')).toBe(false);
     } finally {
-      document.removeEventListener('focusin', swallowFocusIn, true);
+      textarea.removeEventListener('focus', swallowFocus, true);
     }
 
     // After unblocking, the bridge path restores.

--- a/spec/tests/T-BASE-TEXTAREA-0001.yaml
+++ b/spec/tests/T-BASE-TEXTAREA-0001.yaml
@@ -91,6 +91,7 @@ implementations:
       - Intercepts the native control focusin before it reaches the boundary to prove that focus still lands physically while logical focused/focusVisible projection breaks without the bridge signal.
       - Calls the exposed focusSelf method and proves that the physical control becomes active and the logical focused state synchronizes back; physical blur and refocus cover the reverse direction.
       - Routes physical focus through adapter-private ingress; document/boundary listeners observe no second public focus event while Proto focused/focusVisible facts still update.
+      - Normalizes the private callback payload to declared `focus` / `blur` types while retaining the original physical `focusin` / `focusout` event only as private nativeEvent context.
     exercises:
       - P-BASE-TEXTAREA
   - id: docs-browser-brutalist-textarea-focus
@@ -126,6 +127,9 @@ sources:
   - path: packages/adapters/web-component/test/text-control.integration.test.ts
   - path: apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
 revisions:
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Normalized private text-control focus ingress to declared focus/blur callback types while retaining physical focusin/focusout only as native context.
   - version: 0.3.0-alpha.0
     change: revised
     summary: Kept physical text-control focus projection inside adapter-private ingress and added negative evidence that no second public boundary focus event is emitted.

--- a/spec/tests/T-BASE-TEXTAREA-0001.yaml
+++ b/spec/tests/T-BASE-TEXTAREA-0001.yaml
@@ -90,6 +90,7 @@ implementations:
     notes:
       - Intercepts the native control focusin before it reaches the boundary to prove that focus still lands physically while logical focused/focusVisible projection breaks without the bridge signal.
       - Calls the exposed focusSelf method and proves that the physical control becomes active and the logical focused state synchronizes back; physical blur and refocus cover the reverse direction.
+      - Routes physical focus through adapter-private ingress; document/boundary listeners observe no second public focus event while Proto focused/focusVisible facts still update.
     exercises:
       - P-BASE-TEXTAREA
   - id: docs-browser-brutalist-textarea-focus
@@ -125,6 +126,9 @@ sources:
   - path: packages/adapters/web-component/test/text-control.integration.test.ts
   - path: apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
 revisions:
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Kept physical text-control focus projection inside adapter-private ingress and added negative evidence that no second public boundary focus event is emitted.
   - version: 0.3.0-alpha.0
     change: revised
     summary: Added explicit bridge-absence failure evidence and bidirectional focusSelf-to-physical-control synchronization coverage for the Web Component textarea.

--- a/spec/tests/T-BASE-TEXTAREA-0001.yaml
+++ b/spec/tests/T-BASE-TEXTAREA-0001.yaml
@@ -44,12 +44,12 @@ cases:
       - P-BASE-TEXTAREA-PRESENTATION-SURFACE
     expectation: base-textarea-visual-and-focus-surface-is-the-single-physical-editor
   - id: T-BASE-TEXTAREA-0001-CASE-WC-FOCUS-BRIDGE
-    title: Web Component physical focus projects through one native textarea across keyboard, pointer, remount, and teardown
+    title: Web Component physical focus projects bidirectionally through one native textarea across keyboard, pointer, focusSelf, remount, and teardown, and the path fails when the bridge signal is intercepted
     covers:
       - P-BASE-TEXTAREA-PHYSICAL-TARGET
       - P-BASE-TEXTAREA-A11Y-AND-FOCUS
       - P-BASE-TEXTAREA-PRESENTATION-SURFACE
-    expectation: wc-native-textarea-focus-bridges-to-one-logical-boundary-without-leaks-or-extra-tab-stops
+    expectation: wc-native-textarea-focus-bridges-bidirectionally-to-one-logical-boundary-with-an-explicit-bridge-absence-failure-control-and-no-leaks-or-extra-tab-stops
   - id: T-BASE-TEXTAREA-0001-CASE-AUTHORING-SURFACE
     title: Direct and asHook entries expose the same bounded Textarea protocol and static requirements
     covers:
@@ -87,6 +87,9 @@ implementations:
     required: true
     consumesCases:
       - T-BASE-TEXTAREA-0001-CASE-WC-FOCUS-BRIDGE
+    notes:
+      - Intercepts the native control focusin before it reaches the boundary to prove that focus still lands physically while logical focused/focusVisible projection breaks without the bridge signal.
+      - Calls the exposed focusSelf method and proves that the physical control becomes active and the logical focused state synchronizes back; physical blur and refocus cover the reverse direction.
     exercises:
       - P-BASE-TEXTAREA
   - id: docs-browser-brutalist-textarea-focus
@@ -122,6 +125,9 @@ sources:
   - path: packages/adapters/web-component/test/text-control.integration.test.ts
   - path: apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
 revisions:
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Added explicit bridge-absence failure evidence and bidirectional focusSelf-to-physical-control synchronization coverage for the Web Component textarea.
   - version: 0.3.0-alpha.0
     change: revised
     summary: Added real native keyboard and pointer focus, remount, teardown, exposed-state, DOM-marker, and browser ring evidence for the Web Component physical textarea.

--- a/spec/tests/T-BASE-TEXTAREA-0001.yaml
+++ b/spec/tests/T-BASE-TEXTAREA-0001.yaml
@@ -3,7 +3,7 @@ type: test
 title: Base Textarea protocol tests
 status: draft
 since: 0.2.0-rc.7
-summary: Web Component coverage for one contentless Web textarea profile, shared direct/asHook static requirements, stable value ownership, normalized edit and IME events, native property and accessibility projection, physical focus, and the bounded expose surface.
+summary: Web Component and browser coverage for one contentless Web textarea profile, shared direct/asHook static requirements, stable value ownership, normalized edit and IME events, native property and accessibility projection, physical focus across input modalities and view epochs, and the bounded expose surface.
 cases:
   - id: T-BASE-TEXTAREA-0001-CASE-PHYSICAL-SURFACE
     title: Root materializes one contentless native textarea with the complete initial property surface
@@ -43,6 +43,13 @@ cases:
       - P-BASE-TEXTAREA-PHYSICAL-TARGET
       - P-BASE-TEXTAREA-PRESENTATION-SURFACE
     expectation: base-textarea-visual-and-focus-surface-is-the-single-physical-editor
+  - id: T-BASE-TEXTAREA-0001-CASE-WC-FOCUS-BRIDGE
+    title: Web Component physical focus projects through one native textarea across keyboard, pointer, remount, and teardown
+    covers:
+      - P-BASE-TEXTAREA-PHYSICAL-TARGET
+      - P-BASE-TEXTAREA-A11Y-AND-FOCUS
+      - P-BASE-TEXTAREA-PRESENTATION-SURFACE
+    expectation: wc-native-textarea-focus-bridges-to-one-logical-boundary-without-leaks-or-extra-tab-stops
   - id: T-BASE-TEXTAREA-0001-CASE-AUTHORING-SURFACE
     title: Direct and asHook entries expose the same bounded Textarea protocol and static requirements
     covers:
@@ -73,6 +80,25 @@ implementations:
       - T-BASE-TEXTAREA-0001-CASE-PRESENTATION-SURFACE
     exercises:
       - P-BASE-TEXTAREA
+  - id: adapter-web-component-textarea-focus-bridge
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/text-control.integration.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-TEXTAREA-0001-CASE-WC-FOCUS-BRIDGE
+    exercises:
+      - P-BASE-TEXTAREA
+  - id: docs-browser-brutalist-textarea-focus
+    kind: adapter-test
+    status: passing
+    path: apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-TEXTAREA-0001-CASE-WC-FOCUS-BRIDGE
+    exercises:
+      - P-BASE-TEXTAREA
+      - P-BRUTALIST-TEXTAREA
 verifies:
   prototypes:
     - id: P-BASE-TEXTAREA
@@ -93,7 +119,12 @@ exercises:
 sources:
   - path: packages/prototypes/base/test/textarea.test.ts
   - path: packages/adapters/web-component/test/previewer.demo-renderer.test.ts
+  - path: packages/adapters/web-component/test/text-control.integration.test.ts
+  - path: apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
 revisions:
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Added real native keyboard and pointer focus, remount, teardown, exposed-state, DOM-marker, and browser ring evidence for the Web Component physical textarea.
   - version: 0.2.0-rc.7
     change: revised
     summary: Added host-neutral direct/asHook static requirement coverage.

--- a/spec/tests/T-BRUTALIST-TEXTAREA-0001.yaml
+++ b/spec/tests/T-BRUTALIST-TEXTAREA-0001.yaml
@@ -3,7 +3,7 @@ type: test
 title: Brutalist Textarea inheritance and visual contract tests
 status: draft
 since: 0.2.0-rc.7
-summary: Covers complete Base Textarea inheritance on one contentless native target and the square lavender, ink, monospace, hard-shadow visual delta.
+summary: Covers complete Base Textarea inheritance on one contentless native target, Web Component modality-correct focus projection, and the square lavender, ink, monospace, hard-shadow visual delta.
 cases:
   - id: T-BRUTALIST-TEXTAREA-0001-CASE-INHERITANCE
     title: Brutalist Textarea preserves the complete Base protocol and normalized uncontrolled editing on one native target
@@ -25,6 +25,15 @@ cases:
       - P-BRUTALIST-TEXTAREA-SINGLE-TARGET
       - C-HOST-SURFACE-PROJECTION-0001-G
     expectation: wc-brutalist-textarea-state-markers-and-conditional-style-share-one-surface
+  - id: T-BRUTALIST-TEXTAREA-0001-CASE-WC-FOCUS-RING
+    title: Keyboard focus projects the Brutalist ring onto the single physical Web Component textarea while pointer focus does not
+    covers:
+      - P-BRUTALIST-TEXTAREA-BASE-INHERITANCE
+      - P-BRUTALIST-TEXTAREA-SINGLE-TARGET
+      - P-BRUTALIST-TEXTAREA-VISUAL-GRAMMAR
+      - P-BASE-TEXTAREA-A11Y-AND-FOCUS
+      - P-BASE-TEXTAREA-PRESENTATION-SURFACE
+    expectation: wc-brutalist-textarea-renders-the-physical-ring-only-for-keyboard-focus-visible
 implementations:
   - id: prototypes-brutalist-textarea-contract
     kind: module-test
@@ -35,6 +44,16 @@ implementations:
       - T-BRUTALIST-TEXTAREA-0001-CASE-INHERITANCE
       - T-BRUTALIST-TEXTAREA-0001-CASE-VISUAL-GRAMMAR
       - T-BRUTALIST-TEXTAREA-0001-CASE-STATEFUL-SURFACE
+    exercises:
+      - P-BASE-TEXTAREA
+      - P-BRUTALIST-TEXTAREA
+  - id: docs-browser-brutalist-textarea-focus
+    kind: adapter-test
+    status: passing
+    path: apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
+    required: true
+    consumesCases:
+      - T-BRUTALIST-TEXTAREA-0001-CASE-WC-FOCUS-RING
     exercises:
       - P-BASE-TEXTAREA
       - P-BRUTALIST-TEXTAREA
@@ -54,7 +73,11 @@ exercises:
     - P-BRUTALIST-TEXTAREA
 sources:
   - path: packages/prototypes/brutalist/test/textarea.test.ts
+  - path: apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
 revisions:
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Added Light/Dark browser evidence for native keyboard focus, pointer modality, exposed focus facts, colocalized DOM markers, and the physical Brutalist ring.
   - version: 0.2.0-rc.7
     change: revised
     summary: Added state-selector colocation coverage for the Web Component presentation surface.


### PR DESCRIPTION
Closes #395.

## Root cause

Host-bound `host:focus` / `host:blur` listeners are attached to the custom-element boundary, while the WC runtime's natively focusable surface is the physical `<textarea>` / `<input>` (`part="control"`). Native focus/blur do not bubble, so Focus never observed the physical editor; React and Vue use a root focus target and were unaffected.

## Change

- The WC view binds physical `focusin` / `focusout` for its text-control target and routes the trusted native event through `createWebProtoEventRouter().dispatchHostRootEvent(...)`, an adapter-private gated ingress. It does **not** dispatch a second public focus/blur DOM event from the custom-element boundary.
- The private ingress invokes the existing `host:*` listener path and preserves the physical target for Focus. Per-view disposal removes the bridge and router listeners; detach/remount/terminal disposal do not duplicate or leak them.
- `focusSelf` delegates to the physical editor through the existing WC focus override; logical `focused` / `focusVisible` and style markers synchronize in both directions.
- Callback payload types are normalized to declared `focus`/`blur` while retaining the originating physical event as non-enumerable `nativeEvent` context.

## Exclusions / residual risk

- No new Focus Host Capability, Event router change, or cross-adapter generic modality model is introduced.
- The private ingress applies only to the WC runtime's physical text control; React and Vue use the existing root focus target path and are unaffected.
- Screenshot pixels and non-Chromium UA behavior were not independently audited.

## Validation (current head `121684f3`)

- Adapter-base/Web Component/Base Textarea: 21 files / 73 tests passed.
- Brutalist browser journey: 6/6.
- `check:types` — 0 errors/warnings/hints.
- `check:prototype-catalog` — OK.
- `test:public-docs` — passed.
- Live CI/DCO/Vercel checks are green on the exact head.
- Local actionlint was not independently run; the existing CI lanes remain the required evidence.

## Contribution provenance

- **Original rights:** The adapter-private focus ingress, WC integration, tests, and spec/test projection updates are original work created for Proto UI. The DCO signer confirms the right to submit them under the MIT License.
- **Third-party/upstream:** No code or assets were copied or ported. The implementation relies only on public DOM focus/focusin/focusout behavior and existing Proto UI Event/Focus/Text Control contracts.
- **Material AI assistance:** An AI coding assistant (OpenAI Codex/GPT-5.6 family via Oh My Pi) materially assisted with root-cause tracing, implementation, tests, documentation, and review remediation. The human contributor reviewed all diffs and validated physical focus, private event transport, remount/teardown, browser paint, focused tests, types, and catalog checks. No third-party or private code was supplied to the model.
- **Employer/client:** The signer confirms the contribution is not derived from an employer/client proprietary repository and that they have the right to publish it.