### PR TITLE
docs: align prototype authoring guides with spec

### DIFF
--- a/apps/www/src/content/docs/en/build/prototypes/building-a-styled-library-on-top-of-base.md
+++ b/apps/www/src/content/docs/en/build/prototypes/building-a-styled-library-on-top-of-base.md
@@ -1,0 +1,79 @@
+---
+title: 'Building a Styled Library on Top of Base'
+description: 'Understand Base projections, styled-only identities, and design-language deltas.'
+---
+
+This page is a conceptual introduction. For a complete contribution, follow [Projecting Base into a Design Language](/en/build/prototypes/projecting-base-into-a-design-language/) for P/T, provenance, tests, exports, CLI, demos, and validation.
+
+## Decide between projection and styled-only first
+
+### Base projection
+
+When Base already owns state, events, focus, accessibility, context, or positioning, a derived P connects to Base through `inherits.prototypes` and consumes the corresponding asHook in implementation. The derived layer adds only cataloged design-language deltas and never creates a second semantic owner.
+
+### Styled-only
+
+When a subject owns only design-language props, visual rules, a content model, or visual anatomy—and has no independent Base information path—it can be a formal styled-only P. Do not create an empty Base identity merely to obtain an inheritance entry.
+
+Base admission requires an independent, cross-host, testable input-fact-to-observable-output path. A component directory or a familiar name from a popular design system is not evidence.
+
+## The current shape of Shadcn Button
+
+`P-SHADCN-BUTTON` currently declares one direct Prototype:
+
+- `inherits.prototypes` points to `P-BASE-BUTTON`;
+- [button.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/shadcn/src/button/button.proto.ts) calls `asButton()`;
+- it adds six `variant` values, four `size` values, and visual tokens;
+- visual rules derive from inherited `hovered`, `focusVisible`, `pressed`, and `disabled` facts plus `colorScheme` meta;
+- upstream `asChild` is explicitly unavailable, while other parity differences remain in a compatibility open question; and
+- the Shadcn layer does not add another authored asHook.
+
+The former guide listed `invalid` and `expanded` as current Shadcn Button rule inputs. The current implementation and passing P criteria do not provide that guarantee.
+
+`P-BASE-BUTTON` and `P-SHADCN-BUTTON` are both currently `draft`. npm publication at 0.2.0 does not automatically make either entity active.
+
+## What a derived P should contain
+
+A reviewable design-language P focuses on its delta:
+
+- exact upstream repository, path, revision, and provenance;
+- `inherits.prototypes` or styled-only classification;
+- variants, sizes, tokens, visual anatomy, and compatibility boundaries;
+- any explicit setup-time negative patch and replacement semantics;
+- unsupported upstream APIs; and
+- substantive `T-*` evidence and real source paths.
+
+Do not copy every Base criterion or promise upstream parity that has not been implemented.
+
+## How implementation should reuse Base
+
+Implementation normally calls the owning Base asHook first, then adds:
+
+- design-language props;
+- `feedback.style` tokens;
+- rules based on Base state or meta;
+- necessary cataloged visual anatomy; and
+- derived types and public entries.
+
+Pause and return to the issue if the implementation begins to own Base value, event requests, focus, accessibility, dismissal, or positioning again. The style layer must not become a second semantic truth.
+
+## Negative patches and compatibility boundaries
+
+A derived Prototype may abandon or replace an inherited guarantee during setup, but its own P criterion must identify:
+
+- the Base capability being abandoned;
+- the replacement semantics;
+- the public compatibility impact; and
+- absence assertions that prevent the capability from returning silently.
+
+A runtime flag must not masquerade as a setup-time negative patch.
+
+## Host and Adapter claims
+
+The current Web Component, React, and Vue previews provide cross-Adapter evidence for one Web host profile. A design-language page may compare those Web projections, but it must not infer non-Web host conformance or claim identical APIs across every host.
+
+## Next
+
+- For the complete delivery workflow, read [Projecting Base into a Design Language](/en/build/prototypes/projecting-base-into-a-design-language/)
+- To choose sources and evidence, read [How to Read Reference Implementations](/en/build/prototypes/reference-patterns/)
+- Before opening a pull request, use the [Prototype Author Checklist](/en/build/prototypes/checklist/)

--- a/apps/www/src/content/docs/en/build/prototypes/checklist.md
+++ b/apps/www/src/content/docs/en/build/prototypes/checklist.md
@@ -49,7 +49,15 @@ description: 'Check contribution readiness, spec ownership, evidence, and delive
 - Are unsupported upstream APIs and compatibility limits documented?
 - Should a subject with no Base protocol be styled-only rather than creating an empty Base identity?
 
-## 8. Does the website demo represent installed usage?
+## 8. Do authoring entries match the cataloged protocol?
+
+- Does the applicable P entity require a direct Prototype, an authored asHook, or both?
+- When direct and authored-asHook entries express one protocol, do they share implementation and remain in one P entity?
+- Did I avoid adding an asHook merely for API symmetry?
+- Did I avoid using one protocol-specific authored asHook as another Base protocol's behavior substrate?
+- Does any configurable authored asHook stay within an explicitly governed contract?
+
+## 9. Does the website demo represent installed usage?
 
 - Does every new public Prototype identity or anatomy family have a reachable page connected to the website documentation entry point?
 - Does the pull request provide a local preview route that maintainers can open directly?
@@ -60,7 +68,7 @@ description: 'Check contribution readiness, spec ownership, evidence, and delive
 - Does the demo source and pull request say which exception code is not installed with the package and must be recreated by consumers?
 - Is the internal Demo Matrix treated as supplementary evidence rather than a replacement for the website page?
 
-## 9. Is evidence coherent?
+## 10. Is evidence coherent?
 
 - Does every new or changed P criterion have a substantive `T-*` case?
 - Do T cases anchor exact criteria and map real executable paths?

--- a/apps/www/src/content/docs/en/build/prototypes/index.md
+++ b/apps/www/src/content/docs/en/build/prototypes/index.md
@@ -31,7 +31,15 @@ Every new public Prototype must appear on a reachable website page in the same p
 
 Proto UI does not admit a Base Prototype because a component name is familiar or a styled library wants an inheritance point. A Base subject must own an independent, cross-host, testable input-fact-to-observable-output path with substantive executable evidence.
 
-The longer conceptual authoring series is currently maintained primarily in Chinese. Its English routes remain available through the documentation locale fallback while translation is in progress.
+## Conceptual reading sequence
+
+If you are still deciding what kind of Prototype work you have:
+
+1. Read [Why You Usually Do Not Need a New Prototype](/en/build/prototypes/when-not-to-write-a-new-prototype/)
+2. Use [Writing a Custom Primitive Prototype](/en/build/prototypes/writing-a-custom-primitive-prototype/) to understand a leaf authoring entry inside an approved boundary
+3. Continue to [Writing a Compound Prototype](/en/build/prototypes/writing-a-compound-prototype/) when the approved subject is a family
+4. For presentation and compatibility deltas, read [Building a Styled Library on Top of Base](/en/build/prototypes/building-a-styled-library-on-top-of-base/)
+5. Follow [How to Read Reference Implementations](/en/build/prototypes/reference-patterns/) from P/T entities into source and public projections
 
 ## Current boundary
 

--- a/apps/www/src/content/docs/en/build/prototypes/reference-patterns.md
+++ b/apps/www/src/content/docs/en/build/prototypes/reference-patterns.md
@@ -1,0 +1,109 @@
+---
+title: 'How to Read Reference Implementations'
+description: 'Move from P/T entities into source, tests, exports, and public projections without treating implementation as specification.'
+---
+
+Existing Prototype implementations are important evidence, but they are not the highest authority. Use this reading order:
+
+```text
+applicable P lifecycle and criteria
+→ related decisions / contracts / inheritance
+→ mapped T cases and executable paths
+→ implementation and focused tests
+→ exports, CLI, docs, demo
+```
+
+When implementation conflicts with an applicable entity, identify drift first. Do not silently change protocol meaning because “the repository currently does it this way.”
+
+## 1. Find the applicable P/T graph
+
+Search by name, ID, or criterion:
+
+```sh
+rg -n "<prototype name|entity id|criterion id>" spec packages/prototypes apps/www internal/records
+```
+
+Confirm:
+
+- whether the P entity is `draft`, `active`, deprecated, or removed;
+- which criteria apply to the current problem;
+- how direct Prototypes, authored asHooks, and Parts are cataloged;
+- `inherits.prototypes`, dependencies, and related decisions; and
+- which executable tests the T cases map.
+
+Legacy contracts and records can explain background. They cannot override an existing applicable spec entity.
+
+## 2. Read a leaf Prototype
+
+Button is a relatively small vertical slice:
+
+- `P-BASE-BUTTON`;
+- `T-BASE-BUTTON-0001`;
+- [button.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/button/button.proto.ts); and
+- `packages/prototypes/base/test/as-button.test.ts`.
+
+Trace criteria into props, state, accessibility, events, exposes, and absence guarantees instead of recording only the order of API calls.
+
+Toggle provides another independent Base protocol for comparison:
+
+- `P-BASE-TOGGLE` and `T-BASE-TOGGLE-0001`; and
+- [toggle.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/toggle/toggle.proto.ts).
+
+Button and Toggle both having authored asHooks does not permit one protocol to consume the other's protocol-specific hook.
+
+## 3. Read a compound family
+
+Tabs requires Root and Parts together:
+
+- `P-BASE-TABS` plus the List, Trigger, Content, and Indicator P entities;
+- the corresponding `T-BASE-TABS-*` entities;
+- [shared.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/shared.ts);
+- [root.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/root.proto.ts);
+- [list.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/list.proto.ts);
+- [trigger.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/trigger.proto.ts);
+- [content.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/content.proto.ts); and
+- [indicator.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/indicator.proto.ts).
+
+Trace owners, context facts, anatomy claims, collection and focus responsibilities, and mapped tests. File count alone does not prove a correct boundary.
+
+## 4. Read a design-language projection
+
+Shadcn Button is a compact Base-projection example:
+
+- `P-SHADCN-BUTTON` and `T-SHADCN-BUTTON-0001`;
+- inherited `P-BASE-BUTTON` criteria;
+- [Shadcn Button source](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/shadcn/src/button/button.proto.ts); and
+- `packages/prototypes/shadcn/test/button.test.ts`.
+
+Verify that:
+
+- the derived P declares only its delta;
+- implementation calls the owning Base asHook;
+- rules depend on inherited protocol states instead of making host selectors a second truth;
+- unsupported upstream APIs and absence assertions are recorded; and
+- package exports, CLI facades, website demos, and the P/T surface agree.
+
+Shadcn Switch and Tabs offer differently sized projections, but always begin from their own P/T graph rather than mechanically copying directory structure.
+
+## 5. Finish with the public delivery surface
+
+After source and tests, inspect:
+
+- package subpaths and root exports;
+- CLI registry and generated facades;
+- component-preset or style-token closure when applicable;
+- bilingual docs and a real public-package demo;
+- Web Component, React, and Vue Web evidence; and
+- generated workspace and Agent projections.
+
+This distinguishes “implementation exists” from “the contribution forms a consumable, reviewable closure.”
+
+## Lifecycle note
+
+The Base Button, Toggle, Tabs, and Shadcn Button entities referenced here are currently `draft`. Learn from their ownership and evidence structure without widening current implementation details into uncataloged stable guarantees.
+
+## Further reading
+
+- [Maintaining an Existing Prototype](/en/build/prototypes/maintaining-an-existing-prototype/)
+- [Projecting Base into a Design Language](/en/build/prototypes/projecting-base-into-a-design-language/)
+- [Implementing an Approved Base Semantic Slice](/en/build/prototypes/implementing-an-approved-base-slice/)

