### PR TITLE
fix(docs): remove AI-slop tells from the documentation shell

### DIFF
--- a/apps/www/src/components/DocStageNotice.astro
+++ b/apps/www/src/components/DocStageNotice.astro
@@ -2,17 +2,12 @@
 interface Props {
   title: string;
   body: string;
-  tone?: 'amber' | 'blue';
 }
 
-const { title, body, tone = 'amber' } = Astro.props;
+const { title, body } = Astro.props;
 ---
 
-<aside
-  class:list={['doc-stage-notice', `doc-stage-notice--${tone}`]}
-  role="note"
-  aria-label={title}
->
+<aside class="doc-stage-notice" role="note" aria-label={title}>
   <p class="doc-stage-notice__title">{title}</p>
   <p class="doc-stage-notice__body">{body}</p>
 </aside>
@@ -22,21 +17,8 @@ const { title, body, tone = 'amber' } = Astro.props;
     margin: 1rem 0 1.5rem;
     padding: 1rem 1.1rem;
     border-radius: 1rem;
-    border: 1px solid transparent;
-  }
-
-  .doc-stage-notice--amber {
-    border-color: color-mix(in oklch, #f59e0b 34%, var(--color-border) 66%);
-    background:
-      linear-gradient(135deg, color-mix(in oklch, #f59e0b 18%, transparent), transparent 70%),
-      color-mix(in oklch, #fff7ed 82%, var(--color-background) 18%);
-  }
-
-  .doc-stage-notice--blue {
-    border-color: color-mix(in oklch, #3b82f6 30%, var(--color-border) 70%);
-    background:
-      linear-gradient(135deg, color-mix(in oklch, #60a5fa 14%, transparent), transparent 68%),
-      color-mix(in oklch, #eff6ff 80%, var(--color-background) 20%);
+    border: 1px solid color-mix(in oklch, var(--color-border) 70%, var(--color-foreground) 30%);
+    background: var(--color-muted);
   }
 
   .doc-stage-notice__title,
@@ -56,19 +38,5 @@ const { title, body, tone = 'amber' } = Astro.props;
     font-size: 0.92rem;
     line-height: 1.55;
     color: color-mix(in oklch, var(--color-foreground) 82%, var(--color-muted-foreground) 18%);
-  }
-
-  :global([data-theme='dark']) .doc-stage-notice--amber {
-    border-color: color-mix(in oklch, #f59e0b 44%, var(--color-border) 56%);
-    background:
-      linear-gradient(135deg, color-mix(in oklch, #f59e0b 16%, transparent), transparent 68%),
-      color-mix(in oklch, #3b2a08 52%, var(--color-background) 48%);
-  }
-
-  :global([data-theme='dark']) .doc-stage-notice--blue {
-    border-color: color-mix(in oklch, #60a5fa 40%, var(--color-border) 60%);
-    background:
-      linear-gradient(135deg, color-mix(in oklch, #60a5fa 16%, transparent), transparent 68%),
-      color-mix(in oklch, #0d223d 52%, var(--color-background) 48%);
   }
 </style>

--- a/apps/www/src/components/InstallCommandCard.astro
+++ b/apps/www/src/components/InstallCommandCard.astro
@@ -212,14 +212,8 @@ const activeManager =
     border: 1px solid var(--color-border);
     border-radius: 1.5rem;
     overflow: hidden;
-    background: linear-gradient(
-      180deg,
-      color-mix(in oklch, var(--color-muted) 42%, var(--color-background) 58%),
-      color-mix(in oklch, var(--color-muted) 68%, var(--color-background) 32%)
-    );
-    box-shadow:
-      0 1px 0 color-mix(in oklch, var(--color-foreground) 4%, transparent),
-      inset 0 1px 0 color-mix(in oklch, white 35%, transparent);
+    background: color-mix(in oklch, var(--color-muted) 55%, var(--color-background) 45%);
+    box-shadow: 0 1px 0 color-mix(in oklch, var(--color-foreground) 4%, transparent);
   }
 
   .install-command-card__toolbar {
@@ -323,14 +317,7 @@ const activeManager =
   }
 
   :global([data-theme='dark']) .install-command-card {
-    background: linear-gradient(
-      180deg,
-      color-mix(in oklch, var(--color-muted) 24%, #080808 76%),
-      color-mix(in oklch, var(--color-muted) 14%, #111111 86%)
-    );
-    box-shadow:
-      0 1px 0 color-mix(in oklch, white 3%, transparent),
-      inset 0 1px 0 color-mix(in oklch, white 4%, transparent);
+    box-shadow: 0 1px 0 color-mix(in oklch, white 3%, transparent);
   }
 
   :global([data-theme='dark']) .install-command-card__prompt {

--- a/apps/www/src/components/PrototypePreviewer/HomeDemoPreviewer.astro
+++ b/apps/www/src/components/PrototypePreviewer/HomeDemoPreviewer.astro
@@ -166,32 +166,12 @@ const initialDemo = demos.find((demo) => demo.id === initialDemoId) ?? demos[0];
     border: 1px solid color-mix(in oklch, var(--color-border) 86%, transparent);
     border-radius: 1.5rem;
     overflow: hidden;
-    background:
-      radial-gradient(
-        circle at top left,
-        color-mix(in oklch, var(--color-accent) 12%, transparent),
-        transparent 34%
-      ),
-      linear-gradient(
-        180deg,
-        color-mix(in oklch, var(--color-muted) 28%, transparent),
-        transparent 40%
-      ),
-      linear-gradient(
-        135deg,
-        color-mix(in oklch, var(--color-accent) 5%, transparent),
-        transparent 55%
-      ),
-      var(--color-background);
-    box-shadow:
-      0 16px 48px color-mix(in oklch, black 10%, transparent),
-      inset 0 1px 0 color-mix(in oklch, white 55%, transparent);
+    background: var(--color-background);
+    box-shadow: 0 16px 48px color-mix(in oklch, black 10%, transparent);
   }
 
   :global([data-theme='dark']) .home-demo-previewer__panel {
-    box-shadow:
-      0 20px 56px color-mix(in oklch, black 22%, transparent),
-      inset 0 1px 0 color-mix(in oklch, white 10%, transparent);
+    box-shadow: 0 20px 56px color-mix(in oklch, black 22%, transparent);
   }
 
   .home-demo-previewer__header {

--- a/apps/www/src/components/PrototypePreviewer/QUICK_START.md
+++ b/apps/www/src/components/PrototypePreviewer/QUICK_START.md
@@ -1,32 +1,32 @@
 # PrototypePreviewer 快速参考
 
-## 📝 添加新原型（2 步完成）
+## 添加新原型（2 步完成）
 
-### 1️⃣ 创建原型文件
+### 1. 创建原型文件
 
 ```typescript
-// src/content/docs/zh-cn/my-awesome-demo.demo.proto.ts
+// src/content/docs/zh-cn/my-demo.demo.proto.ts
 import { definePrototype } from '@proto.ui/core';
 
-const MyAwesomeDemo = definePrototype({
-  name: 'my-awesome-demo',
+const MyDemo = definePrototype({
+  name: 'my-demo',
   setup(props) {
     return (h) => {
       return h(
         'div',
         {
-          class: 'p-4 bg-blue-500 text-white rounded',
+          class: 'p-4 bg-muted text-foreground rounded',
         },
-        'My Awesome Demo!'
+        'My demo'
       );
     };
   },
 });
 
-export default MyAwesomeDemo;
+export default MyDemo;
 ```
 
-### 2️⃣ 在 MDX 中使用
+### 2. 在 MDX 中使用
 
 ```mdx
 ---
@@ -36,14 +36,14 @@ title: 我的页面
 import { PrototypePreviewer } from '../../../components/PrototypePreviewer';
 // 或使用 DemoPreviewer（PrototypePreviewer 的别名）
 
-<PrototypePreviewer prototypeId="my-awesome-demo" initialRuntime="wc" />
+<PrototypePreviewer prototypeId="my-demo" initialRuntime="wc" />
 ```
 
-完成！🎉
+完成。
 
 ---
 
-## 🎨 常用配置
+## 常用配置
 
 ### 基础用法
 
@@ -121,7 +121,7 @@ export default {
 
 ---
 
-## 🔍 调试命令
+## 调试命令
 
 ### 查看所有可用原型
 
@@ -146,7 +146,7 @@ await loadPrototype('demo-inline');
 
 ---
 
-## ⚡️ 性能技巧
+## 性能技巧
 
 ### 预加载多个原型
 
@@ -167,9 +167,9 @@ await loadPrototype('demo-inline');
 
 ---
 
-## 🚨 常见错误
+## 常见错误
 
-### ❌ 错误: "未找到原型"
+### 错误: "未找到原型"
 
 ```
 Error: [PrototypePreviewer] 未找到原型 "my-demo"
@@ -179,7 +179,7 @@ Error: [PrototypePreviewer] 未找到原型 "my-demo"
 
 ---
 
-### ❌ 错误: "无法加载原型模块"
+### 错误: "无法加载原型模块"
 
 ```
 Error: 加载原型模块 "my-demo" 失败
@@ -189,7 +189,7 @@ Error: 加载原型模块 "my-demo" 失败
 
 ---
 
-### ❌ 错误: "registerPrototype: invalid id"
+### 错误: "registerPrototype: invalid id"
 
 ```
 Error: registerPrototype: invalid id
@@ -199,7 +199,7 @@ Error: registerPrototype: invalid id
 
 ---
 
-## 📚 完整文档
+## 完整文档
 
 - [完整使用指南](./README.md)
 - [迁移指南](./MIGRATION.md)
@@ -218,9 +218,9 @@ Error: registerPrototype: invalid id
 - 例外逻辑必须位于 Prototype 之外、只调用 public API，并在 Demo source 与 PR 中说明它不会随 package 安装、消费者需要自行实现什么；
 - 内部 Demo Matrix 只能补充验证，不能替代官网页面。
 
-## 💡 最佳实践速查
+## 最佳实践速查
 
-✅ **DO**
+**DO**
 
 - 使用 kebab-case 命名原型 ID
 - 使用 `*.demo.proto.ts` 后缀，靠近文档就近维护
@@ -228,7 +228,7 @@ Error: registerPrototype: invalid id
 - 为原型添加有意义的注释
 - 优先让 Demo 依靠 Prototype 自身公开交互完成演示
 
-❌ **DON'T**
+**DON'T**
 
 - 不要在 MDX 中直接 import 原型文件
 - 不要使用 camelCase 或 PascalCase 作为原型 ID
@@ -237,7 +237,7 @@ Error: registerPrototype: invalid id
 
 ---
 
-## 🎯 快速模板
+## 快速模板
 
 复制粘贴这个模板快速开始：
 
@@ -266,4 +266,4 @@ import { PrototypePreviewer } from '../../../components/PrototypePreviewer';
 <PrototypePreviewer prototypeId="your-demo" />
 ```
 
-现在开始创建吧！🚀
+现在可以开始创建了。

--- a/apps/www/src/components/PrototypePreviewer/TransitionDemoStyles.astro
+++ b/apps/www/src/components/PrototypePreviewer/TransitionDemoStyles.astro
@@ -3,33 +3,30 @@
     --transition-duration: 0.3s;
   }
 
+  .transition-demo-container .transition-box {
+    background: var(--color-foreground);
+    transition: all var(--transition-duration) cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
   .transition-demo-container .transition-wrapper[data-transition-state='closed'] .transition-box {
     opacity: 0;
     transform: scale(0.95) translateY(-10px);
-    background: linear-gradient(135deg, #9ca3af 0%, #6b7280 100%);
   }
 
   .transition-demo-container .transition-wrapper[data-transition-state='entering'] .transition-box {
     opacity: 0.7;
     transform: scale(0.98) translateY(-2px);
-    background: linear-gradient(135deg, #60a5fa 0%, #3b82f6 100%);
     transition: all var(--transition-duration) cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   .transition-demo-container .transition-wrapper[data-transition-state='entered'] .transition-box {
     opacity: 1;
     transform: scale(1) translateY(0);
-    background: linear-gradient(135deg, #34d399 0%, #10b981 100%);
   }
 
   .transition-demo-container .transition-wrapper[data-transition-state='leaving'] .transition-box {
     opacity: 0.5;
     transform: scale(0.98) translateY(2px);
-    background: linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%);
-    transition: all var(--transition-duration) cubic-bezier(0.4, 0, 0.2, 1);
-  }
-
-  .transition-demo-container .transition-box {
     transition: all var(--transition-duration) cubic-bezier(0.4, 0, 0.2, 1);
   }
 </style>

--- a/apps/www/src/components/UiLibraryGallery.astro
+++ b/apps/www/src/components/UiLibraryGallery.astro
@@ -778,8 +778,7 @@ const copy =
   .shadcn-preview {
     position: absolute;
     inset: 0;
-    background:
-      radial-gradient(circle at 83% 15%, rgba(255, 255, 255, 0.9), transparent 30%), #e4e4e7;
+    background: #e4e4e7;
     padding: 1rem;
   }
 

--- a/apps/www/src/components/WikiTerm.astro
+++ b/apps/www/src/components/WikiTerm.astro
@@ -123,15 +123,8 @@ const instanceId = `wiki-term-${slug}-${Math.random().toString(36).slice(2, 10)}
     display: inline;
     color: var(--color-foreground);
     border-bottom: 1px dashed color-mix(in oklab, var(--color-primary) 60%, transparent);
-    background: linear-gradient(
-        to top,
-        color-mix(in oklab, var(--color-primary) 10%, transparent) 0%,
-        color-mix(in oklab, var(--color-primary) 10%, transparent) 100%
-      )
-      0 100% / 100% 0.45em no-repeat;
     transition:
       border-color 180ms ease,
-      background-size 180ms ease,
       color 180ms ease;
     text-decoration: none;
   }
@@ -140,7 +133,6 @@ const instanceId = `wiki-term-${slug}-${Math.random().toString(36).slice(2, 10)}
   .wiki-term__trigger:focus-visible {
     color: var(--color-primary);
     border-bottom-color: var(--color-primary);
-    background-size: 100% 0.8em;
     outline: none;
   }
 
@@ -154,11 +146,7 @@ const instanceId = `wiki-term-${slug}-${Math.random().toString(36).slice(2, 10)}
     translate: -50% 0.35rem;
     border: 1px solid color-mix(in oklab, var(--color-border) 88%, transparent);
     border-radius: 1rem;
-    background: linear-gradient(
-      180deg,
-      color-mix(in oklab, var(--color-background) 92%, white 8%),
-      color-mix(in oklab, var(--color-background) 98%, black 2%)
-    );
+    background: var(--color-background);
     box-shadow:
       0 18px 40px rgba(15, 23, 42, 0.12),
       0 2px 10px rgba(15, 23, 42, 0.08);
@@ -171,11 +159,6 @@ const instanceId = `wiki-term-${slug}-${Math.random().toString(36).slice(2, 10)}
   }
 
   [data-theme='dark'] .wiki-term__card {
-    background: linear-gradient(
-      180deg,
-      color-mix(in oklab, var(--color-background) 88%, white 4%),
-      color-mix(in oklab, var(--color-background) 94%, black 6%)
-    );
     box-shadow:
       0 18px 40px rgba(0, 0, 0, 0.4),
       0 2px 10px rgba(0, 0, 0, 0.28);

--- a/apps/www/src/content/docs/demo_components/base-transition/baseTransitionCode.ts
+++ b/apps/www/src/content/docs/demo_components/base-transition/baseTransitionCode.ts
@@ -30,7 +30,7 @@ export const codeMap: Record<RuntimeId, Record<string, string>> = {
   wc: {
     'demo-base-transition-command': formatCode(`
 <wc-base-transition open appear class="transition-wrapper">
-  <div class="w-64 h-40 rounded-xl flex flex-col items-center justify-center text-white shadow-xl transition-box">
+  <div class="w-64 h-40 rounded-xl flex flex-col items-center justify-center text-background shadow-xl transition-box">
     <span class="text-lg font-semibold">Animated Box</span>
   </div>
 </wc-base-transition>
@@ -41,7 +41,7 @@ ${cssSnippet}
     `),
     'demo-base-transition-controlled': formatCode(`
 <wc-base-transition class="transition-wrapper">
-  <div class="w-64 h-40 rounded-xl flex flex-col items-center justify-center text-white shadow-xl transition-box cursor-pointer select-none">
+  <div class="w-64 h-40 rounded-xl flex flex-col items-center justify-center text-background shadow-xl transition-box cursor-pointer select-none">
     <span class="text-lg font-semibold">Click Me</span>
   </div>
 </wc-base-transition>
@@ -58,7 +58,7 @@ import { BaseTransition } from '@prototype-libs/base';
 export function DemoBaseTransitionCommandDemo() {
   return (
     <BaseTransition open appear className="transition-wrapper">
-      <div className="w-64 h-40 rounded-xl flex flex-col items-center justify-center text-white shadow-xl transition-box">
+      <div className="w-64 h-40 rounded-xl flex flex-col items-center justify-center text-background shadow-xl transition-box">
         <span className="text-lg font-semibold">Animated Box</span>
       </div>
     </BaseTransition>
@@ -98,7 +98,7 @@ export function DemoBaseTransitionControlledDemo() {
   return (
     <BaseTransition open={open} className="transition-wrapper">
       <div
-        className="w-64 h-40 rounded-xl flex flex-col items-center justify-center text-white shadow-xl transition-box cursor-pointer select-none"
+        className="w-64 h-40 rounded-xl flex flex-col items-center justify-center text-background shadow-xl transition-box cursor-pointer select-none"
         onClick={() => setOpen((v) => !v)}
       >
         <span className="text-lg font-semibold">Click Me</span>
@@ -139,7 +139,7 @@ import { BaseTransition } from '@prototype-libs/base';
 
 <template>
   <BaseTransition open appear class="transition-wrapper">
-    <div class="w-64 h-40 rounded-xl flex flex-col items-center justify-center text-white shadow-xl transition-box">
+    <div class="w-64 h-40 rounded-xl flex flex-col items-center justify-center text-background shadow-xl transition-box">
       <span class="text-lg font-semibold">Animated Box</span>
     </div>
   </BaseTransition>
@@ -160,7 +160,7 @@ const open = ref(false);
 <template>
   <BaseTransition :open="open" class="transition-wrapper">
     <div
-      class="w-64 h-40 rounded-xl flex flex-col items-center justify-center text-white shadow-xl transition-box cursor-pointer select-none"
+      class="w-64 h-40 rounded-xl flex flex-col items-center justify-center text-background shadow-xl transition-box cursor-pointer select-none"
       @click="open = !open"
     >
       <span class="text-lg font-semibold">Click Me</span>

--- a/apps/www/src/content/docs/en/start-here/quick-start.mdx
+++ b/apps/www/src/content/docs/en/start-here/quick-start.mdx
@@ -6,7 +6,6 @@ description: 'Start using Proto UI from the stable npm latest release'
 import DocStageNotice from '@/components/DocStageNotice.astro';
 
 <DocStageNotice
-  tone="amber"
   title="The Proto UI 0.2 stable onboarding flow is not open yet."
   body="The main Quick Start always follows npm latest and does not put prerelease builds on the default user path."
 />

--- a/apps/www/src/content/docs/en/start-here/rc-trial.mdx
+++ b/apps/www/src/content/docs/en/start-here/rc-trial.mdx
@@ -7,7 +7,6 @@ import DocStageNotice from '@/components/DocStageNotice.astro';
 import { Aside } from '@astrojs/starlight/components';
 
 <DocStageNotice
-  tone="amber"
   title="This is the isolated 0.2.0-rc.7 prerelease trial flow."
   body="It does not change the main Quick Start contract, which follows the stable npm latest release."
 />

--- a/apps/www/src/content/docs/en/start-here/why-proto-ui.mdx
+++ b/apps/www/src/content/docs/en/start-here/why-proto-ui.mdx
@@ -6,7 +6,6 @@ description: 'What problem it solves, where it starts to make sense, and what to
 import DocStageNotice from '@/components/DocStageNotice.astro';
 
 <DocStageNotice
-  tone="blue"
   title="Proto UI is in its early public stage."
   body="Core ideas are already visible, but component coverage and ecosystem readiness are still being built up."
 />

--- a/apps/www/src/content/docs/zh-cn/demo-base-transition-command.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-transition-command.demo.ts
@@ -60,7 +60,7 @@ export default {
           {
             kind: 'box',
             className:
-              'w-64 h-40 rounded-xl flex flex-col items-center justify-center text-white shadow-xl transition-box',
+              'w-64 h-40 rounded-xl flex flex-col items-center justify-center text-background shadow-xl transition-box',
             children: [
               {
                 kind: 'box',
@@ -79,21 +79,21 @@ export default {
             kind: 'box',
             ref: 'enterBtn',
             className:
-              'px-3 py-1.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md cursor-pointer select-none',
+              'px-3 py-1.5 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 rounded-md cursor-pointer select-none',
             children: ['Enter'],
           },
           {
             kind: 'box',
             ref: 'leaveBtn',
             className:
-              'px-3 py-1.5 text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 rounded-md cursor-pointer select-none',
+              'px-3 py-1.5 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 rounded-md cursor-pointer select-none',
             children: ['Leave'],
           },
           {
             kind: 'box',
             ref: 'completeBtn',
             className:
-              'px-3 py-1.5 text-sm font-medium text-white bg-emerald-600 hover:bg-emerald-700 rounded-md cursor-pointer select-none',
+              'px-3 py-1.5 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 rounded-md cursor-pointer select-none',
             children: ['Complete'],
           },
         ],
@@ -117,22 +117,22 @@ export default {
         children: [
           {
             kind: 'box',
-            className: 'px-3 py-1 bg-gray-200 rounded',
+            className: 'px-3 py-1 bg-muted text-muted-foreground rounded',
             children: ['closed'],
           },
           {
             kind: 'box',
-            className: 'px-3 py-1 bg-blue-200 rounded',
+            className: 'px-3 py-1 bg-muted text-muted-foreground rounded',
             children: ['entering'],
           },
           {
             kind: 'box',
-            className: 'px-3 py-1 bg-green-200 rounded',
+            className: 'px-3 py-1 bg-muted text-muted-foreground rounded',
             children: ['entered'],
           },
           {
             kind: 'box',
-            className: 'px-3 py-1 bg-orange-200 rounded',
+            className: 'px-3 py-1 bg-muted text-muted-foreground rounded',
             children: ['leaving'],
           },
         ],

--- a/apps/www/src/content/docs/zh-cn/demo-base-transition-controlled.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-transition-controlled.demo.ts
@@ -76,7 +76,7 @@ export default {
             kind: 'box',
             ref: 'box',
             className:
-              'w-64 h-40 rounded-xl flex flex-col items-center justify-center text-white shadow-xl transition-box cursor-pointer select-none',
+              'w-64 h-40 rounded-xl flex flex-col items-center justify-center text-background shadow-xl transition-box cursor-pointer select-none',
             children: [
               {
                 kind: 'box',
@@ -95,7 +95,7 @@ export default {
             kind: 'box',
             ref: 'toggleBtn',
             className:
-              'px-3 py-1.5 text-sm font-medium text-white bg-slate-700 hover:bg-slate-800 rounded-md cursor-pointer select-none',
+              'px-3 py-1.5 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 rounded-md cursor-pointer select-none',
             children: ['Toggle Open'],
           },
         ],
@@ -119,22 +119,22 @@ export default {
         children: [
           {
             kind: 'box',
-            className: 'px-3 py-1 bg-gray-200 rounded',
+            className: 'px-3 py-1 bg-muted text-muted-foreground rounded',
             children: ['closed'],
           },
           {
             kind: 'box',
-            className: 'px-3 py-1 bg-blue-200 rounded',
+            className: 'px-3 py-1 bg-muted text-muted-foreground rounded',
             children: ['entering'],
           },
           {
             kind: 'box',
-            className: 'px-3 py-1 bg-green-200 rounded',
+            className: 'px-3 py-1 bg-muted text-muted-foreground rounded',
             children: ['entered'],
           },
           {
             kind: 'box',
-            className: 'px-3 py-1 bg-orange-200 rounded',
+            className: 'px-3 py-1 bg-muted text-muted-foreground rounded',
             children: ['leaving'],
           },
         ],

--- a/apps/www/src/content/docs/zh-cn/demo-base-transition.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-transition.demo.ts
@@ -27,7 +27,7 @@ export default {
           {
             kind: 'box',
             className:
-              'w-64 h-40 rounded-xl flex flex-col items-center justify-center text-white shadow-xl transition-box',
+              'w-64 h-40 rounded-xl flex flex-col items-center justify-center text-background shadow-xl transition-box',
             children: [
               {
                 kind: 'box',
@@ -49,22 +49,22 @@ export default {
         children: [
           {
             kind: 'box',
-            className: 'px-3 py-1 bg-gray-200 rounded',
+            className: 'px-3 py-1 bg-muted text-muted-foreground rounded',
             children: ['closed'],
           },
           {
             kind: 'box',
-            className: 'px-3 py-1 bg-blue-200 rounded',
+            className: 'px-3 py-1 bg-muted text-muted-foreground rounded',
             children: ['entering'],
           },
           {
             kind: 'box',
-            className: 'px-3 py-1 bg-green-200 rounded',
+            className: 'px-3 py-1 bg-muted text-muted-foreground rounded',
             children: ['entered'],
           },
           {
             kind: 'box',
-            className: 'px-3 py-1 bg-orange-200 rounded',
+            className: 'px-3 py-1 bg-muted text-muted-foreground rounded',
             children: ['leaving'],
           },
         ],

--- a/apps/www/src/content/docs/zh-cn/start-here/quick-start.mdx
+++ b/apps/www/src/content/docs/zh-cn/start-here/quick-start.mdx
@@ -6,7 +6,6 @@ description: '使用 npm latest 稳定版本开始使用 Proto UI'
 import DocStageNotice from '@/components/DocStageNotice.astro';
 
 <DocStageNotice
-  tone="amber"
   title="Proto UI 0.2 stable 上手流程尚未开放。"
   body="官网主 Quick Start 永远跟随 npm latest，不会默认把预发布版本交给普通使用者。"
 />

--- a/apps/www/src/content/docs/zh-cn/start-here/rc-trial.mdx
+++ b/apps/www/src/content/docs/zh-cn/start-here/rc-trial.mdx
@@ -7,7 +7,6 @@ import DocStageNotice from '@/components/DocStageNotice.astro';
 import { Aside } from '@astrojs/starlight/components';
 
 <DocStageNotice
-  tone="amber"
   title="这是独立的 0.2.0-rc.7 预发布试用流程。"
   body="它不会改变官网主 Quick Start 对 npm latest 稳定版本的承诺。"
 />

--- a/apps/www/src/content/docs/zh-cn/start-here/why-proto-ui.mdx
+++ b/apps/www/src/content/docs/zh-cn/start-here/why-proto-ui.mdx
@@ -6,7 +6,6 @@ description: '它解决什么问题，未来会先在哪些场景中变得有价
 import DocStageNotice from '@/components/DocStageNotice.astro';
 
 <DocStageNotice
-  tone="amber"
   title="Proto UI 目前处于公开发布初期。"
   body="核心思路已经清晰可见，但组件储备与生态能力仍在持续补齐。"
 />


### PR DESCRIPTION
## Summary

Runs the killaislop.com catalogue over `apps/www` and removes the tells it names: decorative gradients, the default semantic palette, the one-hue status box, and a decorative highlight. Net −92 lines.

## Related context

- Issue: closes #429
- Applicable spec entities and lifecycle: none. Documentation-site shell, theme styles, and demos only; no `spec/**` change, per the issue's boundary.
- Criteria / test anchors: none applicable; the evidence anchor is the Light/Dark measurement table below.
- Related upstream: none.

## Audit table

Every catalogue entry was checked against `apps/www`. `keep` rows carry a reason, as required.

### Removed

| # | Tell | File | What was there |
| --- | --- | --- | --- |
| 04 | Default semantic palette | `components/DocStageNotice.astro` | `tone="amber"` / `tone="blue"` selecting `#f59e0b` vs `#3b82f6` |
| 05 | One-hue status box | `components/DocStageNotice.astro` | Border and background tint both derived from the same hue |
| 06 | Gradients as atmosphere | `components/DocStageNotice.astro` | Two `linear-gradient(135deg, …)` washes, plus two more in the dark override |
| 01, 06 | Indigo→violet family / atmosphere | `components/PrototypePreviewer/TransitionDemoStyles.astro` | Four `linear-gradient(135deg, …)` state fills |
| 04 | Default semantic palette | `TransitionDemoStyles.astro` + 3 transition demos + `baseTransitionCode.ts` | gray/blue/green/amber per state; `bg-blue-600` / `bg-amber-600` / `bg-emerald-600` action buttons; `bg-gray-200` / `bg-blue-200` / `bg-green-200` / `bg-orange-200` legend chips |
| 06 | Gradients as atmosphere | `components/InstallCommandCard.astro` | `linear-gradient(180deg, …)` surface wash + `inset 0 1px 0 white 35%` fake bevel; dark override hard-coded `#080808` / `#111111` |
| 09 | Decorative highlights | `components/WikiTerm.astro` | Highlighter band grown from `0.45em` to `0.8em` on hover via `background-size` |
| 06 | Gradients as atmosphere | `components/WikiTerm.astro` | `linear-gradient(180deg, …)` popover fill, in both themes |
| 06 | Gradients as atmosphere | `components/PrototypePreviewer/HomeDemoPreviewer.astro` | Three stacked layers — top-left `radial-gradient` spotlight plus two `linear-gradient` washes — and an `inset 0 1px 0 white 55%` bevel |
| 06 | Gradients as atmosphere | `components/UiLibraryGallery.astro` | `radial-gradient(circle at 83% 15%, …)` spotlight on the shadcn preview |
| 04 | Default semantic palette | `PrototypePreviewer/QUICK_START.md` | `bg-blue-500 text-white` in the copyable template |
| 14, 15 | AI copywriting voice / emoji | `PrototypePreviewer/QUICK_START.md` | `My Awesome Demo!`, `完成！🎉`, `现在开始创建吧！🚀`, emoji on every heading, `1️⃣`/`2️⃣` step markers, `✅ DO` / `❌ DON'T` |

### Kept, with reasons

| # | Tell | File | Reason |
| --- | --- | --- | --- |
| 06 | Gradients as atmosphere | `PrototypePreviewer/CodePanel.astro` | `bg-gradient-to-b from-transparent to-muted` is the overflow fade on clipped code and is hidden at `data-code-expanded=true`. Functional, exactly as the issue anticipated. |
| 06 | Gradients as atmosphere | `PrototypePreviewer/PrototypePreviewer.astro` | The skeleton's three-stop gradient **is** the animation payload — a shimmer sweep over `background-position` that signals pending state. Not a surface wash. |
| 06 | Gradients as atmosphere | `UiLibraryGallery.astro` — Brutalist preview | `linear-gradient(135deg, transparent 72%, #fca5a5 72%)` puts both stops at `72%`. It is a hard stop, so it renders as a flat diagonal wedge with no blend — Neo-Brutalist geometry, not atmosphere. |
| 06 | Gradients as atmosphere | `UiLibraryGallery.astro` — Base preview | Two 1px `linear-gradient`s at `background-size: 18px 18px` are a repeating graph-paper pattern depicting the unstyled Base library, not a wash. |
| 20 | Oversized drop shadow | `WikiTerm.astro`, `HomeDemoPreviewer.astro` | `0 18px 40px` and `0 16px 48px` on a 20rem popover and a full-width panel. The tell is a *small* element casting a huge shadow; the catalogue's signals start at `0 30px 80px`. Elevation here is functional layering. The fake inset bevels that sat alongside them were removed. |
| 26 | The springy hover | `AdapterSelect.astro`, `SiteTitle.astro`, `SocialIcons.astro`, `pattern/LinkButton.astro`, `markdown.css` | `transition-all` is present, but the tell is the springy hover: there is no `hover:scale-*`, no `hover:-translate-y-*`, and no overshoot easing anywhere in `apps/www`. These animate colour and ring only. |
| 26 | The springy hover | `TransitionDemoStyles.astro`, `baseTransitionCode.ts` | Same reasoning. `cubic-bezier(0.4, 0, 0.2, 1)` has no overshoot, and this is a transition demo where animating is the subject. I deliberately did **not** narrow `transition: all`, to keep the stylesheet and the documented snippet identical. |
| 26 | The springy hover | `UiLibraryGallery.astro` | `.library-card:hover … { transform: translate(2px, -2px) }` nudges a link arrow by 2px. Conventional affordance, not a card scale-up. |
| 33 | Inter everywhere | `styles/tailwindcss.css` | `GeistSans` is on the catalogue's list, but it is self-hosted from `./assets/font/GeistVF.woff2`, not the `fonts.googleapis.com` / `next/font/google` boilerplate the tell names. Changing the site typeface is a design decision, not a slop removal. |
| 19, 21 | Max radius / corners that don't nest | `DocStageNotice`, `WikiTerm`, `InstallCommandCard`, `HomeDemoPreviewer` | `1rem` and `1.5rem` on containers. No `rounded-full` on cards, no `backdrop-blur` panes, and no nested same-radius mismatch. Radius is untouched — no tell names it here. |
| 23 | Badge and pill spam | `override/Hero.astro` | One `rounded-full` badge on the hero. A single conventional badge is not spam, and it carries release-stage information. |
| 10 | Kicker above every heading | `demo-brutalist-textarea.demo.ts` | The one `uppercase tracking-wide` is inside a Brutalist demo. Brutalist is governed design grammar and out of scope per the issue. |

### Checked, absent

`02` gradient headline text · `03` warm cozy palette · `07`/`08` serif misuse · `11` full-sentence display headline · `12` flat type hierarchy · `13` highlighted keywords in copy · `16` glowing status dot · `17` rounded card with coloured left border · `18` rounded-square icon tiles · `22` border that dies at the corner · `24` AI-drawn SVG icons · `25` icon in a tint of itself · `27` wobbling spinner · `28` all-caps card grid · `29` invented stat row · `30` `01`/`02`/`03` section markers · `31` cards inside cards · `32` one gap everywhere · `34` tasteful terminal · `35` editorial dashboard.

## Three findings I did not fix

**1. An EN/ZH parity defect, now moot.** `why-proto-ui.mdx` carried `tone="blue"` in EN and `tone="amber"` in ZH — the same notice, two different hues. That is the clearest possible evidence that `tone` encoded nothing, which is why the prop is removed rather than neutralised. All six call sites are updated.

**2. Emoji in three more internal docs — scope question.** `PrototypePreviewer/README.md` (22), `MIGRATION.md` (13), and `ARCHITECTURE.md` (3) carry the same `#15` tell as `QUICK_START.md`. I fixed only `QUICK_START.md`, because the issue names it explicitly and its code sample propagates into real demos, while the other three are internal developer docs that fall outside the issue's four scoped categories and never render on the site. Say the word and I will include them — one follow-up commit. Note that some are `✅`/`❌` **table cells** carrying yes/no data rather than decoration; those I would convert to 是/否 rather than delete.

**3. Fixed `bg-white` outside this issue.** `demo-base-dialog.demo.ts:23` and `demo-base-select.demo.ts:29` use `bg-white`, which paints a white panel on the Dark documentation surface. That is the #422 family, not a catalogue tell, so it is untouched here. Worth its own issue if one is not already open.

**Issue path correction:** the issue lists `apps/www/src/components/TransitionDemoStyles.astro`; the file is at `apps/www/src/components/PrototypePreviewer/TransitionDemoStyles.astro`.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs.
- [x] Normative behavior changes include coherent P/C/T criteria, revisions, executable evidence, and affected projections.
- [x] This change does not create an empty catalog identity or silently widen a draft/active public guarantee.

## Contribution provenance

- [x] This contribution was created by me and I have the right to submit it.
- [ ] This contribution adapts or derives from third-party material.
- [x] This contribution includes material AI-assisted generation or transformation.
- [ ] This contribution may be subject to employer or client ownership, and I have confirmed that I may submit it.
- [x] No third-party source disclosure is required.

### AI assistance

Claude (Anthropic) was used as a coding assistant for the sweep, the replacements, and the measurement harness. I directed the work, read the full killaislop.com catalogue, made every `remove`/`keep` call myself, and reviewed every file. No third-party or private code was provided to the model beyond this public repository. Every number below comes from an executed browser measurement.

## DCO

- [x] I have checked the DCO status of this PR.

## Prototype website preview

- [ ] This pull request adds or changes public Prototype behavior and includes the required reachable website page or page update.
- [x] A new or updated website page is not applicable because: no page is added or restructured. Existing shell surfaces change appearance only; copy, headings, links, and accessibility attributes are unchanged apart from the `QUICK_START.md` template strings.

- Public docs routes touched: `/en/`, `/en/start-here/why-proto-ui/`, `/en/start-here/quick-start/`, `/en/start-here/rc-trial/`, `/en/wiki/`, `/en/ui-libraries/`, `/en/ui-libraries/base/transition/`, `/zh-cn/ui-libraries/shadcn/button/`, and the ZH parallels.
- Local preview URL or route: `http://127.0.0.1:4321/en/start-here/why-proto-ui/`
- Applicable runtimes manually reviewed: Web Component, in both light and dark, per the issue's allowance for shell chrome.
- [x] The demo consumes the real public package export and prefers the Prototype's own anatomy, triggers, state, events, and defaults.
- [x] The Demo Matrix, when used, is supplementary evidence rather than a replacement for the website page.
- External demo orchestration: none.
- Consumer-owned orchestration that is not installed with the package: none.

## Validation

Node 25 locally, so `corepack` is not bundled; repository scripts ran through a local shim forwarding to `pnpm@10.32.1`.

- Focused tests: `vitest run apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts` → 3 passed, unchanged.
- Catalog / generated checks: not applicable — no `spec/**` entity, prototype, or preset is touched.
- Types / repository tests: `pnpm --filter apps-www check` → 138 files, 0 errors, 0 warnings, 0 hints.
- Docs build / preview: `pnpm --filter apps-www build` → 196 pages, no errors.
- Manual or browser evidence: Playwright Chromium against the local dev server. Colours resolve through a 1×1 canvas so `lab()` and `oklch()` are measured as painted; text measures against its own composited backdrop, since several of these surfaces are transparent and the previewer panel sits at 30% alpha.

**Before — clean `d6afce29`, empty working tree**

| theme | surface | `background-image` | text | boundary |
| --- | --- | --- | --- | --- |
| light | DocStageNotice | `linear-gradient(135deg, oklch(0.713726 …` | 16.16:1 | 1.68:1 |
| light | InstallCommandCard | `linear-gradient(oklch(0.987398 …` | 9.89:1 | 1.26:1 |
| light | WikiTerm trigger | `linear-gradient(to top, oklab(0.205 …` | 19.80:1 | n/a |
| light | HomeDemo panel | `radial-gradient(circle at 0% 0%, oklch(0.96999 …` | 15.13:1 | 1.26:1 |
| light | shadcn preview | `radial-gradient(circle at 83% 15%, rgba(255, …` | 13.96:1 | n/a |
| light | Transition box | `linear-gradient(135deg, rgb(52, 211, 153) 0%, …` | **1.03:1** | n/a |
| dark | DocStageNotice | `linear-gradient(135deg, oklch(0.713726 …` | 14.95:1 | 8.94:1 |
| dark | InstallCommandCard | `linear-gradient(oklch(0.16671 …` | 7.11:1 | 19.45:1 |
| dark | WikiTerm trigger | `linear-gradient(to top, oklab(0.921998 …` | 18.97:1 | n/a |
| dark | HomeDemo panel | `radial-gradient(circle at 0% 0%, oklch(0.37099 …` | 15.72:1 | 19.80:1 |
| dark | shadcn preview | `radial-gradient(circle at 83% 15%, rgba(255, …` | 13.96:1 | n/a |
| dark | Transition box | `linear-gradient(135deg, rgb(52, 211, 153) 0%, …` | 18.73:1 | n/a |

**After — this branch**

| theme | surface | `background-image` | surface | text | boundary |
| --- | --- | --- | --- | --- | --- |
| light | DocStageNotice | `none` | `rgb(245,245,245)` | 15.96:1 | 2.78:1 |
| light | InstallCommandCard | `none` | `rgb(67,67,67)` | 9.89:1 | 1.26:1 |
| light | WikiTerm trigger | `none` | `rgb(255,255,255)` | 19.80:1 | n/a |
| light | HomeDemo panel | `none` | `rgb(255,255,255)` | 15.13:1 | 1.26:1 |
| light | shadcn preview | `none` | `rgb(228,228,231)` | 13.96:1 | n/a |
| light | Transition box | `none` | `rgb(10,10,10)` | **19.80:1** | n/a |
| dark | DocStageNotice | `none` | `rgb(38,38,38)` | 12.46:1 | 19.30:1 |
| dark | InstallCommandCard | `none` | `rgb(88,88,88)` | 7.11:1 | 19.45:1 |
| dark | WikiTerm trigger | `none` | `rgb(10,10,10)` | 18.97:1 | n/a |
| dark | HomeDemo panel | `none` | `rgb(10,10,10)` | 15.72:1 | 19.80:1 |
| dark | shadcn preview | `none` | `rgb(228,228,231)` | 13.96:1 | n/a |
| dark | Transition box | `none` | `rgb(250,250,250)` | 18.97:1 | 19.30:1 |

Twelve of twelve surfaces carried a gradient before; zero do now. **No contrast regressed.** Two things improved rather than merely held:

- **`light/Transition box` was 1.03:1.** `text-white` sat on the light-green `entered` gradient, so the demo's own label was effectively invisible in Light mode. Pairing the box with `text-background` on a flat `--color-foreground` surface takes it to 19.80:1. This was not in the issue; the audit surfaced it.
- **`light/DocStageNotice` boundary went 1.68:1 → 2.78:1.** My first neutral pass regressed it to 1.26:1 with a surface only 4/255 from the page — removing the hue had quietly removed the block's delineation too. The committed version uses `var(--color-muted)` with a border mixed 30% toward the foreground, which is still neutral and still token-derived, and now reads as a distinct block in both themes.

The two remaining `1.26:1` boundaries are `--color-border` container hairlines on `InstallCommandCard` and the home panel. Both measured `1.26:1` before this change as well, so neither regressed, and neither conveys state.

- Not run or not applicable, with reason: the full `pnpm test` chain was not run — this branch touches only `apps/www` and no package, export, preset, or entity. Two pre-existing failures in `apps/www/src/components/override/{LanguageSelect,ThemeProvider}.test.ts` (`TypeError: localStorage.clear is not a function`) reproduce on clean `main` with an empty working tree on my Node 25 environment and are unrelated; CI is green on `main`.
