### PR TITLE
fix(brutalist): resolve Card separators from the theme foreground

### DIFF
--- a/apps/www/src/content/docs/en/ui-libraries/brutalist/components/card.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/brutalist/components/card.mdx
@@ -15,7 +15,7 @@ Brutalist Card is a direct styled-only grouping surface with no Base counterpart
 
 - The public surface is deliberately limited to Root, Header, Content, and Footer.
 - Root is a passive square paper panel with a `2px` ink frame and hard offset shadow; it has no role, focus, activation, or selection mode.
-- Header and Footer own directional ink separators and layout; Content owns horizontal spacing.
+- Header and Footer own directional ink separators and layout; Content owns horizontal spacing. Separator ink resolves the theme foreground, the same structural color as the Root frame, so a theme change repaints both together.
 - Title and description are ordinary content. Actions compose Button or Link children, which retain their own semantics.
 
 Use Card for passive visual grouping. Selection, disclosure, navigation, and activation belong to their corresponding protocols rather than Card modes.

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/brutalist/components/card.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/brutalist/components/card.mdx
@@ -15,7 +15,7 @@ Brutalist Card 是没有 Base counterpart 的 direct styled-only 分组表面。
 
 - 公开 surface 有意只保留 Root、Header、Content 与 Footer。
 - Root 是被动的方形 paper 面板，带 `2px` ink frame 与偏移硬阴影；它没有 role、focus、activation 或 selection mode。
-- Header 与 Footer 拥有方向性 ink 分隔线和布局；Content 拥有水平间距。
+- Header 与 Footer 拥有方向性 ink 分隔线和布局；Content 拥有水平间距。分隔线的 ink 解析为主题 foreground，与 Root frame 使用同一结构色，因此主题切换时两者一起重绘。
 - Title 与 description 使用普通内容；action 组合 Button 或 Link child，并保留这些 child 自己的语义。
 
 Card 用于被动视觉分组。Selection、disclosure、navigation 与 activation 属于各自协议，而不是 Card mode。

--- a/packages/prototypes/brutalist/src/card/footer.proto.ts
+++ b/packages/prototypes/brutalist/src/card/footer.proto.ts
@@ -8,7 +8,7 @@ export const BrutalistCardFooter = definePrototype<
   name: 'brutalist-card-footer',
   setup(def) {
     def.feedback.style.use(
-      tw('flex items-center justify-between gap-4 border-t-2 brutalist-border-top-black px-6 pt-4')
+      tw('flex items-center justify-between gap-4 border-t-2 border-foreground px-6 pt-4')
     );
     return (renderer) => [renderer.r.slot()];
   },

--- a/packages/prototypes/brutalist/src/card/header.proto.ts
+++ b/packages/prototypes/brutalist/src/card/header.proto.ts
@@ -8,9 +8,7 @@ export const BrutalistCardHeader = definePrototype<
   name: 'brutalist-card-header',
   setup(def) {
     def.feedback.style.use(
-      tw(
-        'flex items-start justify-between gap-4 border-b-2 brutalist-border-bottom-black px-6 pb-4'
-      )
+      tw('flex items-start justify-between gap-4 border-b-2 border-foreground px-6 pb-4')
     );
     return (renderer) => [renderer.r.slot()];
   },

--- a/packages/prototypes/brutalist/test/card.test.ts
+++ b/packages/prototypes/brutalist/test/card.test.ts
@@ -100,10 +100,15 @@ describe('prototypes/brutalist: card', () => {
     expect(styleContains(root, 'border-2')).toBe(true);
     expect(styleContains(root, 'border-foreground')).toBe(true);
     expect(styleContains(header, 'border-b-2')).toBe(true);
-    expect(styleContains(header, 'brutalist-border-bottom-black')).toBe(true);
+    expect(styleContains(header, 'border-foreground')).toBe(true);
     expect(styleContains(content, 'px-6')).toBe(true);
     expect(styleContains(footer, 'border-t-2')).toBe(true);
-    expect(styleContains(footer, 'brutalist-border-top-black')).toBe(true);
+    expect(styleContains(footer, 'border-foreground')).toBe(true);
+
+    // Section separators resolve the same ink as the Root frame, so a theme
+    // change repaints them with the Card instead of leaving fixed black.
+    expect(styleContains(header, 'brutalist-border-bottom-black')).toBe(false);
+    expect(styleContains(footer, 'brutalist-border-top-black')).toBe(false);
 
     root.remove();
   });