--- a/apps/www/src/content/docs/en/build/prototypes/when-not-to-write-a-new-prototype.md
+++ b/apps/www/src/content/docs/en/build/prototypes/when-not-to-write-a-new-prototype.md
@@ -1,0 +1,80 @@
+---
+title: 'Why You Usually Do Not Need a New Prototype'
+description: 'Distinguish maintenance, composition, design-language projection, and a new Base semantic subject.'
+---
+
+Proto UI provides Prototype authoring APIs, but that does not mean contributors should frequently add new protocol identities. A safer starting point is:
+
+> Find the applicable `P-*` and `T-*` entities first, then decide whether the work is maintenance, composition, a design-language projection, or a new Base semantic subject that still needs approval.
+
+This is a boundary guide, not authorization to implement a new Prototype. A new Base subject must pass a proposal and maintainer checkpoint. Implementation begins only after its boundary, public API, P/T graph, and evidence scope are approved; then follow [Implementing an Approved Base Semantic Slice](/en/build/prototypes/implementing-an-approved-base-slice/).
+
+## Identify the kind of work first
+
+### Maintain an existing Prototype
+
+When an applicable `P-*` already exists and behavior, tests, exports, CLI, docs, or demos disagree with it, follow [Maintaining an Existing Prototype](/en/build/prototypes/maintaining-an-existing-prototype/).
+
+### Compose existing capabilities
+
+When the goal is to compose existing components or Prototypes into a higher-level experience, that composition normally belongs to the host, framework, or compiler layer. `K-PROTOTYPE-COMPOSITION-0001` states that the core template language does not provide prototype-to-prototype composition.
+
+Do not create a Base identity merely to obtain a convenient directory name or composition entry point.
+
+### Project a design language
+
+When Base already owns state, events, focus, accessibility, or context semantics, and the change is mainly:
+
+- variants, sizes, or visual anatomy;
+- style tokens and rules;
+- an upstream design-system compatibility boundary; or
+- an explicit visual or API delta;
+
+the subject is more likely a Base projection or styled-only Prototype. See [Projecting Base into a Design Language](/en/build/prototypes/projecting-base-into-a-design-language/) for the complete workflow.
+
+### Propose a new Base semantic subject
+
+A subject merits a proposal only when it owns an independent, testable, cross-host-stable information path:
+
+- input facts and their owner are explicit;
+- observable outputs and synchronization rules are explicit;
+- existing Base protocols or composition cannot express it without loss;
+- visual, business, layout, Form, and announcement responsibilities outside its ownership are explicit negative boundaries; and
+- every retained criterion can map to substantive executable evidence.
+
+A familiar component name, a directory in a popular design system, or a styled library's desire for an inheritance point is not Base-admission evidence.
+
+## What `asHook` can solve—and what it cannot prove
+
+An `asHook` is an authoring entry for a particular protocol. It is not a universal requirement to extract a hook whenever reuse seems possible.
+
+`P-BASE-BUTTON` catalogs `base-button` and `asButton` as two authoring entries of the same Button protocol; the [Button source](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/button/button.proto.ts) makes both share `setupButton`. In contrast, `P-SHADCN-BUTTON` explicitly has a direct entry and no additional authored asHook.
+
+Therefore:
+
+- confirm that an existing protocol-specific asHook belongs to the applicable P entity before using it;
+- do not use a hook such as `asButton` as generic behavior substrate for another Base protocol;
+- do not add an empty asHook merely for file or API symmetry; and
+- let the entity boundary and real authoring surface decide whether direct and authored-asHook entries both exist.
+
+## A practical decision line
+
+Before writing code, answer these questions in order:
+
+1. Is there an applicable P/T graph that makes this maintenance?
+2. Is this host- or framework-level composition?
+3. Is this only a design-language delta over existing Base semantics?
+4. If it is a new Base subject, has the issue recorded a maintainer checkpoint?
+5. Are lifecycle, criteria, relations, sources, and evidence explicit?
+
+Until the first four steps are resolved, do not start by creating a Prototype file.
+
+## Lifecycle note
+
+`P-BASE-BUTTON` and `P-SHADCN-BUTTON`, referenced here, are currently `draft`. They describe the current cataloged direction and must not be presented as stable protocol guarantees merely because their packages were published in 0.2.0.
+
+## Next
+
+- To understand the structure of a leaf authoring entry, read [Writing a Custom Primitive Prototype](/en/build/prototypes/writing-a-custom-primitive-prototype/)
+- For an approved compound boundary, read [Writing a Compound Prototype](/en/build/prototypes/writing-a-compound-prototype/)
+- For a new design language, read [Building a Styled Library on Top of Base](/en/build/prototypes/building-a-styled-library-on-top-of-base/)

--- a/apps/www/src/content/docs/en/build/prototypes/writing-a-compound-prototype.md
+++ b/apps/www/src/content/docs/en/build/prototypes/writing-a-compound-prototype.md
@@ -1,0 +1,86 @@
+---
+title: 'Writing a Compound Prototype'
+description: 'Model anatomy, ownership, context, and part responsibilities inside an approved boundary.'
+---
+
+A compound Prototype is not a large component split into more files. It begins as a set of approved protocol subjects, owners, and structural relations; source organization follows.
+
+> This guide explains compound modeling. A new Base family still requires a proposal and maintainer checkpoint; implementation follows [Implementing an Approved Base Semantic Slice](/en/build/prototypes/implementing-an-approved-base-slice/).
+
+## Read the P/T graph before splitting DOM
+
+Tabs is a representative current example. Inspect at least:
+
+- `P-BASE-TABS` and its Root-owned selection criteria;
+- `P-BASE-TABS-LIST`, `P-BASE-TABS-TRIGGER`, `P-BASE-TABS-CONTENT`, and `P-BASE-TABS-INDICATOR`;
+- the corresponding `T-BASE-TABS-*` entities and executable mappings;
+- [shared.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/shared.ts) and the `*.proto.ts` implementations; and
+- `packages/prototypes/base/test/tabs.test.ts`.
+
+These P entities are currently `draft`, so the example describes the current cataloged direction—not a stable guarantee created automatically by the 0.2.0 package version.
+
+## Tabs anatomy currently has five roles
+
+The canonical anatomy in `P-BASE-TABS` defines:
+
+| Role | Cardinality | Current responsibility |
+| --- | --- | --- |
+| `root` | `1..1` | selected-value owner, context provider, and anatomy-domain anchor |
+| `list` | `0..1` | trigger collection and roving-focus owner |
+| `trigger` | `0..*` | requests selection using its own value |
+| `content` | `0..*` | projects tabpanel visibility and presence from its value |
+| `indicator` | `0..*` | context-driven visual consumer with no selection, focus, or event ownership |
+
+The former four-part list omitted Indicator and no longer represents the current family.
+
+Anatomy declares roles, cardinality, and `contains` relations. It does not create parts or inject behavior. Each concrete Prototype claims its role through `def.anatomy.claim()`.
+
+## Split ownership by responsibility
+
+A sound compound boundary answers who owns each information path rather than following DOM regions:
+
+- Root owns selected value, controlled/uncontrolled coordination, and context publication.
+- List owns collection ordering and roving focus.
+- Trigger reads shared context and issues selection requests.
+- Content derives current, hidden, and presence behavior from protocol value.
+- Indicator consumes context facts without becoming a second selection owner.
+
+Return to modeling if all state remains in Root while Parts are only named visual shells, or if a Part without an independent responsibility becomes a new P identity.
+
+## Context carries shared protocol facts only
+
+`TABS_CONTEXT` currently includes root identity, selected and active value, orientation, activation mode, the controlled fact, and request/validation coordination. It serves family collaboration, not arbitrary transport for:
+
+- host DOM or framework objects;
+- private visual tokens;
+- page business state; or
+- Form, layout, or announcement responsibilities outside Tabs.
+
+Applicable P criteria and tests must constrain context fields and owners; convenience alone is not enough.
+
+## Compound does not mean prototype-level template composition
+
+`K-PROTOTYPE-COMPOSITION-0001` states that core templates describe structure inside one Root Node and do not directly nest another Prototype. Component composition belongs to the host, framework, or compiler layer.
+
+An anatomy family, context coordination, and application-level component composition are therefore different concerns. Do not collapse them into one “compound component syntax.”
+
+## Close implementation and evidence together
+
+Every new or changed role or criterion should form this chain:
+
+```text
+P criterion
+→ anchored T case
+→ owner or part implementation
+→ focused family test
+→ Adapter and accessibility evidence
+→ exports, CLI, docs, demo
+```
+
+Typical boundaries include controlled requests, disabled items, empty or duplicate values, structural churn, presence, focus, accessibility relationships, and teardown. The approved issue decides the exact scope.
+
+## Next
+
+- To add a design language over an existing Base family, read [Building a Styled Library on Top of Base](/en/build/prototypes/building-a-styled-library-on-top-of-base/)
+- To follow entities and evidence into source, read [How to Read Reference Implementations](/en/build/prototypes/reference-patterns/)
+- Before opening a pull request, use the [Prototype Author Checklist](/en/build/prototypes/checklist/)

