### PR TITLE
fix(brutalist): pair the Dialog close surfaces with their own fills

### DIFF
--- a/apps/www/src/content/docs/en/ui-libraries/brutalist/components/dialog.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/brutalist/components/dialog.mdx
@@ -13,10 +13,10 @@ import BrutalistPageStyle from '@/components/BrutalistPageStyle.astro';
 The panel keeps Base Dialog semantics and command wiring while using an industrial poster treatment.
 
 - The opener uses a sky-blue hard-shadow control.
-- The top-right X is a dedicated canary-yellow square control, not a borderless icon.
+- The top-right X is a dedicated canary-yellow square control, not a borderless icon. Its glyph takes the canary fill's paired foreground, so it stays legible in both themes.
 - Hover changes the X to coral and increases its hard shadow.
 - Press advances the control `1px` in both axes and removes its shadow.
-- Footer dismiss actions use the same explicit close semantics; they must not masquerade as neutral text links.
+- Footer dismiss actions use the same explicit close semantics; they must not masquerade as neutral text links. Close owns dismissal without a control surface of its own, so the footer action composes a Button child and the composition keeps one tab stop.
 - Focus remains a visible hard outline; the accessible `Close` name is preserved.
 
 <div class="brutalist-demo-frame">

--- a/apps/www/src/content/docs/zh-cn/demo-brutalist-dialog.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-brutalist-dialog.demo.ts
@@ -30,7 +30,11 @@ export default {
             kind: 'proto',
             prototypeId: 'brutalist-dialog-footer',
             children: [
-              { kind: 'proto', prototypeId: 'brutalist-dialog-close', children: ['Close'] },
+              {
+                kind: 'proto',
+                prototypeId: 'brutalist-dialog-close',
+                children: [{ kind: 'proto', prototypeId: 'brutalist-button', children: ['Close'] }],
+              },
             ],
           },
           { kind: 'proto', prototypeId: 'brutalist-dialog-close-icon' },

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/brutalist/components/dialog.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/brutalist/components/dialog.mdx
@@ -13,9 +13,9 @@ import BrutalistPageStyle from '@/components/BrutalistPageStyle.astro';
 面板保持 Base Dialog 语义和命令连接，并使用工业海报式处理。
 
 - 触发器使用天空蓝色块与硬阴影。
-- 右上角 X 是独立金丝雀黄色方形控件，不是无边框图标。
+- 右上角 X 是独立金丝雀黄色方形控件，不是无边框图标；其 glyph 取金丝雀填充的配对前景，因此在两个主题下都可读。
 - Hover 变珊瑚红并增加硬阴影；Pressed 移除阴影。
-- footer dismiss 动作保留明确关闭语义，不伪装成普通文本链接。
+- footer dismiss 动作保留明确关闭语义，不伪装成普通文本链接。Close 自身不带 control surface、只拥有 dismissal，因此 footer 动作组合一个 Button child，组合后保持单一 tab stop。
 - 保留硬轮廓 Focus 和可访问名称 `Close`。
 
 <div class="brutalist-demo-frame">