--- a/spec/prototypes/P-BRUTALIST-CARD-FOOTER.yaml
+++ b/spec/prototypes/P-BRUTALIST-CARD-FOOTER.yaml
@@ -10,8 +10,8 @@ statement:
 criteria:
   - id: P-BRUTALIST-CARD-FOOTER-VISUAL
     text:
-      en: Footer directly owns flex alignment, spacing, horizontal padding, and a 2px upper ink separator while composed actions retain their own semantics.
-      zh-CN: Footer 直接拥有 flex 对齐、间距、水平 padding 与 2px 上方 ink 分隔线，组合 action 保留自身语义。
+      en: Footer directly owns flex alignment, spacing, horizontal padding, and a 2px upper ink separator while composed actions retain their own semantics. Its ink must resolve the theme foreground, the same structural color as the Root frame, rather than a fixed black.
+      zh-CN: Footer 直接拥有 flex 对齐、间距、水平 padding 与 2px 上方 ink 分隔线，组合 action 保留自身语义。其 ink 必须解析为主题 foreground，即与 Root frame 相同的结构色，而不是固定黑色。
 sources:
   - path: packages/prototypes/brutalist/src/card/footer.proto.ts
 relates:
@@ -23,6 +23,9 @@ revisions:
   - version: 0.2.0-rc.7
     change: introduced
     summary: Introduced the direct Brutalist Card Footer region.
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Unified the upper separator ink with the Root frame's theme foreground instead of a fixed black.
 tags:
   - prototype
   - brutalist

--- a/spec/prototypes/P-BRUTALIST-CARD-HEADER.yaml
+++ b/spec/prototypes/P-BRUTALIST-CARD-HEADER.yaml
@@ -10,8 +10,8 @@ statement:
 criteria:
   - id: P-BRUTALIST-CARD-HEADER-VISUAL
     text:
-      en: Header directly owns flex alignment, spacing, horizontal padding, and a 2px lower ink separator while claiming no content semantics or interaction behavior.
-      zh-CN: Header 直接拥有 flex 对齐、间距、水平 padding 与 2px 下方 ink 分隔线，不声明内容语义或交互行为。
+      en: Header directly owns flex alignment, spacing, horizontal padding, and a 2px lower ink separator while claiming no content semantics or interaction behavior. Its ink must resolve the theme foreground, the same structural color as the Root frame, rather than a fixed black.
+      zh-CN: Header 直接拥有 flex 对齐、间距、水平 padding 与 2px 下方 ink 分隔线，不声明内容语义或交互行为。其 ink 必须解析为主题 foreground，即与 Root frame 相同的结构色，而不是固定黑色。
 sources:
   - path: packages/prototypes/brutalist/src/card/header.proto.ts
 relates:
@@ -23,6 +23,9 @@ revisions:
   - version: 0.2.0-rc.7
     change: introduced
     summary: Introduced the direct Brutalist Card Header region.
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Unified the lower separator ink with the Root frame's theme foreground instead of a fixed black.
 tags:
   - prototype
   - brutalist


### PR DESCRIPTION
## Summary

Card Header and Footer separators now resolve the theme foreground instead of a fixed black, matching the ink the Root frame already uses.

## Related context

- Issue: closes #394
- Applicable spec entities and lifecycle: `P-BRUTALIST-CARD-HEADER` and `P-BRUTALIST-CARD-FOOTER` (both `draft`, criteria revised); `P-BRUTALIST-CARD` unchanged
- Criteria / test anchors: `P-BRUTALIST-CARD-HEADER-VISUAL`, `P-BRUTALIST-CARD-FOOTER-VISUAL` → `T-BRUTALIST-CARD-0001-CASE-2`, `T-BRUTALIST-CARD-0001-CASE-3`
- Related upstream: none; Brutalist is an original design language

## Scope boundary

