### PR TITLE
fix(docs): make Base Textarea demo output theme-relative

### DIFF
--- a/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
@@ -1,0 +1,354 @@
+// @vitest-environment node
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { access } from 'node:fs/promises';
+import { createServer } from 'node:net';
+import {
+  chromium,
+  type Browser,
+  type BrowserContext,
+  type Locator,
+  type Page,
+} from 'playwright-core';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const RUNTIMES = ['wc', 'react', 'vue'] as const;
+type RuntimeId = (typeof RUNTIMES)[number];
+
+const COLOR_SCHEMES = ['light', 'dark'] as const;
+type ColorScheme = (typeof COLOR_SCHEMES)[number];
+
+const TEXTAREA_ROUTE = '/en/ui-libraries/base/textarea/';
+const TEXTAREA_DEMO_SCOPE = '[data-demo-id="demo-base-textarea"]';
+const TEXTAREA_OUTPUT_SURFACES = ['stateLabel', 'eventLog'] as const;
+const MIN_TEXT_CONTRAST = 4.5;
+
+let browser: Browser;
+let devServer: ChildProcess | null = null;
+let baseUrl = '';
+let serverOutput = '';
+
+async function availablePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Unable to reserve a browser-test port.'));
+        return;
+      }
+      server.close((error) => (error ? reject(error) : resolve(address.port)));
+    });
+  });
+}
+
+async function chromeExecutable(): Promise<string> {
+  const candidates = [
+    process.env.CHROME_PATH,
+    '/usr/bin/google-chrome',
+    '/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  for (const candidate of candidates) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      // Try the next standard Chrome/Chromium location.
+    }
+  }
+
+  throw new Error('Chrome/Chromium is required; set CHROME_PATH to its executable.');
+}
+
+async function waitForServer(url: string): Promise<void> {
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    if (devServer && devServer.exitCode !== null) {
+      throw new Error(`Documentation dev server exited early.\n${serverOutput}`);
+    }
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(2_000) });
+      if (response.ok) return;
+    } catch {
+      // The dev server is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Timed out waiting for ${url}.\n${serverOutput}`);
+}
+
+function recordServerOutput(chunk: Buffer): void {
+  serverOutput = `${serverOutput}${chunk.toString()}`.slice(-20_000);
+}
+
+async function startServer(): Promise<string> {
+  const externalBaseUrl = process.env.PROTO_UI_BROWSER_BASE_URL?.replace(/\/$/, '');
+  if (externalBaseUrl) {
+    await waitForServer(`${externalBaseUrl}${TEXTAREA_ROUTE}`);
+    return externalBaseUrl;
+  }
+
+  const port = await availablePort();
+  const executable = process.platform === 'win32' ? 'corepack.cmd' : 'corepack';
+  devServer = spawn(
+    executable,
+    [
+      'pnpm@10.32.1',
+      '--filter',
+      'apps-www',
+      'dev',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      String(port),
+      '--strictPort',
+    ],
+    {
+      cwd: process.cwd(),
+      detached: process.platform !== 'win32',
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
+  devServer.stdout?.on('data', recordServerOutput);
+  devServer.stderr?.on('data', recordServerOutput);
+
+  const url = `http://127.0.0.1:${port}`;
+  await waitForServer(`${url}${TEXTAREA_ROUTE}`);
+  return url;
+}
+
+async function stopServer(): Promise<void> {
+  if (!devServer || devServer.exitCode !== null || !devServer.pid) return;
+  const signalTarget = process.platform === 'win32' ? devServer.pid : -devServer.pid;
+  process.kill(signalTarget, 'SIGTERM');
+
+  const exited = await Promise.race([
+    new Promise<boolean>((resolve) => devServer?.once('exit', () => resolve(true))),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 5_000)),
+  ]);
+  if (!exited && devServer.exitCode === null) process.kill(signalTarget, 'SIGKILL');
+}
+
+async function openRoute(
+  route: string,
+  viewport: Readonly<{ width: number; height: number }>
+): Promise<{ context: BrowserContext; page: Page; previewer: Locator }> {
+  const context = await browser.newContext({ viewport });
+  const page = await context.newPage();
+  await page.goto(`${baseUrl}${route}`, { waitUntil: 'networkidle' });
+  const previewer = page.locator('[data-previewer-id]').first();
+  await previewer.waitFor({ state: 'visible' });
+  return { context, page, previewer };
+}
+
+async function selectRuntime(
+  page: Page,
+  previewer: Locator,
+  runtime: RuntimeId,
+  readySelector: string,
+  expectedCount: number
+): Promise<void> {
+  await previewer.locator('select.adapter-select').selectOption(runtime);
+  await page.waitForFunction(
+    ({ expectedCount: count, readySelector: selector, runtime: selectedRuntime }) => {
+      const root = document.querySelector<HTMLElement>('[data-previewer-id]');
+      const select = root?.querySelector<HTMLSelectElement>('select.adapter-select');
+      const host = root?.querySelector<HTMLElement>('.host');
+      const firstRoot = host?.querySelector<HTMLElement>('[data-pui-root]');
+      if (!root || !select || !host || select.value !== selectedRuntime) return false;
+      if (root.querySelectorAll(selector).length !== count || !firstRoot) return false;
+      if (selectedRuntime === 'wc') return firstRoot.tagName.startsWith('WC-');
+      if (selectedRuntime === 'vue') return host.hasAttribute('data-v-app');
+      // React owns neither a custom element nor a Vue app root. The host tag is
+      // not always a div: a text-control Prototype roots on its native control.
+      return !firstRoot.tagName.startsWith('WC-') && !host.hasAttribute('data-v-app');
+    },
+    { expectedCount, readySelector, runtime },
+    { timeout: 20_000 }
+  );
+}
+
+/**
+ * Emulates a colour scheme and waits until the documentation theme script has
+ * projected it, so a measurement cannot read the previous theme.
+ */
+async function applyColorScheme(page: Page, colorScheme: ColorScheme): Promise<void> {
+  await page.emulateMedia({ colorScheme });
+  await page.waitForFunction(
+    (scheme) => document.documentElement.dataset.theme === scheme,
+    colorScheme,
+    { timeout: 10_000 }
+  );
+}
+
+/**
+ * Returns the text contrast ratio of each demo ref. Colours resolve through a
+ * 1x1 canvas so `lab()`, `oklch()`, and other non-`rgb()` computed values are
+ * measured as painted. These surfaces paint no background of their own, so the
+ * backdrop composites every translucent ancestor - the previewer panel is 30%
+ * alpha - down onto the nearest opaque one.
+ */
+async function demoTextContrast(
+  page: Page,
+  scope: string,
+  refs: readonly string[]
+): Promise<Record<string, number>> {
+  return page.evaluate(
+    ({ scope: scopeSelector, refs: surfaceRefs }) => {
+      const canvas = document.createElement('canvas');
+      canvas.width = 1;
+      canvas.height = 1;
+      const context = canvas.getContext('2d', { willReadFrequently: true });
+      if (!context) throw new Error('Canvas 2D context is required to resolve painted colours.');
+
+      const paint = (color: string): [number, number, number, number] => {
+        context.clearRect(0, 0, 1, 1);
+        context.fillStyle = 'rgba(0,0,0,0)';
+        context.fillStyle = color;
+        context.fillRect(0, 0, 1, 1);
+        const [r, g, b, a] = context.getImageData(0, 0, 1, 1).data;
+        return [r, g, b, a / 255];
+      };
+      const backdrop = (element: Element): [number, number, number] => {
+        const translucent: [number, number, number, number][] = [];
+        let current: Element | null = element;
+        let opaque: [number, number, number] | null = null;
+        while (current) {
+          const color = paint(getComputedStyle(current).backgroundColor);
+          if (color[3] >= 0.999) {
+            opaque = [color[0], color[1], color[2]];
+            break;
+          }
+          if (color[3] > 0) translucent.push(color);
+          current = current.parentElement;
+        }
+        if (!opaque) {
+          const fallback = paint(getComputedStyle(document.body).backgroundColor);
+          opaque = [fallback[0], fallback[1], fallback[2]];
+        }
+        let composed = opaque;
+        for (let index = translucent.length - 1; index >= 0; index -= 1) {
+          const [r, g, b, a] = translucent[index];
+          composed = [
+            r * a + composed[0] * (1 - a),
+            g * a + composed[1] * (1 - a),
+            b * a + composed[2] * (1 - a),
+          ];
+        }
+        return composed;
+      };
+      const luminance = ([r, g, b]: [number, number, number]): number => {
+        const [rl, gl, bl] = [r, g, b].map((channel) => {
+          const value = channel / 255;
+          return value <= 0.03928 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4);
+        });
+        return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+      };
+      const ratio = (a: number, b: number): number => {
+        const lighter = Math.max(a, b);
+        const darker = Math.min(a, b);
+        return Math.round(((lighter + 0.05) / (darker + 0.05)) * 100) / 100;
+      };
+
+      const demo = document.querySelector(scopeSelector);
+      if (!demo) throw new Error(`Demo scope ${scopeSelector} is missing.`);
+
+      const result: Record<string, number> = {};
+      for (const ref of surfaceRefs) {
+        const element = demo.querySelector(`[data-demo-ref="${ref}"]`);
+        if (!element) throw new Error(`Demo ref ${ref} is missing.`);
+        const [r, g, b] = paint(getComputedStyle(element).color);
+        result[ref] = ratio(luminance([r, g, b]), luminance(backdrop(element)));
+      }
+      return result;
+    },
+    { scope, refs }
+  );
+}
+
+beforeAll(async () => {
+  baseUrl = await startServer();
+  browser = await chromium.launch({
+    executablePath: await chromeExecutable(),
+    headless: true,
+    args: ['--disable-dev-shm-usage', '--no-sandbox'],
+  });
+}, 150_000);
+
+afterAll(async () => {
+  await browser?.close();
+  await stopServer();
+});
+
+describe.sequential('Base control documentation browser regressions', () => {
+  it('keeps Textarea demo output surfaces readable in both themes and all runtimes', async () => {
+    const { context, page, previewer } = await openRoute(TEXTAREA_ROUTE, {
+      width: 1440,
+      height: 900,
+    });
+
+    try {
+      await previewer.scrollIntoViewIfNeeded();
+      for (const runtime of RUNTIMES) {
+        await selectRuntime(page, previewer, runtime, '[data-demo-ref="eventLog"]', 1);
+
+        for (const colorScheme of COLOR_SCHEMES) {
+          await applyColorScheme(page, colorScheme);
+
+          const atRest = await demoTextContrast(
+            page,
+            TEXTAREA_DEMO_SCOPE,
+            TEXTAREA_OUTPUT_SURFACES
+          );
+          for (const ref of TEXTAREA_OUTPUT_SURFACES) {
+            expect(atRest[ref], `${runtime}/${colorScheme}/${ref}/rest`).toBeGreaterThanOrEqual(
+              MIN_TEXT_CONTRAST
+            );
+          }
+
+          // The output panels carry live text; measure them again once the demo
+          // has written into them, since that is the state a reader looks at.
+          await previewer.locator('[data-demo-ref="toggleProps"]').click();
+          await page.waitForFunction(
+            (scope) =>
+              document
+                .querySelector(`${scope} [data-demo-ref="stateLabel"]`)
+                ?.textContent?.includes('disabled=true') === true,
+            TEXTAREA_DEMO_SCOPE
+          );
+          const whileDisabled = await demoTextContrast(
+            page,
+            TEXTAREA_DEMO_SCOPE,
+            TEXTAREA_OUTPUT_SURFACES
+          );
+          for (const ref of TEXTAREA_OUTPUT_SURFACES) {
+            expect(
+              whileDisabled[ref],
+              `${runtime}/${colorScheme}/${ref}/disabled`
+            ).toBeGreaterThanOrEqual(MIN_TEXT_CONTRAST);
+          }
+
+          await previewer.locator('[data-demo-ref="toggleProps"]').click();
+          await page.waitForFunction(
+            (scope) =>
+              document
+                .querySelector(`${scope} [data-demo-ref="stateLabel"]`)
+                ?.textContent?.includes('disabled=false') === true,
+            TEXTAREA_DEMO_SCOPE
+          );
+        }
+      }
+    } finally {
+      await context.close();
+    }
+  }, 180_000);
+});