--- a/apps/www/src/content/docs/en/build/prototypes/writing-a-custom-primitive-prototype.md
+++ b/apps/www/src/content/docs/en/build/prototypes/writing-a-custom-primitive-prototype.md
@@ -1,0 +1,92 @@
+---
+title: 'Writing a Custom Primitive Prototype'
+description: 'Understand the minimal shape of direct and authored-asHook entries inside an approved boundary.'
+---
+
+A leaf Prototype represents a protocol subject with a clear boundary and an independent information-flow responsibility. Button and Toggle are two relatively clear current examples.
+
+> This guide explains authoring structure; it does not approve a new Base identity. Before implementing a new Base subject, complete a maintainer checkpoint and follow the delivery workflow in [Implementing an Approved Base Semantic Slice](/en/build/prototypes/implementing-an-approved-base-slice/).
+
+## Start from entities and evidence
+
+Do not begin by copying source. For Button, read in this order:
+
+1. lifecycle, criteria, relations, and sources in `P-BASE-BUTTON`;
+2. cases and executable mappings in `T-BASE-BUTTON-0001`;
+3. [packages/prototypes/base/src/button/button.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/button/button.proto.ts);
+4. `packages/prototypes/base/test/as-button.test.ts` and applicable Adapter evidence; and
+5. package exports, CLI, documentation, and demos.
+
+`P-BASE-BUTTON` is currently `draft`. Source is implementation evidence, not authority above the applicable entity.
+
+## What `base-button` demonstrates
+
+Button has two official authoring entries:
+
+- the `base-button` direct Prototype; and
+- the `asButton` authored asHook.
+
+They share `setupButton(def)` instead of maintaining two versions of Button semantics. That arrangement realizes `P-BASE-BUTTON-AUTHORING-ENTRIES`; it is not a fixed template that every Prototype must copy.
+
+The current implementation includes:
+
+- `def.props.define()` for `disabled`;
+- `def.state.bool()` for states such as `disabled`, `hovered`, and `pressed`;
+- `asFocusable()` for `focused`, `focusVisible`, and the focus method;
+- `def.event.on()` for pointer routes and `press.commit`;
+- `def.expose.state()`, `def.expose.method()`, and `def.expose.event()` for outward surfaces; and
+- `def.a11y.*` for Button role, name, state, and action.
+
+The former `def.state.fromInteraction()` example no longer describes the current Button implementation and must not be used as the example for this guide.
+
+## The boundary between `def` and `run`
+
+`def` declares the setup-time plan: props, state, events, exposes, accessibility, rules, and lifecycle hooks. `run` appears inside runtime callbacks and provides access to current props, context, lifecycle, and outward effects.
+
+For example:
+
+```ts
+def.event.on('press.commit', (run) => {
+  if (disabled.get()) return;
+  run.expose.emit('click');
+});
+```
+
+The event route is registered during setup; the outward signal is emitted through `run` when the event occurs.
+
+## When to provide an authored asHook
+
+Do not treat “exports a Prototype but no asHook” as a universal error. Ask:
+
+- Does the applicable P catalog direct and authored-asHook forms as two entries of one protocol?
+- Should both entries share the complete protocol surface and implementation?
+- Does the hook serve only its owning protocol rather than becoming cross-Prototype substrate?
+- Would the entry introduce ungoverned options, merge, or configure semantics?
+
+`D-PROTOTYPE-ENTITY-NAMING-0001` requires existing entries for one protocol to be cataloged in the same P entity; it does not require every direct Prototype to generate an asHook. `D-AS-HOOK-CONFIGURABLE-AUTHORED-0001` also keeps ordinary configurable authored asHooks in governed future design space.
+
+## What completes a leaf slice
+
+A source file is only one part of delivery. An approved new leaf Prototype normally needs:
+
+```text
+approved checkpoint
+→ P criteria and relations
+→ T cases and executable tests
+→ implementation and public exports
+→ CLI facade generation
+→ bilingual docs and real public-package demo
+→ applicable WC / React / Vue evidence
+```
+
+The three current Adapter previews verify one Web host profile; they do not automatically prove multi-host conformance.
+
+## When to pause
+
+If implementation needs a new public prop/event/state, changes ownership, requires a raw host object, or exposes a contradiction between P/T and implementation, return to the issue for a checkpoint instead of widening the boundary in source.
+
+## Next
+
+- For a compound family, read [Writing a Compound Prototype](/en/build/prototypes/writing-a-compound-prototype/)
+- For a design-language projection, read [Building a Styled Library on Top of Base](/en/build/prototypes/building-a-styled-library-on-top-of-base/)
+- Before opening a pull request, use the [Prototype Author Checklist](/en/build/prototypes/checklist/)

--- a/apps/www/src/content/docs/zh-cn/build/prototypes/building-a-styled-library-on-top-of-base.md
+++ b/apps/www/src/content/docs/zh-cn/build/prototypes/building-a-styled-library-on-top-of-base.md
@@ -1,151 +1,79 @@
 ---
 title: '基于 Base 长出一个带风格的原型库'
-description: '当你想做新的表现层，而不是新的交互边界时，该怎样复用 Base。'
+description: '理解 Base projection、styled-only identity 与设计语言 delta。'
 ---
 
-> 这篇解释风格库的设计思路。准备向 Proto UI 仓库提交完整投射时，请使用[从 Base 投射风格化 Prototype](/zh-cn/build/prototypes/projecting-base-into-a-design-language/)中的 P/T、来源、测试、导出、Demo 和验证流程。
+这篇是设计思路导论。准备提交完整投射时，请直接使用[从 Base 投射风格化 Prototype](/zh-cn/build/prototypes/projecting-base-into-a-design-language/)中的 P/T、provenance、测试、导出、CLI、Demo 和验证流程。
 
-有时候你想做的并不是新的交互，而是新的表现。
+## 先判断是 projection 还是 styled-only
 
-这时最重要的判断不是“要不要新写原型”，而是：
+### Base projection
 
-> 这是不是应该建立在现有 `base` 原型之上，而不是重新发明交互语义？
+当 Base 已拥有 state、events、focus、a11y、context 或 positioning protocol 时，derived P 通过 `inherits.prototypes` 连接 Base，并在实现中消费对应 asHook。derived layer 只增加已编目的设计语言 delta，不建立第二个语义 owner。
 
-如果答案是“是”，那你更像是在写一个带风格的原型库，而不是在写新的基础原型。
+### Styled-only
 
-## 为什么风格库不应该从零重写交互？
+如果对象只拥有设计语言 props、视觉规则、内容模型或 visual anatomy，又没有独立 Base 信息通路，它可以成为 formal styled-only P。不要为了获得继承入口而创建空 Base identity。
 
-`base` 库的职责，是把更稳定、更可复用的交互语义先收敛下来。  
-如果你做的是另一套视觉风格、另一套设计语言，通常真正变化的是：
+Base admission 需要独立、跨宿主、可测试的 input-fact-to-observable-output path；组件目录名或流行设计系统中的同名对象并不是证据。
 
-- token
-- variant
-- size
-- part 的呈现方式
-- 某些 style rule
+## Shadcn Button 的当前形状
 
-而不是：
+`P-SHADCN-BUTTON` 当前声明一个 direct Prototype：
 
-- 组件与用户之间的基本 event
-- 组件的核心 state
-- 组件的基础 expose 能力
+- 通过 `inherits.prototypes` 指向 `P-BASE-BUTTON`；
+- 在 [button.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/shadcn/src/button/button.proto.ts) 中调用 `asButton()`；
+- 增加六种 `variant`、四种 `size` 与 visual tokens；
+- 根据 inherited `hovered`、`focusVisible`、`pressed`、`disabled` 和 `colorScheme` meta 投射视觉规则；
+- 明确不提供上游 `asChild`，并把其他 parity 差异留在 compatibility open question；
+- 本层不额外提供 authored asHook。
 
-因此，更自然的路径通常是：
+旧指南曾把 `invalid` 与 `expanded` 写成当前 Shadcn Button rule 输入；当前实现和 passing P criteria 并没有这项保证，不能继续这样描述。
 