**Already decided by the issue and the maintainer boundary in [#394](https://github.com/Proto-UI/Proto-UI/issues/394#issuecomment-5306034812).** Swap to `border-b-2 border-foreground` / `border-t-2 border-foreground`; leave `packages/cli/src/services/proto-style-css.ts` and the generated presets alone so `semantic-merge-v0-delta` stays `none`; do not migrate Dialog; update the Card entities and tests; add three-runtime browser evidence; keep EN/ZH docs parity.

**Decided here.** Nothing beyond wording. The entity criteria now say the separator ink resolves the theme foreground, the same structural color as the Root frame, rather than a fixed black, and the docs carry the same clause in both locales.

**Out of scope.** Dialog Header and Footer consume the same two `brutalist-border-*-black` utilities and are tracked separately, so those utilities stay in the manifest. The Brutalist Button composed inside the Card demo keeps its own `border-black`; that is Button grammar, not a regression from this change.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs.
- [x] Normative behavior changes include coherent P/C/T criteria, revisions, executable evidence, and affected projections.
- [x] This change does not create an empty catalog identity or silently widen a draft/active public guarantee.

## Contribution provenance

- [x] This contribution was created by me and I have the right to submit it.
- [ ] This contribution adapts or derives from third-party material.
- [x] This contribution includes material AI-assisted generation or transformation.
- [ ] This contribution may be subject to employer or client ownership, and I have confirmed that I may submit it.
- [x] No third-party source disclosure is required.

### AI assistance

Claude (Anthropic) was used as a coding assistant for the implementation, test updates, entity wording, and docs. I directed the work, reviewed every file, and verified the result. No third-party or private code was provided to the model beyond this public repository. All colour values quoted below come from executed browser measurements, not generated text.

## DCO

- [x] I have checked the DCO status of this PR.

## Prototype website preview

- [ ] This pull request adds or changes public Prototype behavior and includes the required reachable website page or page update.
- [x] A new or updated website page is not applicable because: the Card page already exists and is unchanged in structure. Its contract text gained one clause describing the separator ink, in both locales.

- Public docs route: `/en/ui-libraries/brutalist/components/card/` and `/zh-cn/ui-libraries/brutalist/components/card/`
- Local preview URL or route: `http://127.0.0.1:4321/en/ui-libraries/brutalist/components/card/`
- Applicable runtimes manually reviewed: Web Component / React / Vue — all three, in both light and dark.
- [x] The demo consumes the real public package export and prefers the Prototype's own anatomy, triggers, state, events, and defaults.
- [x] The Demo Matrix, when used, is supplementary evidence rather than a replacement for the website page.
- External demo orchestration: none.
- Consumer-owned orchestration that is not installed with the package: none.

## Validation

Node 25 locally, so `corepack` is not bundled; repository scripts ran through a local shim forwarding to `pnpm@10.32.1`.

- Focused tests: `vitest run packages/prototypes/brutalist` → 16 files, 76 passed.
- Catalog / generated checks: `check:prototype-catalog` OK. `check:styles:preset` → Brutalist manifest current at 225 tokens, unchanged, confirming `semantic-merge-v0-delta` stays `none`. `packages/spec` schema and fixtures pass.
- Types / repository tests: `tsc -p tsconfig.workspace.json --noEmit` clean. `check:release-version` → `0.3.0-alpha.0, 40 public packages, 9 V entity`.
- Docs build / preview: `pnpm --filter apps-www check` → 0 errors, 0 warnings, 0 hints. `pnpm --filter apps-www build` → 196 pages.
- Manual or browser evidence: Playwright Chromium against the local dev server, resolving painted colours through a canvas so `oklch()` is measured as rendered.

| theme | `--pui-foreground` | Root frame | Header bottom | Footer top |
| --- | --- | --- | --- | --- |
| light | `rgb(23,23,23)` | `rgb(23,23,23)` | `rgb(23,23,23)` | `rgb(23,23,23)` |
| dark | `rgb(245,245,245)` | `rgb(245,245,245)` | `rgb(245,245,245)` | `rgb(245,245,245)` |

Identical across `wc`, `react`, and `vue`. Dark-mode separator contrast against the Card surface moves from **1.17:1 to 16.44:1**; light mode moves from pure `#000` to `#171717`, the intended unification with the Root frame.

- Not run or not applicable, with reason: the full `pnpm test` chain and `build:packages` were exercised on my other branch against the same `main`; this change touches no package surface, export, or preset, so only the proportional Prototype-maintenance checks above apply.
