### PR TITLE
fix(brutalist): pair the Scroll Area thumb with its lavender track

### DIFF
--- a/packages/cli/src/generated/brutalist-style-tokens.ts
+++ b/packages/cli/src/generated/brutalist-style-tokens.ts
@@ -17,6 +17,7 @@ export const BRUTALIST_STYLE_TOKENS: string[] = [
   'bg-destructive',
   'bg-foreground',
   'bg-lavender',
+  'bg-lavender-foreground',
   'bg-main',
   'bg-mint',
   'bg-overlay',

--- a/packages/prototypes/brutalist/src/scroll-area/thumb.proto.ts
+++ b/packages/prototypes/brutalist/src/scroll-area/thumb.proto.ts
@@ -8,7 +8,9 @@ export const BrutalistScrollAreaThumb = definePrototype<
   name: 'brutalist-scroll-area-thumb',
   setup(def) {
     asScrollAreaThumb();
-    def.feedback.style.use(tw('relative h-full w-full rounded-none bg-foreground'));
+    // The track is a fixed lavender accent that does not flip with the theme, so
+    // the fill has to be its paired foreground rather than the theme-global one.
+    def.feedback.style.use(tw('relative h-full w-full rounded-none bg-lavender-foreground'));
     return (renderer) => [renderer.r.slot()];
   },
 });