-- 先复用 `base` 的 `asHook`
-- 再叠加库级 props、feedback、rule 和 anatomy 组织
+`P-BASE-BUTTON` 与 `P-SHADCN-BUTTON` 目前均为 `draft`。npm 0.2.0 的发布状态不会自动把这些实体提升为 active。
 
-## `shadcn` 是怎样长在 `base` 之上的？
+## Derived P 应该写什么
 
-当前仓库里最直接的例子，就是 `@proto.ui/prototypes-shadcn`。
+一个可审查的设计语言 P 应聚焦 delta：
 
-### `button`
+- 精确 upstream repository、path、revision 与 provenance；
+- `inherits.prototypes` 或 styled-only classification；
+- variants、sizes、tokens、visual anatomy 与 compatibility boundary；
+- 明确的 setup-time negative patch 及其替代语义；
+- 当前不支持的 upstream API；
+- substantive `T-*` evidence 与真实 source paths。
 
-在 [packages/prototypes/shadcn/src/button/button.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/shadcn/src/button/button.proto.ts) 里，`shadcn-button` 不是从零处理 button 交互，而是先：
+不要复制所有 Base criteria，也不要承诺尚未实现的 upstream parity。
 
-```ts
-asButton();
-```
+## 实现应怎样复用 Base
 
-然后再补：
+通常先调用 owning Base asHook，再增加：
 
-- `variant`
-- `size`
-- `feedback.style`
-- 基于 `hovered / pressed / focusVisible / invalid / expanded` 的 `rule`
+- design-language props；
+- `feedback.style` tokens；
+- 基于 Base state 或 meta 的 rules；
+- 必要且已编目的 visual anatomy；
+- derived types 与 public entries。
 
-这说明 `shadcn-button` 的主要工作不是重新定义交互，而是把一组稳定的视觉与库级 API 长在共享行为之上。
+如果实现重新持有 Base value、event request、focus、a11y、dismissal 或 positioning，就应暂停并返回 Issue，而不是让 style layer 成为第二套语义真相。
 
-### `switch`
+## 负向补丁与兼容边界
 
-在 [packages/prototypes/shadcn/src/switch/root.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/shadcn/src/switch/root.proto.ts) 里，`shadcn-switch-root` 同样是先：
+Derived Prototype 可以在 setup 期放弃或替换某项 inherited guarantee，但必须在自己的 P criterion 中明确：
 
-```ts
-asSwitchRoot();
-```
+- 放弃了哪项 Base capability；
+- 用什么语义替代；
+- 对外兼容影响是什么；
+- 哪些 absence assertions 防止能力悄悄回来。
 
-然后围绕：
+Runtime flag 不能伪装成 setup-time negative patch。
 
-- `checked`
-- `hovered`
-- `pressed`
-- `focusVisible`
-- `disabled`
+## Host 与 Adapter 表述
 
-去补样式 token 和 dark-mode 相关 rule。
-
-### `tabs`
-
-在 [packages/prototypes/shadcn/src/tabs/root.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/shadcn/src/tabs/root.proto.ts) 里，`shadcn-tabs-root` 更极端，它几乎就是：
-
-```ts
-asTabsRoot();
-def.feedback.style.use(...)
-```
-
-这说明当 base 边界已经足够稳时，风格库的工作量可以主要集中在表现层。
-
-## 写风格库时最该理解什么？
-
-### 1. `asHook` 的返回值和语义来源
-
-你不一定总是直接消费返回值，但你必须知道：
-
-- 自己复用的是哪段交互骨架
-- 它已经暴露了哪些 state / expose
-- 你后续的 rule 是建立在哪些共享语义之上
-
-### 2. `anatomy`
-
-一旦是复合组件，风格库往往不只是给 root 上色。  
-你需要知道哪些 part 存在、它们如何组合、哪些状态属于哪个 part。
-
-### 3. `feedback style token`
-
-在当前 Proto UI 里，这通常是风格层最直接的表达手段。  
-像 `shadcn-button` 里的 `BUTTON_BASE_TOKENS`、`VARIANT_TOKENS`、`SIZE_TOKENS` 就是典型做法。
-
-### 4. `rule`
-
-`rule` 的价值不只是“根据状态加点样式”，而是把样式变化仍然建立在协议层状态之上，而不是重新回到宿主私有的 selector 语义里。
-
-例如 `shadcn-button` 并没有把 `hover:*`、`focus-visible:*` 硬编码回宿主伪类，而是根据：
-
-- `hovered`
-- `focusVisible`
-- `pressed`
-- `meta('colorScheme')`
-
-来表达风格变化。
-
-这会让风格层仍然站在 Proto UI 的状态与规则模型里。
-
-## 什么情况下说明你其实不是在写风格库？
-
-如果你发现自己开始大量重新定义：
-
-- 基础 event
-- 核心 state 迁移逻辑
-- 根本性的 context 关系
-- 新的 prototype boundary
-
-那你做的就不再只是“给 base 换皮”，而更像是在定义新的交互对象。
-
-这时应当回退一步，重新判断自己到底是在：
-
-- 长出一个 styled library
-- 还是在发明新的 prototype
-
-## 一个更务实的目标
-
-带风格的原型库不一定追求所有宿主下都出现完全一样的 API。  
-但它至少应该尽量做到：
-
-- 共享同一套交互骨架
-- 在主要宿主中保持足够高的还原度
-- 不把宿主私有实现细节提前写死进 prototype
+当前 Web Component、React 与 Vue 预览共同提供的是一个 Web host profile 的跨 Adapter evidence。设计语言页面可以比较三套 Adapter 的 Web 行为，但不能据此宣称非 Web host conformance 或“所有宿主 API 完全一致”。
 
 ## 下一步
 
-- 如果你想从现有库里挑几个最值得参考的实现，继续读 [参考实现应该怎么看](/zh-cn/build/prototypes/reference-patterns/)
-- 如果你想在动手前先做一次自检，继续读 [原型作者检查清单](/zh-cn/build/prototypes/checklist/)
+- 完整交付流程：读[从 Base 投射风格化 Prototype](/zh-cn/build/prototypes/projecting-base-into-a-design-language/)
+- 选择源码与证据：读[参考实现应该怎么看](/zh-cn/build/prototypes/reference-patterns/)
+- 提交前检查：使用[原型作者检查清单](/zh-cn/build/prototypes/checklist/)

--- a/apps/www/src/content/docs/zh-cn/build/prototypes/checklist.md
+++ b/apps/www/src/content/docs/zh-cn/build/prototypes/checklist.md
@@ -59,11 +59,13 @@ description: '在提交一个新原型或大改动之前，先过一遍这张清
 - unsupported upstream API 和 compatibility boundary 是否明确？
 - 如果对象没有 Base 协议，是否应成为 styled-only，而不是制造空 Base identity？
 
-## 八、别人未来是否还能复用它？
+## 八、Authoring entries 是否与编目协议一致？
 
-- 这段能力是否值得抽成 `asHook`？
-- 暴露出去的 state / method 是否具有稳定意义？
-- 这份实现是否会迫使别人重复写一遍类似逻辑？
+- 适用 P 实体要求 direct Prototype、authored asHook，还是两者都存在？
+- direct 与 authored-asHook entries 表达同一协议时，是否共享实现并记录在同一个 P 实体？
+- 我是否避免了仅为 API 对称增加 asHook？
+- 我是否避免了让一个 protocol-specific authored asHook 成为另一个 Base protocol 的行为 substrate？
+- configurable authored asHook 是否有明确治理契约？
 
 ## 九、官网 Demo 是否代表真实安装体验？
 

--- a/apps/www/src/content/docs/zh-cn/build/prototypes/index.md
+++ b/apps/www/src/content/docs/zh-cn/build/prototypes/index.md
@@ -43,9 +43,10 @@ Base 已经拥有协议，derived P 只增加设计语言 props、tokens、rules
 如果你还没有明确自己是否真的需要新原型：
 
 1. 先读 [为什么你通常不需要新写一个原型？](/zh-cn/build/prototypes/when-not-to-write-a-new-prototype/)
-2. 再读 [编写一个定制的单体原型](/zh-cn/build/prototypes/writing-a-custom-primitive-prototype/)
-3. 然后视需要进入 [编写一个定制的复合原型](/zh-cn/build/prototypes/writing-a-compound-prototype/)
+2. 再用 [编写一个定制的单体原型](/zh-cn/build/prototypes/writing-a-custom-primitive-prototype/) 理解已批准边界内的 leaf authoring entry
+3. 如果获批 subject 是 family，进入 [编写一个定制的复合原型](/zh-cn/build/prototypes/writing-a-compound-prototype/)
 4. 如果你主要想做新的组件风格或 UI 库，再读 [基于 Base 长出一个带风格的原型库](/zh-cn/build/prototypes/building-a-styled-library-on-top-of-base/)
+5. 最后沿 [参考实现应该怎么看](/zh-cn/build/prototypes/reference-patterns/) 从 P/T 实体进入源码与公开投影
 
 ## 当前边界
 

--- a/apps/www/src/content/docs/zh-cn/build/prototypes/reference-patterns.md
+++ b/apps/www/src/content/docs/zh-cn/build/prototypes/reference-patterns.md
@@ -1,92 +1,109 @@
 ---
 title: '参考实现应该怎么看'
-description: '当现有原型库本身就是最好的文档时，应该怎么看它们。'
+description: '从 P/T 实体进入源码、测试、导出与公开投影，而不是把实现当规范。'
 ---
 