--- a/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
@@ -20,7 +20,7 @@ type ColorScheme = (typeof COLOR_SCHEMES)[number];
 
 const TEXTAREA_ROUTE = '/en/ui-libraries/base/textarea/';
 const TEXTAREA_DEMO_SCOPE = '[data-demo-id="demo-base-textarea"]';
-const TEXTAREA_OUTPUT_SURFACES = ['stateLabel', 'eventLog'] as const;
+const TEXTAREA_OUTPUT_SURFACES = ['stateLabel', 'eventLog', 'help'] as const;
 const MIN_TEXT_CONTRAST = 4.5;
 
 let browser: Browser;

--- a/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
@@ -89,13 +89,7 @@ function recordServerOutput(chunk: Buffer): void {
   serverOutput = `${serverOutput}${chunk.toString()}`.slice(-20_000);
 }
 
-async function startServer(): Promise<string> {
-  const externalBaseUrl = process.env.PROTO_UI_BROWSER_BASE_URL?.replace(/\/$/, '');
-  if (externalBaseUrl) {
-    await waitForServer(`${externalBaseUrl}${TEXTAREA_ROUTE}`);
-    return externalBaseUrl;
-  }
-
+async function spawnServer(): Promise<string> {
   const port = await availablePort();
   const executable = process.platform === 'win32' ? 'corepack.cmd' : 'corepack';
   devServer = spawn(
@@ -124,6 +118,30 @@ async function startServer(): Promise<string> {
   const url = `http://127.0.0.1:${port}`;
   await waitForServer(`${url}${TEXTAREA_ROUTE}`);
   return url;
+}
+
+async function startServer(): Promise<string> {
+  const externalBaseUrl = process.env.PROTO_UI_BROWSER_BASE_URL?.replace(/\/$/, '');
+  if (externalBaseUrl) {
+    await waitForServer(`${externalBaseUrl}${TEXTAREA_ROUTE}`);
+    return externalBaseUrl;
+  }
+
+  // availablePort() releases the socket before the child binds it, so two
+  // browser suites running in parallel can be handed the same port and
+  // --strictPort kills the loser. Retry on a fresh port instead.
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      return await spawnServer();
+    } catch (error) {
+      lastError = error;
+      await stopServer();
+      devServer = null;
+      serverOutput = '';
+    }
+  }
+  throw lastError;
 }
 
 async function stopServer(): Promise<void> {

--- a/apps/www/src/content/docs/zh-cn/demo-base-textarea.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-textarea.demo.ts
@@ -236,13 +236,13 @@ export default {
       {
         kind: 'box',
         ref: 'stateLabel',
-        className: 'break-words font-mono text-xs text-slate-700',
+        className: 'break-words font-mono text-xs text-muted-foreground',
         children: ['State exposes'],
       },
       {
         kind: 'box',
         ref: 'eventLog',
-        className: 'min-h-5 break-words font-mono text-xs text-slate-700',
+        className: 'min-h-5 break-words font-mono text-xs text-muted-foreground',
         children: ['Event log: edit the textarea'],
       },
     ],

--- a/apps/www/src/content/docs/zh-cn/demo-base-textarea.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-textarea.demo.ts
@@ -201,7 +201,7 @@ export default {
       {
         kind: 'box',
         ref: 'help',
-        className: 'text-xs text-slate-600',
+        className: 'text-xs text-muted-foreground',
         children: [
           'Type, blur, or use IME to inspect normalized events. Live controls exercise props and exposes.',
         ],


### PR DESCRIPTION
## Summary

The Base Textarea demo's `State exposes`, `Event log`, and help line now use `text-muted-foreground` instead of fixed Slate, and a new browser regression covers them in Light and Dark across all three runtimes.

> **Correction to my own claim on the issue thread.** In https://github.com/Proto-UI/Proto-UI/issues/422#issuecomment-5308326966 I reported 1.91:1 for the output surfaces and said the issue's 1.81:1 differed because I resolved a different effective backdrop. That was wrong. My ancestor walk stopped at the first ancestor with a non-`rgb()` background and never composited the previewer panel's 30%-alpha layer. Corrected, this branch reproduces the issue's numbers exactly — 10.09:1 Light and **1.81:1** Dark. The issue body was right.

## Related context

- Issue: closes #422
- Applicable spec entities and lifecycle: none. Documentation-site demo authoring and test coverage only; no Base Textarea protocol, package, spec, or adapter change, per the issue's Scope section.
- Criteria / test anchors: none applicable; the evidence anchor is the new case in `demo-base-controls.browser.test.ts`.
- Related upstream: none.

## Scope boundary

**Already decided by the issue.** `stateLabel` and `eventLog` reach `>= 4.5:1` in both themes; all three runtimes get the same class projection; transparent layout, monospace typography, wrapping, and minimum height unchanged; an existing shared semantic token rather than a one-off `dark:*`; a browser-level regression across both themes and all three runtimes.

**Decided here — and separated so you can drop it.** The `help` line was the last fixed Slate in this file at **2.47:1** in Dark. The issue does not list it, so it is isolated in its own commit, `b2742e0e`, which changes one class and adds `help` to the covered refs. Revert that commit and the first commit still satisfies every acceptance criterion on its own. I raised this on the thread and did not want to park the work waiting for an answer.

**Token choice.** `text-muted-foreground`, which `demo-base-tooltip.demo.ts` already uses — the same "reuse an established pair" instruction you gave on #396. Worth stating plainly: in Light it measures **4.62:1** against the composited `rgb(252,252,252)` backdrop. That passes, but the margin over 4.5:1 is 0.12, so it is the semantically correct token rather than a comfortable one. `text-foreground` would give 14.75:1 but flattens the intended visual hierarchy between the live controls and their output. Say the word if you would rather have the headroom.

**Out of scope.** The textarea control itself keeps `bg-white` / `text-slate-950` / `border-slate-500`. That is a theme-consistency question, not a contrast one — it measures ~19:1 in both themes — and the issue scopes to the output surfaces. The three live controls already inherit the theme foreground (14.75:1 Light, 14.87:1 Dark) and are unchanged.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs.
- [x] Normative behavior changes include coherent P/C/T criteria, revisions, executable evidence, and affected projections.
- [x] This change does not create an empty catalog identity or silently widen a draft/active public guarantee.

## Contribution provenance

- [x] This contribution was created by me and I have the right to submit it.
- [ ] This contribution adapts or derives from third-party material.
- [x] This contribution includes material AI-assisted generation or transformation.
- [ ] This contribution may be subject to employer or client ownership, and I have confirmed that I may submit it.
- [x] No third-party source disclosure is required.

### AI assistance

Claude (Anthropic) was used as a coding assistant for the demo class changes and the browser test. I directed the work, reviewed every file, and verified the result. No third-party or private code was provided to the model beyond this public repository. Every contrast number below comes from an executed browser measurement, not generated text — including the one that corrected my own earlier report.

## DCO

- [x] I have checked the DCO status of this PR.

## Prototype website preview

- [ ] This pull request adds or changes public Prototype behavior and includes the required reachable website page or page update.
- [x] A new or updated website page is not applicable because: the Base Textarea page already exists and its structure, copy, and demo composition are unchanged. Only three demo-authored foreground classes changed.

- Public docs route: `/en/ui-libraries/base/textarea/` and `/zh-cn/ui-libraries/base/textarea/`
- Local preview URL or route: `http://127.0.0.1:4321/en/ui-libraries/base/textarea/`
- Applicable runtimes manually reviewed: Web Component / React / Vue — all three, in both light and dark.
- [x] The demo consumes the real public package export and prefers the Prototype's own anatomy, triggers, state, events, and defaults.
- [x] The Demo Matrix, when used, is supplementary evidence rather than a replacement for the website page.
- External demo orchestration: none.
- Consumer-owned orchestration that is not installed with the package: none.

## Validation

Node 25 locally, so `corepack` is not bundled; repository scripts ran through a local shim forwarding to `pnpm@10.32.1`.

- Focused tests: `vitest run apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts` → 1 passed. Confirmed red with the demo file reverted to `main`: `wc/dark/stateLabel/rest: expected 1.81 to be greater than or equal to 4.5`.
- Catalog / generated checks: not applicable — no `spec/**` entity, prototype, or preset is touched.
- Types / repository tests: `pnpm --filter apps-www check` → 139 files, 0 errors, 0 warnings, 0 hints.
- Docs build / preview: `pnpm --filter apps-www build` → 196 pages, no errors.
- Manual or browser evidence: Playwright Chromium against the local dev server. Colours resolve through a 1×1 canvas so `lab()` and `oklch()` computed values are measured as painted; these surfaces paint no background of their own, so every translucent ancestor composites down onto the nearest opaque one.

| ref | light before | light after | dark before | dark after |
| --- | --- | --- | --- | --- |
| `stateLabel` | 10.09:1 | 4.62:1 | **1.81:1** | 7.25:1 |
| `eventLog` | 10.09:1 | 4.62:1 | **1.81:1** | 7.25:1 |
| `help` | 7.39:1 | 4.62:1 | **2.47:1** | 7.25:1 |

Composited backdrop is `rgb(252,252,252)` in Light and `rgb(18,18,18)` in Dark, matching the issue's reported values. Identical across `wc`, `react`, and `vue`. Light drops because muted grey is a lower-contrast token than Slate-700 by design; both themes now clear AA, which fixed Slate never did.

## Test-file placement

This is a new file, `demo-base-controls.browser.test.ts`, rather than new cases inside `demo-brutalist-controls.browser.test.ts`. Two reasons: the existing file is scoped and named for the Brutalist library, and #431 already rewrites large parts of it, so adding here would guarantee a conflict.

That leaves the server/browser harness duplicated between the two files. I would rather not leave it that way — once #431 lands I am happy to extract `startServer`, `chromeExecutable`, `openRoute`, `selectRuntime`, and `applyColorScheme` into one shared module and migrate both files in a follow-up. Doing it now would conflict with that PR.

One deliberate difference until then: this file's backdrop resolution composites translucent ancestors, which #431's does not need — every Brutalist surface paints its own opaque background — but which is required here. If you would rather they be identical immediately, I will push the compositing version to #431 as well.

- Not run or not applicable, with reason: the full `pnpm test` chain was not run — this branch touches two documentation-site files and no package, export, preset, or entity. Two pre-existing failures in `apps/www/src/components/override/{LanguageSelect,ThemeProvider}.test.ts` (`TypeError: localStorage.clear is not a function`) reproduce on clean `main` with an empty working tree on my Node 25 environment and are unrelated; CI is green on `main`.
