### PR TITLE
fix(brutalist): resolve Dialog separators from the theme foreground

### DIFF
--- a/packages/cli/src/generated/brutalist-style-tokens.ts
+++ b/packages/cli/src/generated/brutalist-style-tokens.ts
@@ -31,8 +31,6 @@ export const BRUTALIST_STYLE_TOKENS: string[] = [
   'border-t-2',
   'border-transparent',
   'bottom-0',
-  'brutalist-border-bottom-black',
-  'brutalist-border-top-black',
   'cursor-default',
   'cursor-not-allowed',
   'data-[active]:bg-main',

--- a/packages/cli/src/services/proto-style-css.ts
+++ b/packages/cli/src/services/proto-style-css.ts
@@ -164,8 +164,6 @@ const staticUtilities: Record<string, string[]> = {
   'border-t-2': ['border-top-width: 2px;', 'border-top-style: solid;'],
   'border-b': ['border-bottom-width: 1px;', 'border-bottom-style: solid;'],
   'border-l-2': ['border-left-width: 2px;', 'border-left-style: solid;'],
-  'brutalist-border-bottom-black': ['border-bottom-color: #000;'],
-  'brutalist-border-top-black': ['border-top-color: #000;'],
   'border-ink': ['border-color: var(--pui-foreground);'],
   'border-black': ['border-color: #000;'],
   'border-foreground': ['border-color: var(--pui-foreground);'],

--- a/packages/cli/test/proto-style-css.test.ts
+++ b/packages/cli/test/proto-style-css.test.ts
@@ -76,14 +76,12 @@ describe('proto style css renderer', () => {
     expect(css).not.toContain('Unsupported Proto UI style tokens');
   });
 
-  it('renders projection-local directional border colors', () => {
-    const css = renderProtoStyleTokenCss([
-      'brutalist-border-bottom-black',
-      'brutalist-border-top-black',
-    ]);
+  it('renders directional separator borders in the theme foreground', () => {
+    const css = renderProtoStyleTokenCss(['border-b-2', 'border-t-2', 'border-foreground']);
 
-    expect(css).toContain('border-bottom-color: #000;');
-    expect(css).toContain('border-top-color: #000;');
+    expect(css).toContain('border-bottom-width: 2px;');
+    expect(css).toContain('border-top-width: 2px;');
+    expect(css).toContain('border-color: var(--pui-foreground);');
     expect(css).not.toContain('Unsupported Proto UI style tokens');
   });
 

--- a/packages/prototypes/brutalist/src/dialog/footer.proto.ts
+++ b/packages/prototypes/brutalist/src/dialog/footer.proto.ts
@@ -7,9 +7,9 @@ const dialogFooter = definePrototype({
   setup(def) {
     // P-BRUTALIST-DIALOG-FOOTER-ANATOMY: claim DIALOG_FAMILY footer role.
     def.anatomy.claim(DIALOG_FAMILY, { role: 'footer' });
-    // P-BRUTALIST-DIALOG-FOOTER-VISUAL-GRAMMAR: flex-col-reverse gap with a projection-local 2px black top rule.
+    // P-BRUTALIST-DIALOG-FOOTER-VISUAL-GRAMMAR: flex-col-reverse gap with a 2px top rule in the theme foreground.
     def.feedback.style.use(
-      tw('flex flex-col-reverse gap-2 border-t-2 brutalist-border-top-black pt-3 justify-end')
+      tw('flex flex-col-reverse gap-2 border-t-2 border-foreground pt-3 justify-end')
     );
     return (renderer) => renderer.r.slot();
   },

--- a/packages/prototypes/brutalist/src/dialog/header.proto.ts
+++ b/packages/prototypes/brutalist/src/dialog/header.proto.ts
@@ -7,10 +7,8 @@ const dialogHeader = definePrototype({
   setup(def) {
     // P-BRUTALIST-DIALOG-HEADER-ANATOMY: claim DIALOG_FAMILY header role.
     def.anatomy.claim(DIALOG_FAMILY, { role: 'header' });
-    // P-BRUTALIST-DIALOG-HEADER-VISUAL-GRAMMAR: grid gap with a projection-local 2px black bottom rule.
-    def.feedback.style.use(
-      tw('grid gap-1 border-b-2 brutalist-border-bottom-black pb-3 text-left')
-    );
+    // P-BRUTALIST-DIALOG-HEADER-VISUAL-GRAMMAR: grid gap with a 2px bottom rule in the theme foreground.
+    def.feedback.style.use(tw('grid gap-1 border-b-2 border-foreground pb-3 text-left'));
     return (renderer) => renderer.r.slot();
   },
 });

--- a/packages/prototypes/brutalist/test/dialog.test.ts
+++ b/packages/prototypes/brutalist/test/dialog.test.ts
@@ -365,20 +365,16 @@ describe('prototypes/brutalist: dialog', () => {
     expect(dialogHeader.name).toBe('brutalist-dialog-header');
     expect(header.contains(title)).toBe(true);
     expect(header.contains(description)).toBe(true);
-    for (const token of [
-      'grid',
-      'gap-1',
-      'border-b-2',
-      'brutalist-border-bottom-black',
-      'pb-3',
-      'text-left',
-    ]) {
+    for (const token of ['grid', 'gap-1', 'border-b-2', 'border-foreground', 'pb-3', 'text-left']) {
       expect(
         styleContains(header, token),
         `${token} :: ${header.getAttribute('data-pui-style')}`
       ).toBe(true);
     }
     expect(styleContains(header, 'border-black')).toBe(false);
+    // Section separators resolve the theme foreground, so a theme change
+    // repaints them with the panel instead of leaving fixed black.
+    expect(styleContains(header, 'brutalist-border-bottom-black')).toBe(false);
 
     expect(dialogFooter.name).toBe('brutalist-dialog-footer');
     expect(footer.contains(close)).toBe(true);
@@ -387,12 +383,13 @@ describe('prototypes/brutalist: dialog', () => {
       'flex-col-reverse',
       'gap-2',
       'border-t-2',
-      'brutalist-border-top-black',
+      'border-foreground',
       'pt-3',
       'justify-end',
     ]) {
       expect(styleContains(footer, token)).toBe(true);
     }
     expect(styleContains(footer, 'border-black')).toBe(false);
+    expect(styleContains(footer, 'brutalist-border-top-black')).toBe(false);
   });
 });

--- a/spec/prototypes/P-BRUTALIST-DIALOG-FOOTER.yaml
+++ b/spec/prototypes/P-BRUTALIST-DIALOG-FOOTER.yaml
@@ -34,11 +34,11 @@ criteria:
   - id: P-BRUTALIST-DIALOG-FOOTER-VISUAL-GRAMMAR
     text:
       en: >-
-        The surface uses `flex flex-col-reverse gap-2 border-t-2 brutalist-border-top-black pt-3 justify-end` — a flex-col-reverse layout panel with a projection-local 2px black top border, no fill of its own, and tail-aligned content, preserving the Neo-Brutalist structural border grammar without gradients, glass, rounded cards, or soft elevation.
+        The surface uses `flex flex-col-reverse gap-2 border-t-2 border-foreground pt-3 justify-end` — a flex-col-reverse layout panel with a 2px top border resolved from the theme foreground rather than a fixed black, no fill of its own, and tail-aligned content, preserving the Neo-Brutalist structural border grammar without gradients, glass, rounded cards, or soft elevation.
 
 
       zh-CN: >-
-        表面使用 `flex flex-col-reverse gap-2 border-t-2 brutalist-border-top-black pt-3 justify-end`——带有投射局部 2px 黑色上边框的 flex-col-reverse 布局面板、无自有填充、尾部对齐内容，保持 Neo-Brutalist 结构边框语法，不得使用渐变、玻璃拟态、圆角卡片或柔和高度阴影。
+        表面使用 `flex flex-col-reverse gap-2 border-t-2 border-foreground pt-3 justify-end`——带有由主题 foreground 解析而非固定黑色的 2px 上边框的 flex-col-reverse 布局面板、无自有填充、尾部对齐内容，保持 Neo-Brutalist 结构边框语法，不得使用渐变、玻璃拟态、圆角卡片或柔和高度阴影。
 
 
 sources:
@@ -54,6 +54,12 @@ revisions:
     change: introduced
     summary: >-
       Introduced draft Brutalist Dialog Footer projection with real public-API criteria (direct entry, DIALOG_FAMILY footer anatomy, visual grammar) on rc.7. Not present in immutable rc.6.
+
+
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: >-
+      Resolved the upper separator ink from the theme foreground instead of a fixed black.
 
 
 tags: [prototype, brutalist, neo-brutalist, visual, delta, dialog]

--- a/spec/prototypes/P-BRUTALIST-DIALOG-HEADER.yaml
+++ b/spec/prototypes/P-BRUTALIST-DIALOG-HEADER.yaml
@@ -34,11 +34,11 @@ criteria:
   - id: P-BRUTALIST-DIALOG-HEADER-VISUAL-GRAMMAR
     text:
       en: >-
-        The surface uses `grid gap-1 border-b-2 brutalist-border-bottom-black pb-3 text-left` — a grid layout panel with a projection-local 2px black bottom border, no fill of its own, and left-aligned text, preserving the Neo-Brutalist structural border grammar without gradients, glass, rounded cards, or soft elevation.
+        The surface uses `grid gap-1 border-b-2 border-foreground pb-3 text-left` — a grid layout panel with a 2px bottom border resolved from the theme foreground rather than a fixed black, no fill of its own, and left-aligned text, preserving the Neo-Brutalist structural border grammar without gradients, glass, rounded cards, or soft elevation.
 
 
       zh-CN: >-
-        表面使用 `grid gap-1 border-b-2 brutalist-border-bottom-black pb-3 text-left`——带有投射局部 2px 黑色下边框的 grid 布局面板、无自有填充、左对齐文本，保持 Neo-Brutalist 结构边框语法，不得使用渐变、玻璃拟态、圆角卡片或柔和高度阴影。
+        表面使用 `grid gap-1 border-b-2 border-foreground pb-3 text-left`——带有由主题 foreground 解析而非固定黑色的 2px 下边框的 grid 布局面板、无自有填充、左对齐文本，保持 Neo-Brutalist 结构边框语法，不得使用渐变、玻璃拟态、圆角卡片或柔和高度阴影。
 
 
 sources:
@@ -54,6 +54,12 @@ revisions:
     change: introduced
     summary: >-
       Introduced draft Brutalist Dialog Header projection with real public-API criteria (direct entry, DIALOG_FAMILY header anatomy, visual grammar) on rc.7. Not present in immutable rc.6.
+
+
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: >-
+      Resolved the lower separator ink from the theme foreground instead of a fixed black.
 
 
 tags: [prototype, brutalist, neo-brutalist, visual, delta, dialog]


### PR DESCRIPTION
## Summary

Dialog Header and Footer separators now resolve the theme foreground instead of a fixed black, and the two static `brutalist-border-*-black` utilities are removed now that Card (#428) and Dialog were their only consumers.

## Related context

- Issue: closes #425
- Applicable spec entities and lifecycle: `P-BRUTALIST-DIALOG-HEADER` and `P-BRUTALIST-DIALOG-FOOTER` (both `draft`, visual-grammar criteria revised, revision entry at `0.3.0-alpha.0`); `P-BRUTALIST-DIALOG` and the other Dialog parts unchanged
- Criteria / test anchors: `P-BRUTALIST-DIALOG-HEADER-VISUAL-GRAMMAR`, `P-BRUTALIST-DIALOG-FOOTER-VISUAL-GRAMMAR` → `T-BRUTALIST-DIALOG-0001-CASE-9`, `T-BRUTALIST-DIALOG-0001-CASE-10`
- Related upstream: none; Brutalist is an original design language

## Scope boundary

**Already decided by the issue.** Swap to `border-b-2 border-foreground` / `border-t-2 border-foreground`, update the Dialog P entities and `dialog.test.ts`, and keep Light/Dark browser evidence in all three runtimes. The issue also conditions the utility cleanup on #394 having merged first — it merged as `d6afce29`, so the cleanup is in this PR: the two utilities are deleted from `packages/cli/src/services/proto-style-css.ts`, the Brutalist preset is regenerated (225 → 223 tokens), and the CLI test is updated.

**Decided here.** The CLI test case `renders projection-local directional border colors` lost its subject, so it is repointed at the composition that replaced it — `border-b-2` / `border-t-2` with `border-foreground` — rather than deleted, keeping directional separator rendering covered.

**Out of scope.** The Dialog Content **outer frame** is also fixed black in Dark (`2px rgb(0,0,0)` on `rgb(38,38,38)`, 1.39:1). That is `BRUTALIST_STRUCTURAL_INK` grammar, which #427 is deciding, so this PR does not touch it. `border-black` stays in the manifest — Button, Toggle, and the Dialog frame still use it.

`docs/superpowers/specs/2026-07-29-pr336-local-border-resolution-design.md` and its sibling plan describe why the two utilities were introduced. They read as dated records of PR #336, so I left them untouched; say the word if you would rather they carry a superseded note.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs.
- [x] Normative behavior changes include coherent P/C/T criteria, revisions, executable evidence, and affected projections.
- [x] This change does not create an empty catalog identity or silently widen a draft/active public guarantee.

## Contribution provenance

- [x] This contribution was created by me and I have the right to submit it.
- [ ] This contribution adapts or derives from third-party material.
- [x] This contribution includes material AI-assisted generation or transformation.
- [ ] This contribution may be subject to employer or client ownership, and I have confirmed that I may submit it.
- [x] No third-party source disclosure is required.

### AI assistance

Claude (Anthropic) was used as a coding assistant for the implementation, test updates, and entity wording. I directed the work, reviewed every file, and verified the result. No third-party or private code was provided to the model beyond this public repository. All colour values below come from executed browser measurements, not generated text.

## DCO

- [x] I have checked the DCO status of this PR.

## Prototype website preview

- [ ] This pull request adds or changes public Prototype behavior and includes the required reachable website page or page update.
- [x] A new or updated website page is not applicable because: the Dialog page already exists and its contract bullets cover the opener, the X control, hover/press, footer dismiss semantics, and focus — none of them describe the section separators, so there is no clause to amend. Happy to add one if you want the separator ink documented the way Card's now is.

- Public docs route: `/en/ui-libraries/brutalist/components/dialog/` and `/zh-cn/ui-libraries/brutalist/components/dialog/`
- Local preview URL or route: `http://127.0.0.1:4321/en/ui-libraries/brutalist/components/dialog/`
- Applicable runtimes manually reviewed: Web Component / React / Vue — all three, in both light and dark.
- [x] The demo consumes the real public package export and prefers the Prototype's own anatomy, triggers, state, events, and defaults.
- [x] The Demo Matrix, when used, is supplementary evidence rather than a replacement for the website page.
- External demo orchestration: none.
- Consumer-owned orchestration that is not installed with the package: none.

## Validation

Node 25 locally, so `corepack` is not bundled; repository scripts ran through a local shim forwarding to `pnpm@10.32.1`.

- Focused tests: `vitest run packages/prototypes/brutalist packages/cli` → 19 files, 115 passed.
- Catalog / generated checks: `check:prototype-catalog`, `check:component-presets`, `check:package-manifests` OK. `check:styles:preset` → `Brutalist preset token and theme manifests are current (223 tokens)`; the two removed tokens are the only delta, and `semantic-merge-v0-delta` stays `none` because `border-b-2`, `border-t-2`, and `border-foreground` were all already preset-supported.
- Types / repository tests: `tsc -p tsconfig.workspace.json --noEmit` clean. `check:release-version` → `0.3.0-alpha.0, 40 public packages, 9 V entity`.
- Docs build / preview: `pnpm --filter apps-www check` → 0 errors, 0 warnings, 0 hints. `pnpm --filter apps-www build` → 196 pages.
- Manual or browser evidence: Playwright Chromium against the local dev server, opening the dialog through its own trigger and resolving painted colours through a canvas so `oklch()` is measured as rendered. The backdrop is the first opaque painted ancestor.

**Before — clean `d6afce29`, no local changes**

| theme | runtime | header border-bottom | footer border-top | `--pui-foreground` | backdrop | contrast |
| --- | --- | --- | --- | --- | --- | --- |
| light | wc / react / vue | `2px rgb(0,0,0)` | `2px rgb(0,0,0)` | `rgb(23,23,23)` | `rgb(255,255,255)` | 21.00:1 |
| dark | wc / react / vue | `2px rgb(0,0,0)` | `2px rgb(0,0,0)` | `rgb(245,245,245)` | `rgb(38,38,38)` | **1.39:1** |

**After — this branch**

| theme | runtime | header border-bottom | footer border-top | `--pui-foreground` | backdrop | contrast |
| --- | --- | --- | --- | --- | --- | --- |
| light | wc / react / vue | `2px rgb(23,23,23)` | `2px rgb(23,23,23)` | `rgb(23,23,23)` | `rgb(255,255,255)` | 17.93:1 |
| dark | wc / react / vue | `2px rgb(245,245,245)` | `2px rgb(245,245,245)` | `rgb(245,245,245)` | `rgb(38,38,38)` | **13.88:1** |

All six after-rows measure equal to `--pui-foreground` and clear the 3:1 non-text boundary threshold. Dark goes from 1.39:1 to 13.88:1; light moves from pure `#000` to `#171717`, the intended unification with the theme ink. Every runtime produced byte-identical values, so the rows are collapsed.

- Not run or not applicable, with reason: `build:packages` was not run — this change removes two entries from a generated preset consumed inside `@proto.ui/cli` and touches no package export surface. Two pre-existing failures, `apps/www/src/components/override/LanguageSelect.test.ts` and `ThemeProvider.test.ts`, both `TypeError: localStorage.clear is not a function`, reproduce on clean `d6afce29` with an empty working tree on my Node 25 environment and are unrelated to this change; CI is green on `main`. I can file that separately if it is not already known.