-对 Proto UI 原型作者来说，现有原型库往往比单篇文档更有帮助。  
-但“去看代码”本身并不是方法。你还需要知道该看什么。
+现有 Prototype 实现是重要证据，但不是最高权威。一个更稳的阅读顺序是：
 
-## 先看哪一层？
+```text
+applicable P lifecycle and criteria
+→ related decisions / contracts / inheritance
+→ mapped T cases and executable paths
+→ implementation and focused tests
+→ exports, CLI, docs, demo
+```
 
-一个比较稳的顺序通常是：
+如果实现与适用实体冲突，先把它标记为 drift；不要用“仓库现在这样写”静默修改协议含义。
 
-1. 先看 `base`
-2. 再看某个风格库如何复用它
+## 1. 找到适用 P/T
 
-这样你更容易分清：
+可以从名称、ID 或 criterion 搜索：
 
-- 哪些是共享交互骨架
-- 哪些是库层才叠加上去的东西
+```sh
+rg -n "<prototype name|entity id|criterion id>" spec packages/prototypes apps/www internal/records
+```
 
-## 想看单体原型，先看什么？
+先确认：
 
-优先看：
+- P entity 是 `draft`、`active`、deprecated 还是 removed；
+- 哪些 criteria 真正适用于当前问题；
+- direct Prototype、authored asHook 与 parts 如何被编目；
+- `inherits.prototypes`、dependsOn 与 related decisions；
+- T cases 映射到了哪些可执行测试。
 
-- [packages/prototypes/base/src/button/button.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/button/button.proto.ts)
-- [packages/prototypes/base/src/toggle/toggle.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/toggle/toggle.proto.ts)
+旧 contract 与 record 可以解释背景；在已有实体的主题上，它们不能覆盖 spec。
 
-看这些文件时，重点不是逐行抄写 API，而是看：
+## 2. 阅读单体 Prototype
 
-- `setup` 里最先声明了什么
-- `props / state / event / expose` 是如何组织的
-- 是否同时导出了 `asHook`
+Button 是较小的垂直切片：
 
-## 想看复合原型，先看什么？
+- `P-BASE-BUTTON`；
+- `T-BASE-BUTTON-0001`；
+- [button.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/button/button.proto.ts)；
+- `packages/prototypes/base/test/as-button.test.ts`。
 
-优先看 `tabs` 和 `hover-card`：
+重点看 criterion 如何落到 props、state、a11y、event、expose 与 absence guarantees，而不是只记录 API 调用顺序。
 
-- [packages/prototypes/base/src/tabs/shared.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/shared.ts)
-- [packages/prototypes/base/src/tabs/root.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/root.proto.ts)
-- [packages/prototypes/base/src/tabs/trigger.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/trigger.proto.ts)
-- [packages/prototypes/base/src/tabs/content.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/content.proto.ts)
-- [packages/prototypes/base/src/hover-card/root.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/hover-card/root.proto.ts)
+Toggle 可用于比较另一个独立 Base protocol：
 
-重点看：
+- `P-BASE-TOGGLE` 与 `T-BASE-TOGGLE-0001`；
+- [toggle.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/toggle/toggle.proto.ts)。
 
-- family 是怎么定义的
-- context 是怎么提供和订阅的
-- 各 part 的职责是否清楚
+不要因为 Button 与 Toggle 都有 authored asHook，就让一个 protocol 消费另一个 protocol-specific hook。
 
-## 想看“风格如何长出来”，先看什么？
+## 3. 阅读复合 family
 
-优先看：
+Tabs 需要同时阅读 Root 与 Parts：
 
-- [packages/prototypes/shadcn/src/button/button.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/shadcn/src/button/button.proto.ts)
-- [packages/prototypes/shadcn/src/switch/root.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/shadcn/src/switch/root.proto.ts)
-- [packages/prototypes/shadcn/src/tabs/root.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/shadcn/src/tabs/root.proto.ts)
+- `P-BASE-TABS` 及 List、Trigger、Content、Indicator P entities；
+- 对应的 `T-BASE-TABS-*` entities；
+- [shared.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/shared.ts)；
+- [root.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/root.proto.ts)；
+- [list.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/list.proto.ts)；
+- [trigger.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/trigger.proto.ts)；
+- [content.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/content.proto.ts)；
+- [indicator.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/indicator.proto.ts)。
 
-重点看：
+阅读时追踪 owner、context facts、anatomy claims、collection/focus responsibility 与 mapped tests。文件数量本身不能证明边界正确。
 
-- 是否先复用了 `base` 的 `asHook`
-- 库级 props 是如何叠加的
-- style token 和 rule 是如何组织的
-- 哪些地方保留了 Proto UI 的共享语义，而没有退回宿主私有写法
+## 4. 阅读设计语言投射
 
-## 看代码时最容易看错什么？
+Shadcn Button 是 Base projection 的紧凑例子：
 
-### 1. 只看文件数量，不看边界
+- `P-SHADCN-BUTTON` 与 `T-SHADCN-BUTTON-0001`；
+- inherited `P-BASE-BUTTON` criteria；
+- [Shadcn Button source](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/shadcn/src/button/button.proto.ts)；
+- `packages/prototypes/shadcn/test/button.test.ts`。
 
-文件多不代表拆分合理，文件少也不代表边界清楚。  
-关键是每个文件是否对应了稳定的交互责任。
+重点确认：
 
-### 2. 只看样式，不看它依赖的状态来源
+- derived P 只声明 delta；
+- 实现确实调用 owning Base asHook；
+- rules 依赖 inherited protocol states，而不是宿主 selector 成为第二真相；
+- unsupported upstream API 与 absence assertions 有记录；
+- package export、CLI facade、官网 Demo 与 P/T surface 一致。
 
-风格库里的 rule 之所以成立，往往因为它站在共享状态上。  
-不要只看 `tw(...)`，要先看这些 rule 依赖了哪些 `state` 和 `meta`。
+还可以用 Shadcn Switch 和 Tabs 比较不同大小的投射，但每次都应从各自 P/T 开始，而不是机械复制目录结构。
 
-### 3. 把“当前实现这么写”误当成“Proto UI 要求必须这么写”
+## 5. 最后检查公开交付面
 
-现有原型库是重要参考，但不是唯一合法写法。  
-你更应该学习的是：
+源码和测试通过后，继续检查：
 
-- 它为什么这样切边界
-- 为什么这里复用了 `asHook`
-- 为什么这里用 `context`，而不是别的方式
+- package subpath 与 root exports；
+- CLI registry 和 generated facades；
+- component preset / style token closure（如适用）；
+- 双语文档与真实 public-package demo；
+- WC、React、Vue 的 Web evidence；
+- generated workspace 与 Agent projection。
 
-## 最后一个建议
+这一步能区分“实现存在”和“贡献已经形成可消费闭环”。
 
-如果你在读某个实现时，发现自己开始纠结某个局部 API 细节，先退回去问：
+## Lifecycle 提醒
 
-> 这个文件在整个原型里承担什么角色？
+本文列出的 Base Button、Toggle、Tabs 与 Shadcn Button 实体当前均为 `draft`。学习它们的 owner/evidence 结构，不要把当前实现细节扩张为未编目的稳定保证。
 
-Proto UI 的原型实现，比起单个 API 名字，更值得优先理解的是角色分工与边界判断。
+## 延伸阅读
+
+- [维护已有 Prototype](/zh-cn/build/prototypes/maintaining-an-existing-prototype/)
+- [从 Base 投射风格化 Prototype](/zh-cn/build/prototypes/projecting-base-into-a-design-language/)
+- [实现已批准的 Base Semantic Slice](/zh-cn/build/prototypes/implementing-an-approved-base-slice/)

--- a/apps/www/src/content/docs/zh-cn/build/prototypes/when-not-to-write-a-new-prototype.md
+++ b/apps/www/src/content/docs/zh-cn/build/prototypes/when-not-to-write-a-new-prototype.md
@@ -1,99 +1,80 @@
 ---
 title: '为什么你通常不需要新写一个原型？'
-description: 'Proto UI 原型作者最先需要建立的边界判断。'
+description: '先区分维护、组合、设计语言投射与新的 Base semantic subject。'
 ---
 
-Proto UI 提供了原型语法，不代表你应该频繁新写原型。  
-恰恰相反，大多数时候更合理的判断是：
+Proto UI 提供 Prototype authoring API，不代表贡献者应该频繁增加新的协议身份。更稳妥的起点是：
 
-> 先不要写新的原型，先确认现有原型和 `asHook` 是否已经足够。
+> 先找到适用的 `P-*` / `T-*` 实体，再判断问题属于维护、组合、设计语言投射，还是一个尚待批准的新 Base semantic subject。
 
-## 为什么这是第一步？
+这是一篇边界判断指南，不是新 Prototype 的实施授权。新的 Base subject 必须先经过 proposal 和 maintainer checkpoint；只有边界、公共 API、P/T 图与证据范围获批后，才进入[实现已批准的 Base Semantic Slice](/zh-cn/build/prototypes/implementing-an-approved-base-slice/)。
 
-Proto UI 里的原型，不只是一个方便组织代码的壳。  
-它代表的是一个独立的交互主体，以及一组会长期被维护、被适配、被验证的协议边界。
+## 先确认你面对的是哪类工作
 
-一旦你定义了新的原型，后面通常还会跟着这些成本：
+### 维护已有 Prototype
 
-- 需要明确它的交互边界
-- 需要考虑它进入不同宿主后的承接方式
-- 需要决定它是否值得进入某个原型库
-- 需要逐步补上文档、契约和测试
+如果适用的 `P-*` 已经存在，而问题是行为、测试、导出、CLI、文档或 Demo 与实体不一致，应走[维护已有 Prototype](/zh-cn/build/prototypes/maintaining-an-existing-prototype/)。
 