--- a/packages/cli/src/generated/brutalist-style-tokens.ts
+++ b/packages/cli/src/generated/brutalist-style-tokens.ts
@@ -73,6 +73,7 @@ export const BRUTALIST_STYLE_TOKENS: string[] = [
   'data-[hovered]:not-[data-pressed]:not-[data-selected]:border-black',
   'data-[hovered]:not-[data-pressed]:not-[data-selected]:shadow-[4px_4px_0_0_#000]',
   'data-[hovered]:shadow-[4px_4px_0_0_#000]',
+  'data-[hovered]:text-coral-foreground',
   'data-[open]:animate-in',
   'data-[open]:fade-in-0',
   'data-[open]:zoom-in-95',

--- a/packages/prototypes/brutalist/src/dialog/close-icon.proto.ts
+++ b/packages/prototypes/brutalist/src/dialog/close-icon.proto.ts
@@ -12,16 +12,17 @@ const dialogCloseIcon = definePrototype<BrutalistDialogCloseProps, BrutalistDial
 
     // P-BRUTALIST-DIALOG-CLOSE-ICON-A11Y-NAME: a11y accessible name 'Close'.
     def.a11y.name('Close');
-    // P-BRUTALIST-DIALOG-CLOSE-ICON-VISUAL-GRAMMAR + P-BRUTALIST-DIALOG-CLOSE-ICON-PAIR-INVARIANT: fixed bg-canary/text-foreground surface, square border-2 black, hard shadow-3, trailing X icon.
+    // P-BRUTALIST-DIALOG-CLOSE-ICON-VISUAL-GRAMMAR + P-BRUTALIST-DIALOG-CLOSE-ICON-PAIR-INVARIANT: fixed bg-canary/text-canary-foreground surface, square border-2 black, hard shadow-3, trailing X icon.
     def.feedback.style.use(
       tw(
-        'absolute right-4 top-4 inline-flex size-9 items-center justify-center rounded-none border-2 border-black bg-canary text-foreground shadow-[3px_3px_0_0_#000] outline-none transition-none'
+        'absolute right-4 top-4 inline-flex size-9 items-center justify-center rounded-none border-2 border-black bg-canary text-canary-foreground shadow-[3px_3px_0_0_#000] outline-none transition-none'
       )
     );
-    // P-BRUTALIST-DIALOG-CLOSE-ICON-INTERACTION: hover → bg-coral deeper shadow; focus-visible → ring-3; disabled → opacity-50 pointer-events-none.
+    // P-BRUTALIST-DIALOG-CLOSE-ICON-INTERACTION: hover → bg-coral with its own paired foreground and deeper shadow; focus-visible → ring-3; disabled → opacity-50 pointer-events-none.
     def.rule({
       when: (w) => w.state(hovered).eq(true),
-      intent: (i) => i.feedback.style.use(tw('bg-coral shadow-[4px_4px_0_0_#000]')),
+      intent: (i) =>
+        i.feedback.style.use(tw('bg-coral text-coral-foreground shadow-[4px_4px_0_0_#000]')),
     });
     def.rule({
       when: (w) => w.state(focusVisible).eq(true),

--- a/packages/prototypes/brutalist/test/dialog.test.ts
+++ b/packages/prototypes/brutalist/test/dialog.test.ts
@@ -14,6 +14,7 @@ import {
   dialogTitle,
   dialogTrigger,
 } from '../src/dialog';
+import { brutalistButton } from '../src/button';
 import type {
   BrutalistDialogContentExposes,
   BrutalistDialogContentProps,
@@ -48,6 +49,7 @@ for (const prototype of [
 ]) {
   AdaptToWebComponent(prototype);
 }
+AdaptToWebComponent(brutalistButton);
 
 async function flush(): Promise<void> {
   for (let index = 0; index < 4; index += 1) await Promise.resolve();
@@ -319,11 +321,14 @@ describe('prototypes/brutalist: dialog', () => {
       'border-2',
       'border-black',
       'bg-canary',
-      'text-foreground',
+      'text-canary-foreground',
       'shadow-[3px_3px_0_0_#000]',
     ]) {
       expect(styleContains(closeIcon, token)).toBe(true);
     }
+    // Canary is a fixed accent, so the glyph takes its paired foreground; the
+    // theme-global one flips to near-white and disappears on the yellow square.
+    expect(styleContains(closeIcon, 'text-foreground')).toBe(false);
     expect(
       Array.from(closeIcon.querySelectorAll('path')).map((path) => path.getAttribute('d'))
     ).toEqual(['M18 6 6 18', 'm6 6 12 12']);
@@ -331,6 +336,7 @@ describe('prototypes/brutalist: dialog', () => {
     await flush();
     expect(closeIcon.getExposes().hovered.get()).toBe(true);
     expect(styleContains(closeIcon, 'data-[hovered]:bg-coral')).toBe(true);
+    expect(styleContains(closeIcon, 'data-[hovered]:text-coral-foreground')).toBe(true);
     expect(styleContains(closeIcon, 'data-[hovered]:shadow-[4px_4px_0_0_#000]')).toBe(true);
 
     setElementProps(closeIcon, { disabled: true });
@@ -394,5 +400,34 @@ describe('prototypes/brutalist: dialog', () => {
       expect(styleContains(footer, token)).toBe(true);
     }
     expect(styleContains(footer, 'border-black')).toBe(false);
+  });
+
+  it('gives a composed footer Close one control surface and one dismissal', async () => {
+    // T-BRUTALIST-DIALOG-0001-CASE-7
+    vi.useFakeTimers();
+    const { root, trigger, close } = createDialog();
+    const button = document.createElement(brutalistButton.name) as HTMLElement;
+    button.textContent = 'Close';
+    close.replaceChildren(button);
+    await flush();
+    trigger.click();
+    await vi.advanceTimersByTimeAsync(0);
+    await flush();
+
+    // The Close keeps dismissal ownership but stays off the tab ring; the Button
+    // is the only control surface, so there is one stop and one command.
+    expect(close.getAttribute('role')).toBeNull();
+    expect(close.tabIndex).toBe(-1);
+    expect(button.getAttribute('role')).toBe('button');
+    expect(button.tabIndex).toBe(0);
+    for (const token of ['border-2', 'shadow-[3px_3px_0_0_#000]', 'data-[focus-visible]:ring-2']) {
+      expect(styleContains(button, token)).toBe(true);
+    }
+
+    expect(root.getExposes().open.get()).toBe(true);
+    button.click();
+    await vi.advanceTimersByTimeAsync(0);
+    await flush();
+    expect(root.getExposes().open.get()).toBe(false);
   });
 });

--- a/spec/prototypes/P-BRUTALIST-DIALOG-CLOSE-ICON.yaml
+++ b/spec/prototypes/P-BRUTALIST-DIALOG-CLOSE-ICON.yaml
@@ -9,11 +9,11 @@ summary: >-
 
 statement:
   en: >-
-    Brutalist Dialog Close Icon is a draft Proto UI-maintained Neo-Brutalist design-language projection over Base Dialog Close used as a precomposed close-icon variant. It preserves inherited Base protocol semantics (close/disabled/hovered/focusVisible state ownership) and adds visual/style behavior: a fixed `bg-canary` with `text-foreground` resting pair, `bg-coral` on hover, an a11y accessible name `Close`, a trailing X SVG icon, zero radius, black structural borders, hard offset shadows, and hover/focus-visible/disabled interaction projection.
+    Brutalist Dialog Close Icon is a draft Proto UI-maintained Neo-Brutalist design-language projection over Base Dialog Close used as a precomposed close-icon variant. It preserves inherited Base protocol semantics (close/disabled/hovered/focusVisible state ownership) and adds visual/style behavior: a fixed `bg-canary` with `text-canary-foreground` resting pair, `bg-coral` with `text-coral-foreground` on hover, an a11y accessible name `Close`, a trailing X SVG icon, zero radius, black structural borders, hard offset shadows, and hover/focus-visible/disabled interaction projection.
 
 
   zh-CN: >-
-    Brutalist Dialog Close Icon 是 Proto UI 维护的 draft Neo-Brutalist design-language 投射，建立在 Base Dialog Close 之上，作为预组合的 close-icon 变体使用。它保留继承的 Base 协议语义（close/disabled/hovered/focusVisible 状态归属），增加视觉/style 行为：固定 `bg-canary` 与 `text-foreground` 静止色对、hover 时 `bg-coral`、a11y 可访问名称 `Close`、尾部 X SVG 图标、零圆角、黑色结构边框、硬偏移阴影，以及 hover/focus-visible/disabled 交互投射。
+    Brutalist Dialog Close Icon 是 Proto UI 维护的 draft Neo-Brutalist design-language 投射，建立在 Base Dialog Close 之上，作为预组合的 close-icon 变体使用。它保留继承的 Base 协议语义（close/disabled/hovered/focusVisible 状态归属），增加视觉/style 行为：固定 `bg-canary` 与 `text-canary-foreground` 静止色对、hover 时 `bg-coral` 与 `text-coral-foreground`、a11y 可访问名称 `Close`、尾部 X SVG 图标、零圆角、黑色结构边框、硬偏移阴影，以及 hover/focus-visible/disabled 交互投射。
 
 
 criteria:
@@ -44,11 +44,11 @@ criteria:
   - id: P-BRUTALIST-DIALOG-CLOSE-ICON-PAIR-INVARIANT
     text:
       en: >-
-        The resting fill must co-select its foreground: `bg-canary` with `text-foreground`. Hover swaps the fill to `bg-coral` (preserving `text-foreground`). No rule may replace the foreground with a theme-global text token independently of its background.
+        The resting fill must co-select its own paired foreground: `bg-canary` with `text-canary-foreground`. Hover swaps both together, to `bg-coral` with `text-coral-foreground`. Because both fills are fixed accents that do not flip with the theme, no rule may pair them with the theme-global `text-foreground`, which flips and leaves the glyph illegible in one theme.
 
 
       zh-CN: >-
-        静止填充必须同时选择其前景：`bg-canary` 与 `text-foreground`。hover 将填充切换为 `bg-coral`（保留 `text-foreground`）。任何规则都不得在脱离背景的情况下用主题全局文本 token 覆盖前景。
+        静止填充必须同时选择其配对前景：`bg-canary` 与 `text-canary-foreground`。hover 时二者一同切换为 `bg-coral` 与 `text-coral-foreground`。由于两个填充都是不随主题翻转的固定 accent，任何规则都不得将它们与会翻转的主题全局 `text-foreground` 配对，否则 glyph 在其中一个主题下不可读。
 
 
   - id: P-BRUTALIST-DIALOG-CLOSE-ICON-INTERACTION
@@ -64,11 +64,11 @@ criteria:
   - id: P-BRUTALIST-DIALOG-CLOSE-ICON-VISUAL-GRAMMAR
     text:
       en: >-
-        The surface uses `absolute right-4 top-4 inline-flex size-9 items-center justify-center rounded-none border-2 border-black bg-canary text-foreground shadow-[3px_3px_0_0_#000] outline-none transition-none` and renders a trailing X icon (two 16×16 SVG paths `M18 6 6 18` and `m6 6 12 12`), preserving square corners, black structural borders, hard zero-blur offset shadows, and flat theme-token fills without gradients, glass, rounded cards, or soft elevation.
+        The surface uses `absolute right-4 top-4 inline-flex size-9 items-center justify-center rounded-none border-2 border-black bg-canary text-canary-foreground shadow-[3px_3px_0_0_#000] outline-none transition-none` and renders a trailing X icon (two 16×16 SVG paths `M18 6 6 18` and `m6 6 12 12`), preserving square corners, black structural borders, hard zero-blur offset shadows, and flat theme-token fills without gradients, glass, rounded cards, or soft elevation.
 
 
       zh-CN: >-
-        表面使用 `absolute right-4 top-4 inline-flex size-9 items-center justify-center rounded-none border-2 border-black bg-canary text-foreground shadow-[3px_3px_0_0_#000] outline-none transition-none`，并渲染尾部 X 图标（两条 16×16 SVG 路径 `M18 6 6 18` 与 `m6 6 12 12`），保持直角、黑色结构边框、零模糊硬偏移阴影和平面主题 token 填充，不得使用渐变、玻璃拟态、圆角卡片或柔和高度阴影。
+        表面使用 `absolute right-4 top-4 inline-flex size-9 items-center justify-center rounded-none border-2 border-black bg-canary text-canary-foreground shadow-[3px_3px_0_0_#000] outline-none transition-none`，并渲染尾部 X 图标（两条 16×16 SVG 路径 `M18 6 6 18` 与 `m6 6 12 12`），保持直角、黑色结构边框、零模糊硬偏移阴影和平面主题 token 填充，不得使用渐变、玻璃拟态、圆角卡片或柔和高度阴影。
 
 
 sources:
@@ -87,6 +87,12 @@ revisions:
     change: introduced
     summary: >-
       Introduced draft Brutalist Dialog Close Icon projection with real public-API criteria (Base inheritance, direct entry, a11y Close name, canary/coral pair invariant, interaction, X icon visual grammar) on rc.7. Not present in immutable rc.6.
+
+
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: >-
+      Paired the canary and coral fills with their own foregrounds instead of the theme-global one.
 
 
 tags: [prototype, brutalist, neo-brutalist, visual, delta, dialog]

--- a/spec/prototypes/P-BRUTALIST-DIALOG-CLOSE.yaml
+++ b/spec/prototypes/P-BRUTALIST-DIALOG-CLOSE.yaml
@@ -31,6 +31,16 @@ criteria:
     text:
       en: The direct prototype entry name is `brutalist-dialog-close`.
       zh-CN: 直接 prototype 入口名为 `brutalist-dialog-close`。
+  - id: P-BRUTALIST-DIALOG-CLOSE-COMPOSITION
+    text:
+      en: >-
+        Close owns dismissal and projects no control surface of its own: it claims no role, stays off the tab ring, and carries no resting, hover, pressed, or focus-visible treatment. A consumer that needs a visible action composes a control child, normally Brutalist Button, whose continuous trigger route merges with Close under `asTrigger()`, so the composition keeps one tab stop and issues one dismissal.
+
+
+      zh-CN: >-
+        Close 拥有 dismissal，自身不投射任何 control surface：不声明 role、不进入 tab 序列，也不带 resting、hover、pressed 或 focus-visible 处理。需要可见 action 的调用方组合一个 control child（通常是 Brutalist Button），其连续 trigger route 在 `asTrigger()` 下与 Close 合并，因此组合后只有一个 tab stop、只发出一次 dismissal。
+
+
 sources:
   - path: packages/prototypes/brutalist/src/dialog/close.proto.ts
   - path: packages/prototypes/brutalist/test/dialog.test.ts
@@ -47,6 +57,12 @@ revisions:
     change: introduced
     summary: >-
       Introduced draft Brutalist Dialog Close projection with real public-API criteria (Base inheritance, direct entry) on rc.7. Not present in immutable rc.6.
+
+
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: >-
+      Cataloged that Close owns dismissal without a control surface and that consumers compose one.
 
 
 tags: [prototype, brutalist, neo-brutalist, visual, delta, dialog]

--- a/spec/tests/T-BRUTALIST-DIALOG-0001.yaml
+++ b/spec/tests/T-BRUTALIST-DIALOG-0001.yaml
@@ -57,11 +57,12 @@ cases:
       - P-BRUTALIST-DIALOG-DESCRIPTION-VISUAL-GRAMMAR
     expectation: p-brutalist-dialog-description-typography
   - id: T-BRUTALIST-DIALOG-0001-CASE-7
-    title: Close bare entry and Base inheritance
+    title: Close entry, Base inheritance, and composed control surface
     covers:
       - P-BRUTALIST-DIALOG-CLOSE-ENTRY
       - P-BRUTALIST-DIALOG-CLOSE-BASE-INHERITANCE
-    expectation: p-brutalist-dialog-close-entry-inheritance
+      - P-BRUTALIST-DIALOG-CLOSE-COMPOSITION
+    expectation: p-brutalist-dialog-close-entry-inheritance-and-single-owner-composition
   - id: T-BRUTALIST-DIALOG-0001-CASE-8
     title: Close-icon canary pair, a11y Close name and interaction
     covers:


### PR DESCRIPTION
## Summary

Both Dialog close-surface facets from #391. The trailing X takes the canary fill's paired foreground (**1.07:1 → 18.05:1** in Dark), and the footer `Close` composes a real Brutalist Button control surface while Dialog Close keeps sole dismissal ownership.

## Related context

- Issue: closes #391
- Applicable spec entities and lifecycle: `P-BRUTALIST-DIALOG-CLOSE-ICON` (`draft`, statement + `-PAIR-INVARIANT` + `-VISUAL-GRAMMAR` revised) and `P-BRUTALIST-DIALOG-CLOSE` (`draft`, new `-COMPOSITION` criterion). Both carry a revision entry at `0.3.0-alpha.0`.
- Criteria / test anchors: `P-BRUTALIST-DIALOG-CLOSE-ICON-PAIR-INVARIANT` → `T-BRUTALIST-DIALOG-0001-CASE-8`; `P-BRUTALIST-DIALOG-CLOSE-COMPOSITION` → `T-BRUTALIST-DIALOG-0001-CASE-7`
- Related upstream: none; Brutalist is an original design language.

## Facet 1 — the X glyph

`bg-canary` paired with the theme-global `text-foreground`. Canary is `#FEF08A` in both themes; `text-foreground` flips to `#f5f5f5` in Dark, so a near-white glyph landed on a light-yellow square. `--canary-foreground` is `#000000` in both themes and already existed.

**The catalog contradicted itself here.** `P-BRUTALIST-DIALOG-CLOSE-ICON-PAIR-INVARIANT` read:

> The resting fill must co-select its foreground: `bg-canary` with `text-foreground`. … **No rule may replace the foreground with a theme-global text token independently of its background.**

`text-foreground` *is* the theme-global text token. The invariant named the defect and then specified it. The criterion now states the rule it was reaching for: a fixed accent that does not flip must not be paired with a foreground that does.

**Also fixed, and separable.** The hover rule swapped the fill to `bg-coral` without swapping the foreground — the same broken pairing one rule down. `--coral-foreground` is also `#000000`, so there is no visible defect today, but the invariant was broken there too. If you want this PR held strictly to the resting pair named in the issue, dropping `text-coral-foreground` from the hover rule and its one test assertion is a clean subtraction.

## Facet 2 — the footer Close

The issue asks for "the repository's established behavior-owner + control-surface composition pattern" with "only one interaction owner". That pattern already exists and is normative: `D-AS-CHILD-OMISSION-0001` records that Proto UI deliberately has no `asChild` because **continuous trigger event routes are merged automatically by the privileged `asTrigger()` mechanism**. Both sides use it — `brutalist-dialog-close` through `setupDialogCommand`, `brutalist-button` through `asButton` → Base Button.

So the demo now nests a Button inside the Close rather than putting bare text in it. I verified the merge rather than assuming it:

| node | `role` | `tabIndex` |
| --- | --- | --- |
| `brutalist-dialog-close` | `null` | `-1` — not a tab stop |
| composed `brutalist-button` | `button` | `0` — the only tab stop |

Clicking the Button takes `open` from `true` to `false` exactly once. One tab stop, one command, and the Button brings the full Brutalist resting/hover/pressed/focus-visible grammar the bare protocol node never had.

`P-BRUTALIST-DIALOG-CLOSE` previously had only inheritance and entry criteria, so nothing in the catalog said the Close is surface-less by design. The new `-COMPOSITION` criterion states it, which is what makes the demo's old shape a defect rather than a style preference.

## Scope boundary

**Already decided by the issue.** Use the canary paired foreground; compose a real styled control for the footer action; keep one interaction owner; no arbitrary hard-coded black in the demo; fix the semantic pair and the demo composition at their respective sources; cross-runtime browser coverage.

**Decided here.** The hover pair (above), and the wording of the two entity criteria.

**Out of scope.** The Dialog Content outer frame and the Header/Footer separators — those are #427 and #425/#430 respectively. `border-black` and `shadow-[3px_3px_0_0_#000]` on the close icon are untouched.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs.
- [x] Normative behavior changes include coherent P/C/T criteria, revisions, executable evidence, and affected projections.
- [x] This change does not create an empty catalog identity or silently widen a draft/active public guarantee.

## Contribution provenance

- [x] This contribution was created by me and I have the right to submit it.
- [ ] This contribution adapts or derives from third-party material.
- [x] This contribution includes material AI-assisted generation or transformation.
- [ ] This contribution may be subject to employer or client ownership, and I have confirmed that I may submit it.
- [x] No third-party source disclosure is required.

### AI assistance

Claude (Anthropic) was used as a coding assistant for the token changes, the demo composition, the entity wording, the test case, and the measurement harness. I directed the work, reviewed every file, and verified the result. No third-party or private code was provided to the model beyond this public repository. Every value below comes from an executed browser measurement.

## DCO

- [x] I have checked the DCO status of this PR.

## Prototype website preview

- [ ] This pull request adds or changes public Prototype behavior and includes the required reachable website page or page update.
- [x] A new or updated website page is not applicable because: the Brutalist Dialog page already exists and its structure and copy are unchanged. The demo's footer gains a composed Button child; no route, heading, or contract bullet changes.

- Public docs route: `/en/ui-libraries/brutalist/components/dialog/` and `/zh-cn/ui-libraries/brutalist/components/dialog/`
- Local preview URL or route: `http://127.0.0.1:4321/en/ui-libraries/brutalist/components/dialog/`
- Applicable runtimes manually reviewed: Web Component / React / Vue — all three, in both light and dark.
- [x] The demo consumes the real public package export and prefers the Prototype's own anatomy, triggers, state, events, and defaults.
- [x] The Demo Matrix, when used, is supplementary evidence rather than a replacement for the website page.
- External demo orchestration: none.
- Consumer-owned orchestration that is not installed with the package: none.

## Validation

Node 25 locally, so `corepack` is not bundled; repository scripts ran through a local shim forwarding to `pnpm@10.32.1`.

- Focused tests: `vitest run packages/prototypes/brutalist` → 16 files, 77 passed (76 before, plus the new composition case).
- Catalog / generated checks: `check:prototype-catalog` OK. `check:styles:preset` → Brutalist manifest regenerates to 226 tokens; the single addition is `data-[hovered]:text-coral-foreground`. `text-canary-foreground` was already in the manifest, and all three tokens already resolved in `packages/cli/src/services/proto-style-css.ts`, so **that file is untouched** and `semantic-merge-v0-delta` stays `none`.
- Types / repository tests: `check:release-version` → `0.3.0-alpha.0, 40 public packages, 9 V entity`.
- Docs build / preview: `pnpm --filter apps-www check` → 0 errors, 0 warnings, 0 hints. `pnpm --filter apps-www build` → 196 pages.
- Manual or browser evidence: Playwright Chromium at 1440×1000 against the local dev server, opening the dialog through its own trigger, resolving painted colours through a canvas so `oklch()` is measured as rendered. The footer control is located runtime-agnostically, by finding the footer through its own tokens and then the `[role="button"]` inside it.

**Before — clean `d6afce29`, empty working tree**

| theme | runtime | X glyph | canary fill | glyph/fill | footer control border | shadow | focused after open |
| --- | --- | --- | --- | --- | --- | --- | --- |
| light | wc / react / vue | `rgb(23,23,23)` | `rgb(254,240,138)` | 15.41:1 | `0px` | `none` | yes |
| dark | wc / react / vue | `rgb(245,245,245)` | `rgb(254,240,138)` | **1.07:1** | `0px` | `none` | yes |

**After — this branch**

| theme | runtime | X glyph | canary fill | glyph/fill | close `role`/`tab` | button `role`/`tab` | button border | shadow | focused after open |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| light | wc / react / vue | `rgb(0,0,0)` | `rgb(254,240,138)` | 18.05:1 | `null` / `-1` | `button` / `0` | `2px` | set | yes |
| dark | wc / react / vue | `rgb(0,0,0)` | `rgb(254,240,138)` | **18.05:1** | `null` / `-1` | `button` / `0` | `2px` | set | yes |

The glyph now reads **identically in both themes**, which is the property a fixed accent paired with its fixed foreground guarantees. The baseline reproduces the issue's reported `1.07:1` exactly, and the `0px` / `none` footer control reproduces its "border: 0, box-shadow: none" finding. Focus lands inside the footer control immediately after opening in every row, before and after — the change is that it is now a control the user can see.

### Acceptance criteria status

- [x] The trailing X is visibly legible in Light and Dark and uses the canonical canary background/foreground pair.
- [x] The footer `Close` is recognizable as an interactive control at rest and while focused — `2px` border, hard shadow, and the Button's `data-[focus-visible]:ring-2`, asserted in the new test.
- [x] Keyboard focus is visible immediately after the dialog opens — focus lands on the Button, which now carries a focus-visible treatment.
- [x] Pointer and keyboard activation close the dialog exactly once and restore focus to the trigger — the new test asserts a single `open: true → false`; focus restoration is covered by the existing dismissal cases, unchanged.
- [x] Web Components, React, and Vue render equivalent close surfaces and states — all six measured rows are identical.
- [x] Catalog criteria, implementation, docs demo, and executable tests describe the same visual/composition contract.

- Not run or not applicable, with reason: the full `pnpm test` chain was not run. This branch changes two style tokens, one demo composition, two entities, one test, and a generated manifest; no export surface or adapter path is touched. Two pre-existing failures in `apps/www/src/components/override/{LanguageSelect,ThemeProvider}.test.ts` (`TypeError: localStorage.clear is not a function`) reproduce on clean `main` with an empty working tree on my Node 25 environment and are unrelated; CI is green on `main`.