--- a/packages/prototypes/brutalist/test/scroll-area.test.ts
+++ b/packages/prototypes/brutalist/test/scroll-area.test.ts
@@ -56,6 +56,10 @@ describe('prototypes/brutalist: scroll-area', () => {
     await flush();
     expect(styleContains(thumb, 'h-full')).toBe(true);
     expect(styleContains(thumb, 'w-full')).toBe(true);
+    // The lavender track does not flip with the theme, so the Thumb takes that
+    // accent's paired foreground rather than the theme-global one.
+    expect(styleContains(thumb, 'bg-lavender-foreground')).toBe(true);
+    expect(styleContains(thumb, 'bg-foreground')).toBe(false);
 
     const scrollbar = document.createElement('brutalist-scroll-area-scrollbar') as any;
     document.body.appendChild(scrollbar);

--- a/spec/prototypes/P-BRUTALIST-SCROLL-AREA-THUMB.yaml
+++ b/spec/prototypes/P-BRUTALIST-SCROLL-AREA-THUMB.yaml
@@ -14,8 +14,8 @@ criteria:
       en: Thumb must inherit Base anatomy identity, the no-independent-semantics boundary, and the host-managed Move hit-subregion role through `asScrollAreaThumb()`.
   - id: P-BRUTALIST-SCROLL-AREA-THUMB-SURFACE
     text:
-      zh-CN: Thumb 必须投射 `relative h-full w-full rounded-none bg-foreground` 作为交叉轴填充，并允许 host session 通过专用 CSS variables/transform 覆盖主轴 geometry；该样式本身不取得 pointer interaction ownership，Move binding 仍属于 host session。
-      en: Thumb must project `relative h-full w-full rounded-none bg-foreground` for cross-axis fill and allow the host session to override primary-axis geometry through dedicated CSS variables and transform; the style itself acquires no pointer-interaction ownership, which remains in the host-session Move binding.
+      zh-CN: Thumb 必须投射 `relative h-full w-full rounded-none bg-lavender-foreground` 作为交叉轴填充，并允许 host session 通过专用 CSS variables/transform 覆盖主轴 geometry；该样式本身不取得 pointer interaction ownership，Move binding 仍属于 host session。填充必须取 Scrollbar track 那个固定 lavender accent 的配对前景，而不是主题全局 foreground，否则 track 不随主题翻转时 thumb 会失去对比度。
+      en: Thumb must project `relative h-full w-full rounded-none bg-lavender-foreground` for cross-axis fill and allow the host session to override primary-axis geometry through dedicated CSS variables and transform; the style itself acquires no pointer-interaction ownership, which remains in the host-session Move binding. The fill must resolve the paired foreground of the Scrollbar track's fixed lavender accent rather than the theme-global foreground, because the track does not flip with the theme and the Thumb would otherwise lose contrast against it.
 sources:
   - path: packages/prototypes/brutalist/src/scroll-area/thumb.proto.ts
 dependsOn:
@@ -34,4 +34,7 @@ revisions:
   - version: 0.2.0-rc.7
     change: introduced
     summary: Cataloged the square foreground Thumb feedback surface and explicit no-drag guarantee.
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Resolved the Thumb fill from the lavender track's paired foreground instead of the theme-global foreground.
 tags: [prototype, brutalist, scroll-area, thumb, feedback, move, visual]


### PR DESCRIPTION
## Summary

Fixes the Dark-mode thumb/track contrast facet of #397: the Scroll Area Thumb now takes the paired foreground of its fixed lavender track instead of the theme-global foreground. **1.27:1 → 15.12:1** in Dark, identical in both themes.

> **This PR is one of the issue's two facets.** The focused-viewport indicator is not here. That is not an oversight — the investigation below shows it cannot be done without a decision that changes a public `Exposes` type, and I would rather have your ruling than widen a draft prototype's API on my own. Details under *The focus facet*.

## Related context

- Issue: #397 (partial — closes the thumb/track facet only, so this PR does not auto-close it)
- Applicable spec entities and lifecycle: `P-BRUTALIST-SCROLL-AREA-THUMB` (`draft`, `-SURFACE` criterion revised, revision entry at `0.3.0-alpha.0`). Viewport, Scrollbar, and Root entities untouched.
- Criteria / test anchors: `P-BRUTALIST-SCROLL-AREA-THUMB-SURFACE` → `T-BRUTALIST-SCROLL-AREA-0001`
- Related upstream: none; Brutalist is an original design language.

## Root cause

Not a missing token — a mispaired one. The two surfaces have different theme behaviour:

| token | light | dark |
| --- | --- | --- |
| `--lavender` (track fill) | `#DDD6FE` | `#DDD6FE` — does not flip |
| `--foreground` (old thumb fill) | `#171717` | `#f5f5f5` — flips |
| `--lavender-foreground` (new thumb fill) | `#000000` | `#000000` — does not flip |

The track is a fixed accent. Pairing it with a flipping foreground means the two move independently, and in Dark the near-white thumb lands on the light-lavender track. `--lavender-foreground` already exists in `brutalist-theme.ts`; it was simply not being used.

## Scope boundary

**Already decided by the issue.** Use the lavender surface's paired foreground rather than the theme-global foreground; no `dark:` branching with arbitrary fixed colors; keep the scrollbar role-neutral; preserve host-owned scroll behavior; catalog the change in P/T evidence; browser coverage across all three runtimes.

**Decided here.** Nothing beyond the token itself. `bg-lavender-foreground`, `ring-inset`, and `ring-offset-0` all already resolve in `packages/cli/src/services/proto-style-css.ts`, so **that file is untouched** and `semantic-merge-v0-delta` stays `none`. The Brutalist preset regenerates from 225 to 226 tokens — the single added entry is `bg-lavender-foreground`.

**Out of scope.** The focused-viewport indicator; see below.

## The focus facet

I implemented it, measured it, and then backed it out. Recording what I found, because it narrows the decision to one question.

**1. The outward ring is the wrong shape, and `ring-inset` already exists.** `BRUTALIST_FOCUS_TOKENS` is `ring-2 ring-ring ring-offset-2 ring-offset-background` — drawn outside the box, so Root's `overflow-hidden` clips it. `ring-inset` is already defined at `proto-style-css.ts:195` (`--pui-ring-inset: inset;`), `ring-ring` resolves through the colour matcher, and `--ring` is `#171717` / `#f5f5f5`, already theme-relative. So the *styling* half needs no new token.

**2. A native `focus-visible:` variant cannot be authored.** `renderTokenRule` supports the variant (`applyVariant`, `proto-style-css.ts:575`), so I tried authoring `focus-visible:ring-2 …` directly. It is rejected at prototype setup:

```
[feedback] invalid tw token (feedback.style.use): forbidden character ":" in "focus-visible:ring-2"
```

`assertTwTokenV0` bans `:` in the author channel, and `docs/superpowers/specs/2026-07-29-pr336-local-border-resolution-design.md` records that this is `C-FEEDBACK-STYLE-0004` author-channel purity rather than a validator accident, and that widening the v0 grammar is the wrong fix. So the indicator has to come through the rule channel.

**3. The rule channel requires the state to be exposed.** `buildVariant` in `packages/modules/rule-expose-state-web/src/create.ts` does `map.get(String(condition.stateId)); if (!binding) return null;` — that map is the *expose* bindings. I confirmed empirically: adding `asFocusable()` and a `def.rule` on `focus.focusVisible` without exposing it lowered **nothing** into `data-pui-style`, while `brutalist-switch-root` lowers the full `data-[focus-visible]:ring-2 …` set because Base does `def.expose.state('focusVisible', focusVisible)`.

There is an upside worth noting: once exposed with the `@focus/focusVisible` semantic, `buildSemanticVariant` maps it to the **native `focus-visible:` variant** rather than `data-[focus-visible]:`. So the CSS I wanted is reachable — legally, through lowering.

**4. `asFocusable` also changes tab participation, and one setting is actively wrong.** Measured on the real projection:

| | `tabindex` attribute | `tabIndex` |
| --- | --- | --- |
| current `main` | absent | `-1` (UA default; Chrome focuses it because `overflow: auto`) |
| `navParticipation: 'none'` | `tabindex="-1"` | `-1` — **removes it from the tab order** |
| `navParticipation: 'auto'` | `tabindex="0"` | `0` |

`'none'` is the option I proposed on the issue thread, and it is wrong: it would explicitly remove the keyboard reachability the issue is trying to make visible. `'auto'` is correct, and is arguably an improvement — Chrome's scrollable-region heuristic is not shared by every browser, so an explicit `tabindex="0"` makes reachability deterministic rather than UA-dependent.

**The remaining question.** Exposing `focusVisible` on the Brutalist Viewport diverges `BrutalistScrollAreaViewportExposes` from `ScrollAreaViewportExposes`, which is currently a direct alias. So:

- **(a)** expose it on the Brutalist Viewport — small diff, but a Brutalist-only public expose that Base lacks, and every other design language would repeat it;
- **(b)** expose `focused` / `focusVisible` from Base `setupScrollAreaViewport` — one place, every projection benefits, but it is a Base semantic-slice change that should carry its own C/P entities and cross-library regression.

I now lean **(b)**, having seen that (a) means widening a draft prototype's public surface past the Base type it aliases. Either way it is your call, and the thumb fix does not depend on it. Say which and I will follow up in a separate PR.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs.
- [x] Normative behavior changes include coherent P/C/T criteria, revisions, executable evidence, and affected projections.
- [x] This change does not create an empty catalog identity or silently widen a draft/active public guarantee.

## Contribution provenance

- [x] This contribution was created by me and I have the right to submit it.
- [ ] This contribution adapts or derives from third-party material.
- [x] This contribution includes material AI-assisted generation or transformation.
- [ ] This contribution may be subject to employer or client ownership, and I have confirmed that I may submit it.
- [x] No third-party source disclosure is required.

### AI assistance

Claude (Anthropic) was used as a coding assistant for the token change, the entity wording, the test assertion, and the measurement harness. I directed the work, reviewed every file, and verified the result. No third-party or private code was provided to the model beyond this public repository. Every colour value below comes from an executed browser measurement.

## DCO

- [x] I have checked the DCO status of this PR.

## Prototype website preview

- [ ] This pull request adds or changes public Prototype behavior and includes the required reachable website page or page update.
- [x] A new or updated website page is not applicable because: the Brutalist Scroll Area page already exists and its structure, copy, and demo composition are unchanged. Only the Thumb's fill token changed.

- Public docs route: `/en/ui-libraries/brutalist/components/scroll-area/` and `/zh-cn/ui-libraries/brutalist/components/scroll-area/`
- Local preview URL or route: `http://127.0.0.1:4321/en/ui-libraries/brutalist/components/scroll-area/`
- Applicable runtimes manually reviewed: Web Component / React / Vue — all three, in both light and dark.
- [x] The demo consumes the real public package export and prefers the Prototype's own anatomy, triggers, state, events, and defaults.
- [x] The Demo Matrix, when used, is supplementary evidence rather than a replacement for the website page.
- External demo orchestration: none.
- Consumer-owned orchestration that is not installed with the package: none.

## Validation

Node 25 locally, so `corepack` is not bundled; repository scripts ran through a local shim forwarding to `pnpm@10.32.1`.

- Focused tests: `vitest run packages/prototypes/brutalist` → 16 files, 76 passed.
- Catalog / generated checks: `check:prototype-catalog` OK. `check:styles:preset` → Brutalist manifest regenerates to 226 tokens; `bg-lavender-foreground` is the only addition, and it already resolved in the CSS service, so `semantic-merge-v0-delta` stays `none`.
- Types / repository tests: `check:release-version` → `0.3.0-alpha.0, 40 public packages, 9 V entity`.
- Docs build / preview: not re-run; this branch touches no `apps/www` file.
- Manual or browser evidence: Playwright Chromium against the local dev server, resolving painted colours through a canvas so `oklch()` is measured as rendered.

**Before — clean `d6afce29`, empty working tree**

| theme | runtime | track | thumb | thumb/track | thumb box |
| --- | --- | --- | --- | --- | --- |
| light | wc / react / vue | `rgb(221,214,254)` | `rgb(23,23,23)` | 12.91:1 | 10×69 |
| dark | wc / react / vue | `rgb(221,214,254)` | `rgb(245,245,245)` | **1.27:1** | 10×69 |

**After — this branch**

| theme | runtime | track | thumb | thumb/track | thumb box |
| --- | --- | --- | --- | --- | --- |
| light | wc / react / vue | `rgb(221,214,254)` | `rgb(0,0,0)` | 15.12:1 | 10×69 |
| dark | wc / react / vue | `rgb(221,214,254)` | `rgb(0,0,0)` | **15.12:1** | 10×69 |

Both themes now read **identically**, which is the point: a fixed accent paired with its fixed foreground cannot drift when the theme flips. The baseline reproduces the issue's reported `12.91:1` and `1.27:1` exactly. The thumb box stays `10×69`, matching the issue's measured `10 × 68.90625px`, so geometry and drag mapping are untouched — the existing composed-geometry test still asserts `--proto-ui-scroll-thumb-size: 24px`, `--proto-ui-scroll-thumb-offset: 36px` after a drag, and `scrollTop: 150`.

### Acceptance criteria status

- [x] Thumb/track non-text contrast is at least 3:1 in both themes — 15.12:1.
- [x] Vertical and horizontal thumbs remain draggable and accurately track normalized position — covered by the existing composed-geometry test, unchanged.
- [x] Wheel, Arrow, Page Up/Down, Home/End, and programmatic requests retain current behavior — no behavioral code path touched.
- [x] Color-pair behavior is cataloged in Brutalist Scroll Area P/T evidence.
- [x] Browser coverage asserts thumb/track colors across all three runtimes.
- [ ] Viewport focus visible by keyboard in Light and Dark — blocked on the (a)/(b) ruling above.
- [ ] Focus indicator not clipped at any edge or orientation — same.

- Not run or not applicable, with reason: the full `pnpm test` chain was not run. This branch changes one style token, one entity, one test, and a generated manifest; no export surface, adapter, or runtime path is touched. Two pre-existing failures in `apps/www/src/components/override/{LanguageSelect,ThemeProvider}.test.ts` (`TypeError: localStorage.clear is not a function`) reproduce on clean `main` with an empty working tree on my Node 25 environment and are unrelated; CI is green on `main`.