-如果这件事其实只是“把现有能力重新拼一下”，那直接新写原型通常是在过早发明抽象。
+### 组合已有能力
 
-## 优先判断：你是不是其实想要 `asHook`
+如果目标只是把现有组件或 Prototype 组合成更高层体验，组合通常属于宿主、框架或编译层。`K-PROTOTYPE-COMPOSITION-0001` 明确指出，core template language 不提供 prototype-to-prototype composition。
 
-在当前 Proto UI 里，更常见的需求不是“发明新的交互对象”，而是：
+不要为了获得一个方便的目录名或组合入口而制造新的 Base identity。
 
-- 想复用已有原型中的一部分逻辑
-- 想取消某一段默认行为
-- 想保留同样的交互语义，但在更高层做不同组织
-- 想基于现有原型长出新的风格或新的库
+### 投射设计语言
 
-这类需求更适合优先考虑 `asHook`。
+如果 Base 已经拥有 state、event、focus、a11y 或 context 语义，而变化主要是：
 
-以 [packages/prototypes/base/src/button/button.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/button/button.proto.ts) 为例，同一套 `setupButton` 同时被导出为：
+- variant、size 或视觉 anatomy；
+- style token 与 rule；
+- 上游设计系统兼容边界；
+- 明确的视觉或 API 增量；
 
-- `asButton`
-- `base-button`
+那么它更可能是 Base projection 或 styled-only Prototype。完整流程见[从 Base 投射风格化 Prototype](/zh-cn/build/prototypes/projecting-base-into-a-design-language/)。
 
-这说明 `asHook` 在 Proto UI 里不是“附加辅助函数”，而是原型能力的一种可重组入口。
+### 提议新的 Base semantic subject
 
-## 什么情况下写新原型是在造轮子？
+只有在对象拥有独立、可测试、跨宿主稳定的信息通路时，才值得进入 proposal：
 
-下面这些情况，通常都还没有到“必须新写原型”的程度：
+- 输入事实与 owner 明确；
+- observable output 与同步规则明确；
+- 现有 Base protocol 或 composition 无法无损表达；
+- 不拥有的视觉、业务、布局、Form 或 announcement 责任有清楚的负向边界；
+- 每项保留的准则都能映射到 substantive executable evidence。
 
-- 你只是想换一套样式
-- 你只是想删掉或替换现有逻辑中的某一段
-- 你只是想在现有原型之上组合出一个更高层的 API
-- 你只是想把已有交互迁移进另一套设计语言
+熟悉的组件名、某个设计系统已有同名目录，或 styled library 想要继承点，都不是 Base admission 证据。
 
-这类需求更像是在：
+## `asHook` 能解决什么，不能证明什么
 
-- 复用 `asHook`
-- 在库层重新组织 anatomy
-- 用 `feedback` 和 `rule` 补风格表达
+`asHook` 是某个 protocol 的 authoring entry，而不是“需要复用时就自动抽一个”的通用要求。
 
-而不是在发明新的交互边界。
+`P-BASE-BUTTON` 把 `base-button` 与 `asButton` 编目为同一 Button protocol 的两个 authoring entries；[Button 源码](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/button/button.proto.ts)让两者共享 `setupButton`。与此同时，`P-SHADCN-BUTTON` 明确只有 direct entry，不额外提供 authored asHook。
 
-`shadcn-button` 就是一个很直接的例子。  
-它并没有重新发明 Button 的交互语义，而是在 [packages/prototypes/shadcn/src/button/button.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/shadcn/src/button/button.proto.ts) 中先调用 `asButton()`，再叠加：
+因此：
 
-- `variant` / `size` 这类库级 props
-- 样式 token
-- 基于状态与 meta 的 rule
+- 使用现有 protocol-specific asHook 时，先确认它确实属于适用 P 实体；
+- 不要把 `asButton` 之类的协议钩子当成其他 Base protocol 的通用行为 substrate；
+- 不要仅为了文件或 API 对称增加空 asHook；
+- direct prototype 与 authored asHook 是否同时存在，由实体边界和真实 authoring surface 决定。
 
-这是一种“在 base 上长风格”的写法，而不是重新定义一个新的底层 button 交互原型。
+## 一条可执行的判断线
 
-## 什么情况下才值得认真考虑新原型？
+在写代码前依次回答：
 
-通常至少要满足下面一类情况：
+1. 是否已有适用的 P/T，可以按 maintenance 处理？
+2. 是否只是宿主或框架层的 composition？
+3. 是否只是已有 Base 语义上的 design-language delta？
+4. 如果真是新 Base subject，Issue 是否已经记录 maintainer checkpoint？
+5. lifecycle、criteria、relations、sources 与 evidence 是否都已经明确？
 
-- 你引入了新的交互媒介，现有原型没有可复用的边界
-- 你在做一个确实不同于现有原型的新组件类型
-- 你发现现有 `asHook` 组合后仍然无法表达该组件的核心交互责任
-- 你遇到的不是“风格差异”，而是“交互主体已经不同”
+前四步没有走完，就不应从“先建一个原型文件”开始。
 
-这时你真正需要问的不是“能不能写”，而是：
+## Lifecycle 提醒
 
-> 这个对象是否已经构成一个新的 `Prototype Boundary`？
-
-这正是白皮书 [原型边界](/zh-cn/whitepaper/prototype-boundary/) 那篇要你先建立的判断。
-
-## 一条更实用的判断线
-
-在决定是否新写原型之前，先依次问自己：
-
-1. 我是否只是想换风格？
-2. 我是否只是想改写现有交互的一部分？
-3. 现有 `asHook` 是否已经可以组合出我要的行为？
-4. 我面对的是否真的是一个新的交互主体，而不是旧主体的另一种实现？
-
-如果前 3 个问题里有一个答案是“是”，那大概率还不该新写原型。
+本文引用的 `P-BASE-BUTTON` 与 `P-SHADCN-BUTTON` 当前均为 `draft`。它们描述当前编目方向，不应仅因相关包已经发布 0.2.0 就被写成稳定协议保证。
 
 ## 下一步
 
-- 如果你已经确认自己面对的是一个新的基础交互对象，继续读 [编写一个定制的单体原型](/zh-cn/build/prototypes/writing-a-custom-primitive-prototype/)
-- 如果你面对的是复合组件，继续读 [编写一个定制的复合原型](/zh-cn/build/prototypes/writing-a-compound-prototype/)
-- 如果你主要想做新的风格库，继续读 [基于 Base 长出一个带风格的原型库](/zh-cn/build/prototypes/building-a-styled-library-on-top-of-base/)
+- 想理解单体 authoring entry 的结构，读[编写一个定制的单体原型](/zh-cn/build/prototypes/writing-a-custom-primitive-prototype/)
+- 已有获批的复合边界，读[编写一个定制的复合原型](/zh-cn/build/prototypes/writing-a-compound-prototype/)
+- 主要目标是新的设计语言，读[基于 Base 长出一个带风格的原型库](/zh-cn/build/prototypes/building-a-styled-library-on-top-of-base/)

--- a/apps/www/src/content/docs/zh-cn/build/prototypes/writing-a-compound-prototype.md
+++ b/apps/www/src/content/docs/zh-cn/build/prototypes/writing-a-compound-prototype.md
@@ -1,155 +1,86 @@
 ---
 title: '编写一个定制的复合原型'
-description: '如何按 Proto UI 的原型边界拆分复合组件。'
+description: '在已批准边界内建模 anatomy、owner、context 与 part responsibilities。'
 ---
 
-复合原型不是“单体原型写大一点”。  
-它真正困难的地方，不在语法量，而在边界判断。
+复合 Prototype 不是“把一个大组件拆成更多文件”。它首先是一组经过批准的 protocol subjects、owners 与结构关系，然后才是源码组织。
 
-白皮书 [原型边界](/zh-cn/whitepaper/prototype-boundary/) 里已经给出了一个核心原则：
+> 本文解释 compound modeling。新的 Base family 仍需 proposal 与 maintainer checkpoint；实现阶段使用[实现已批准的 Base Semantic Slice](/zh-cn/build/prototypes/implementing-an-approved-base-slice/)。
 
-> 看一个子结构是否开始承担独立的信息通路责任。
+## 先读 P/T 图，而不是先拆 DOM
 
-这一篇讨论的就是：  
-当你已经确认自己面对的是复合组件时，代码层面该怎样把这条边界落下来。
+Tabs 是当前仓库里的代表性例子。开始前至少检查：
 
-## 什么时候该把它当成复合原型？
+- `P-BASE-TABS` 及 Root-owned selection criteria；
+- `P-BASE-TABS-LIST`、`P-BASE-TABS-TRIGGER`、`P-BASE-TABS-CONTENT` 与 `P-BASE-TABS-INDICATOR`；
+- 对应的 `T-BASE-TABS-*` 实体与 executable mappings；
+- [shared.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/shared.ts) 和各 `*.proto.ts` 实现；
+- `packages/prototypes/base/test/tabs.test.ts`。
 
-比较典型的信号包括：
+这些 P 实体当前都是 `draft`，所以示例表达的是当前编目方向，而不是由 0.2.0 包版本自动产生的稳定保证。
 
-- 组件天然由多个 part 组成
-- 不同 part 之间需要共享状态或上下文
-- 至少有一部分子结构已经不是“纯内部 DOM”，而是独立承担交互责任
+## Tabs anatomy 当前包含五个 roles
 
-`tabs` 是当前仓库里最典型的例子。  
-在 `base` 里它被拆成：
+`P-BASE-TABS` 的 canonical anatomy 定义：
 
-- `root`
-- `list`
-- `trigger`
-- `content`
+| Role        | Cardinality | 当前责任                                                         |
+| ----------- | ----------- | ---------------------------------------------------------------- |
+| `root`      | `1..1`      | selected value owner、context provider 与 anatomy domain anchor  |
+| `list`      | `0..1`      | trigger collection 与 roving-focus owner                         |
+| `trigger`   | `0..*`      | 使用自身 value 请求 selection                                    |
+| `content`   | `0..*`      | 按 value 投射 tabpanel visibility/presence                       |
+| `indicator` | `0..*`      | context-driven visual consumer，不拥有 selection、focus 或 event |
 
-对应文件见：
+旧的四-part 列表遗漏了 Indicator，不能再代表当前 family。
 
-- [packages/prototypes/base/src/tabs/root.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/root.proto.ts)
-- [packages/prototypes/base/src/tabs/list.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/list.proto.ts)
-- [packages/prototypes/base/src/tabs/trigger.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/trigger.proto.ts)
-- [packages/prototypes/base/src/tabs/content.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/content.proto.ts)
+Anatomy 只声明 roles、cardinality 与 `contains` relations；它不会创建 parts，也不会注入行为。源码中的 `def.anatomy.claim()` 让具体 Prototype 声明自己承担哪个 role。
 
-## 复合原型不是先拆文件，而是先拆交互主体
+## 按责任划分 owner
 
-很多框架里，复合组件的第一反应是：
+好的 compound boundary 不是按 DOM 区域切，而是回答每条信息通路由谁拥有：
 
-- 先按 DOM 区域拆
-- 先按视觉区域拆
-- 先按开发方便拆
+- Root 拥有 selected value、controlled/uncontrolled 协调与 context publication；
+- List 拥有 collection ordering 和 roving focus；
+- Trigger 读取 shared context，并发出 selection request；
+- Content 根据 protocol value 管理 current、hidden 与 presence；
+- Indicator 只消费 context facts，不成为第二个 selection owner。
 
-Proto UI 更关心的是：  
-谁已经形成了独立交互责任。
+如果所有状态仍集中在 Root，而 Parts 只是有名字的视觉壳，或者某个 Part 没有独立责任却被建成新 P identity，都应该返回建模阶段。
 
-在 `tabs` 里：
+## Context 只承接共享 protocol facts
 
-- `trigger` 会接收输入并影响 value
-- `content` 会根据当前选中值切换自己的可见状态
-- `list` 会承担焦点移动与 focus group
-- `root` 则维护共享的上下文与整体状态
+`TABS_CONTEXT` 当前包含 root identity、selected/active value、orientation、activation mode、controlled fact 与 request/validation coordination。它用于 family 内部协作，不应该成为随手放入以下内容的容器：
 
-这就不是“视觉切块”能解释的了，而是多个交互主体在共同组成一个 family。
+- 宿主 DOM 或 framework object；
+- 私有视觉 token；
+- 页面业务状态；
+- 不属于 Tabs 的 Form、layout 或 announcement 责任。
 
-## `anatomy` 的作用是什么？
+Context 的字段和 owner 必须由 applicable P criteria 与测试约束，而不是仅因为传值方便。
 
-在 Proto UI 里，复合原型不是一堆松散 part 的约定俗成，而是显式的 anatomy family。
+## Compound 不等于 prototype-level template composition
 
-在 [packages/prototypes/base/src/tabs/shared.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/tabs/shared.ts) 里，`TABS_FAMILY` 定义了：
+`K-PROTOTYPE-COMPOSITION-0001` 明确：core template 描述一个 Root Node 内部结构，不直接嵌套另一个 Prototype。组件间组合发生在宿主、框架或编译层。
 
-- 有哪些 role
-- 每个 role 的 cardinality
-- 哪些 role 之间允许存在 `contains` 关系
+因此 anatomy family、context coordination 与应用层 component composition 是三件不同的事，不应混成一个“复合组件语法”。
 
-这意味着 anatomy 在 Proto UI 里不只是“给 part 起名字”，而是：
+## 实现与验证闭环
 
-- 定义 family 的结构约束
-- 给 part 之间的协作提供稳定身份
-- 让原型作者和 adapter 作者都能知道“谁是谁”
+每个新增或变化的 role/criterion 都应形成：
 
-如果你在写复合原型，通常应该尽早判断：
+```text
+P criterion
+→ anchored T case
+→ owner or part implementation
+→ focused family test
+→ Adapter and accessibility evidence
+→ exports, CLI, docs, demo
+```
 
-- 这个 family 有哪些 part
-- 哪些 part 是必须存在的
-- 哪些 part 是可选的
-- part 之间是否有明确的结构关系
-
-## `context` 在复合原型里通常承担什么？
-
-`context` 在复合原型里最常见的职责，不是“偷懒传值”，而是承接 family 内部共享的交互语义。
-
-在 `tabs/root.ts` 里，`root` 通过 `def.context.provide(TABS_CONTEXT, ...)` 提供：
-
-- 当前值
-- orientation
-- activationMode
-- 是否 controlled
-
-而 `trigger` 与 `content` 再各自订阅它。  
-这是一种非常典型的复合原型写法：
-
-- `root` 维护共享语义
-- part 订阅上下文并据此工作
-
-如果你发现不同 part 之间需要共享“当前属于谁”的状态、模式或协作环境，通常就该认真考虑 `context` 了。
-
-## 复合原型里常见的拆分模式
-
-### Root
-
-通常承担：
-
-- shared state
-- 共享 props
-- `context.provide`
-- 对整个 family 的 expose
-
-### Part
-
-通常承担：
-
-- 自己那一段局部职责
-- 对共享上下文的订阅
-- 必要时对 anatomy family 的 claim
-
-### Shared
-
-通常放：
-
-- family 定义
-- context key
-- 共享类型
-- 共享工具常量
-
-`tabs/shared.ts` 正是这种角色。
-
-## 什么时候说明你拆错了？
-
-### 1. 某个 part 没有独立交互责任，却被强行拆成原型
-
-这通常会得到一堆“只是多了名字”的 part，而不是更清晰的原型边界。
-
-### 2. 所有状态都还塞在 root，part 只是视觉壳
-
-如果 `trigger`、`content` 这些 part 已经承担独立 event 或 state 责任，却还被写成纯内部结构，边界通常就偏大了。
-
-### 3. `context` 里装了过多宿主细节或风格细节
-
-`context` 更适合放共享交互语义，不适合变成一个随手塞所有信息的大袋子。
-
-## 一个值得注意的现实
-
-复合原型最大的工作量，常常不是“把语法写出来”，而是先把边界想对。  
-如果边界判断没有成立，后面的 `anatomy`、`context` 和 part 组织通常都会越来越乱。
-
-所以在 Proto UI 里，复合原型首先是一项建模工作，其次才是编码工作。
+需要关注 controlled request、disabled item、empty/duplicate value、动态结构、presence、focus、a11y relationship 与 teardown 等边界；具体范围以获批 Issue 为准。
 
 ## 下一步
 
-- 如果你已经有了稳定的 base 交互，只是想长出不同设计风格，继续读 [基于 Base 长出一个带风格的原型库](/zh-cn/build/prototypes/building-a-styled-library-on-top-of-base/)
-- 如果你想先用现有代码建立直觉，继续读 [参考实现应该怎么看](/zh-cn/build/prototypes/reference-patterns/)
+- 已有 Base family，只增加设计语言：读[基于 Base 长出一个带风格的原型库](/zh-cn/build/prototypes/building-a-styled-library-on-top-of-base/)
+- 想沿实体和证据阅读代码：读[参考实现应该怎么看](/zh-cn/build/prototypes/reference-patterns/)
+- 准备提交：使用[原型作者检查清单](/zh-cn/build/prototypes/checklist/)

--- a/apps/www/src/content/docs/zh-cn/build/prototypes/writing-a-custom-primitive-prototype.md
+++ b/apps/www/src/content/docs/zh-cn/build/prototypes/writing-a-custom-primitive-prototype.md
@@ -1,124 +1,92 @@
 ---
 title: '编写一个定制的单体原型'
-description: '从最小结构出发理解 Proto UI 单体原型的写法。'
+description: '在已批准边界内理解 direct Prototype 与 authored asHook 的最小结构。'
 ---
 
-这一篇只讨论最小的、单体的原型。  
-它不讨论复合组件的拆分，也不试图讲完所有能力。
+单体 Prototype 对应一个边界明确、可以独立承担信息通路责任的 protocol subject。Button 与 Toggle 是当前较清楚的例子。
 
-目标只有一个：
+> 本文解释 authoring 结构，不负责批准新的 Base identity。实现新 Base subject 前，必须先完成 maintainer checkpoint，并使用[实现已批准的 Base Semantic Slice](/zh-cn/build/prototypes/implementing-an-approved-base-slice/)所定义的完整交付流程。
 
-> 让你知道一个 Proto UI 原型最小是怎样长出来的。
+## 从实体和证据开始
 
-## 单体原型到底在描述什么？
+不要先复制源码。以 Button 为例，阅读顺序应是：
 
-Proto UI 的单体原型通常对应一个相对完整、边界明确的交互主体。  
-例如 `button`、`toggle`，这类对象通常不需要先拆成多个 part，才能成立。
+1. `P-BASE-BUTTON` 的 lifecycle、criteria、relations 与 sources；
+2. `T-BASE-BUTTON-0001` 的 cases 与 executable mappings；
+3. [packages/prototypes/base/src/button/button.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/button/button.proto.ts)；
+4. `packages/prototypes/base/test/as-button.test.ts` 及相关 Adapter evidence；
+5. package exports、CLI、文档和 Demo。
 
-从白皮书角度讲，它已经是一个能独立承担信息通路责任的对象。  
-从代码角度讲，它通常会体现为：
+当前 `P-BASE-BUTTON` 是 `draft`。源码是当前实现证据，不高于适用实体。
 
-- 一个 `setup(def)` 过程
-- 一组最小 props
-- 几个核心 state
-- 必要的 event / expose
-- 如果需要复用，再导出一个 `asHook`
+## `base-button` 展示了什么
 
-## 一个最小例子：`base-button`
+Button 的两个官方 authoring entries 是：
 
-[packages/prototypes/base/src/button/button.proto.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/button/button.proto.ts) 是当前仓库里最适合作为起点的例子之一。
+- `base-button` direct prototype；
+- `asButton` authored asHook。
 
-它的结构很典型：
+它们共享 `setupButton(def)`，所以不会各自维护一套 Button 语义。这是 `P-BASE-BUTTON-AUTHORING-ENTRIES` 的具体投影，不是每个 Prototype 都必须复制的固定模板。
 
-1. 先定义 `setupButton(def)`
-2. 在里面声明 `props`
-3. 建立内部状态与 exposed state
-4. 绑定事件
-5. 最后同时导出 `asButton` 和 `base-button`
+当前实现的关键结构包括：
 
-这背后的思路是：
+- `def.props.define()` 声明 `disabled`；
+- `def.state.bool()` 建立 `disabled`、`hovered` 与 `pressed` 等状态；
+- `asFocusable()` 提供 `focused`、`focusVisible` 与 focus method；
+- `def.event.on()` 承接 pointer 与 `press.commit`；
+- `def.expose.state()`、`def.expose.method()` 和 `def.expose.event()` 提供 outward surface；
+- `def.a11y.*` 声明 Button 的 role、name、state 与 action。
 
-- 行为先被组织成一段可复用的 setup
-- `asHook` 与 `prototype` 共用同一份核心交互逻辑
+旧的 `def.state.fromInteraction()` 例子已经不代表当前 Button 实现，不应继续作为这篇指南的示例。
 
-## `def` 和 `run` 的分割到底是什么意思？
+## `def` 与 `run` 的边界
 
-Proto UI 里一个很重要的分界是：
+`def` 用于声明 setup-time 计划：props、state、events、exposes、a11y、rules 与 lifecycle hooks。`run` 只在具体 runtime callback 中提供当前 props、context、lifecycle 与 outward effect 入口。
 
-- `def` 负责定义结构、能力和规则
-- `run` 负责在真实执行中读取当前值、更新上下文、发出效果
+例如：
 
-简单理解：
+```ts
+def.event.on('press.commit', (run) => {
+  if (disabled.get()) return;
+  run.expose.emit('click');
+});
+```
 
-- 在 `def` 阶段，你是在说“这个原型允许什么、会有哪些能力、要监听什么”
-- 在 `run` 阶段，你才真正面对某一次实例化后的当前数据
+这里 event route 在 setup 期注册；真正的 outward signal 在事件发生时通过 `run` 发出。
 
-例如在 `base-button` 里：
+## 什么时候提供 authored asHook
 
-- `def.props.define()` 是定义 props 契约
-- `def.state.fromInteraction()` 是声明要使用哪些交互状态
-- `def.event.on('press.commit', (run) => { ... })` 则是在实际事件触发时通过 `run` 处理当前实例
+不要把“只导出 prototype，不导出 asHook”当成通用错误。先问：
 
-如果你把这两层混在一起，通常会很快丢掉 Proto UI 对执行期的基本秩序。
+- applicable P 是否把 direct form 与 authored asHook 记录为同一 protocol 的两个 entries？
+- 两者是否应共享完整协议面与实现？
+- 这个 hook 是否只服务其 owning protocol，而不是被误用为跨 Prototype substrate？
+- 新增 entry 是否会引入未经治理的 options、merge 或 configure 语义？
 
-## 单体原型最小会碰到哪些能力？
+`D-PROTOTYPE-ENTITY-NAMING-0001` 要求同一协议已有的多个 entries 编目在同一个 P 实体；它不要求每个 direct Prototype 自动生成 asHook。`D-AS-HOOK-CONFIGURABLE-AUTHORED-0001` 还将普通 configurable authored asHook 保留为待治理设计空间。
 
-对一个基础单体原型来说，最常见的是下面这几类：
+## 一个完整单体 slice 还需要什么
 
-- `props` 用来承接 Maker 侧的输入，例如 `disabled`
-- `state` 用来保存原型内部需要稳定表达的状态
-- `event` 用来承接用户输入或宿主输入
-- `expose` 用来把状态或方法交还给外部
+源码文件只是交付面的一部分。获批的新单体 Prototype 通常还需要：
 
-`base-button` 就几乎把这一组最小能力都走了一遍：
+```text
+approved checkpoint
+→ P criteria and relations
+→ T cases and executable tests
+→ implementation and public exports
+→ CLI facade generation
+→ bilingual docs and real public-package demo
+→ applicable WC / React / Vue evidence
+```
 
-- 通过 `def.props.define()` 声明 `disabled`
-- 通过 `def.state.fromInteraction()` 建立 `hovered`、`pressed`、`focused`
-- 通过 `def.event.on()` 监听 `pointer.enter`、`press.commit` 等事件
-- 通过 `def.expose.state()` 和 `def.expose.method()` 向外暴露能力
+三套当前 Adapter 预览验证的是一个 Web host profile，不能自动推导为多宿主 conformance。
 
-## `asHook` 在这里是什么角色？
+## 何时暂停
 
-在 Proto UI 里，`asHook` 不是一个次要配件，而是“把一段原型能力拿出来重组”的标准入口。
-
-在 `base-button` 里，`asButton` 与 `base-button` 共用同一份 `setupButton`。  
-这意味着：
-
-- 原型作者可以直接消费 `base-button`
-- 更高层的原型作者也可以只复用 `button` 的交互骨架
-
-因此，当你在写一个新的单体原型时，最好尽早判断：
-
-- 这段逻辑以后是否值得被别的原型复用？
-
-如果答案是“很可能会”，那通常值得像 `base-button` 一样，把共享的 setup 单独整理出来，再同时导出 `asHook` 和 `prototype`。
-
-## 单体原型最常见的误区
-
-### 1. 一开始就试图把所有能力都塞进去
-
-Proto UI 的原型不是“能力越多越完整”。  
-单体原型更适合先围绕一个稳定的交互核心收敛最小能力。
-
-### 2. 把风格表达和交互边界混在一起
-
-如果你还在定义交互主体本身，先不要急着把 design system 的变体、视觉规则也一起塞进来。  
-这类东西更适合在库层长出来。
-
-### 3. 只导出 prototype，不导出 `asHook`
-
-如果你写出来的是一个明显可能被复用的基础能力，却没有提供 `asHook`，后面别人更容易被逼着重新写一遍。
-
-## 什么样的单体原型比较像“写对了”？
-
-你可以先用很现实的标准判断：
-
-- 它描述的是一个独立交互主体，而不是一段局部拼图
-- 它只承诺自己真正应该承诺的能力
-- 它能被更高层原型复用，而不是只能作为最终产物存在
-- 它暂时不依赖某个特定 design system 才成立
+如果实现中需要新增公共 prop/event/state、改变 owner、引入 raw host object，或发现 P/T 与实现互相矛盾，应回到 Issue 请求 checkpoint，而不是在源码里扩张边界。
 
 ## 下一步
 
-- 如果你已经发现自己写的不是单体对象，而是一个复合组件系统，继续读 [编写一个定制的复合原型](/zh-cn/build/prototypes/writing-a-compound-prototype/)
-- 如果你其实想做的是风格库，继续读 [基于 Base 长出一个带风格的原型库](/zh-cn/build/prototypes/building-a-styled-library-on-top-of-base/)
+- 复合 family：读[编写一个定制的复合原型](/zh-cn/build/prototypes/writing-a-compound-prototype/)
+- 设计语言投射：读[基于 Base 长出一个带风格的原型库](/zh-cn/build/prototypes/building-a-styled-library-on-top-of-base/)
+- 提交前：使用[原型作者检查清单](/zh-cn/build/prototypes/checklist/)


### PR DESCRIPTION
## Summary

- rewrite the five Chinese Prototype authoring concept guides around the cataloged P/T graph, entity lifecycle, and maintainer checkpoint
- add matching English routes and remove the temporary locale fallback from the Prototype contribution entry
- update both author checklists and both entry pages so authoring entries, `asHook`, compound parts, and public delivery checks match the current catalog
- correct stale examples for Base Button state authoring, Tabs Indicator ownership, Shadcn Button states, and current Web adapter evidence

## Why

The Prototype authoring material predated the current spec-first governance model and the 0.2 release. Several Chinese guides still presented obsolete APIs or incomplete boundaries, while the corresponding English routes did not exist. That made it too easy for contributors to treat implementation structure as protocol authority or start new Base work without an approved semantic boundary.

## Impact

Contributors now get the same bilingual, spec-first decision path for maintenance, composition, Base projection, and approved Base slices. The guides distinguish conceptual reading from implementation authorization and point readers from P/T entities through executable evidence and public projections.

## Validation

- `corepack pnpm@10.32.1 --filter apps-www check`
- `corepack pnpm@10.32.1 check:agent-doc`
- `corepack pnpm@10.32.1 --filter apps-www build`
- Prettier check and `git diff --check`
- verified all ten bilingual routes, locale switching, light/dark themes, 390 px navigation, Pagefind results, and browser console output

Closes #415