### PR TITLE
docs(base): document the released 0.2 family surface

### DIFF
--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -234,6 +234,26 @@ export default defineConfig({
                   slug: 'ui-libraries/base',
                 },
                 {
+                  label: 'Button',
+                  translations: { en: 'Button', 'zh-CN': 'Button' },
+                  slug: 'ui-libraries/base/button',
+                },
+                {
+                  label: 'Toggle',
+                  translations: { en: 'Toggle', 'zh-CN': 'Toggle' },
+                  slug: 'ui-libraries/base/toggle',
+                },
+                {
+                  label: 'Switch',
+                  translations: { en: 'Switch', 'zh-CN': 'Switch' },
+                  slug: 'ui-libraries/base/switch',
+                },
+                {
+                  label: 'Tabs',
+                  translations: { en: 'Tabs', 'zh-CN': 'Tabs' },
+                  slug: 'ui-libraries/base/tabs',
+                },
+                {
                   label: 'Hover Card',
                   translations: { en: 'Hover Card', 'zh-CN': 'Hover Card' },
                   slug: 'ui-libraries/base/hover-card',
@@ -247,6 +267,11 @@ export default defineConfig({
                   label: 'Dialog',
                   translations: { en: 'Dialog', 'zh-CN': 'Dialog' },
                   slug: 'ui-libraries/base/dialog',
+                },
+                {
+                  label: 'Dropdown Menu',
+                  translations: { en: 'Dropdown Menu', 'zh-CN': 'Dropdown Menu' },
+                  slug: 'ui-libraries/base/dropdown-menu',
                 },
                 {
                   label: 'Transition',
@@ -267,6 +292,16 @@ export default defineConfig({
                   label: 'Textarea',
                   translations: { en: 'Textarea', 'zh-CN': 'Textarea' },
                   slug: 'ui-libraries/base/textarea',
+                },
+                {
+                  label: 'Separator',
+                  translations: { en: 'Separator', 'zh-CN': 'Separator' },
+                  slug: 'ui-libraries/base/separator',
+                },
+                {
+                  label: 'Scroll Area',
+                  translations: { en: 'Scroll Area', 'zh-CN': 'Scroll Area' },
+                  slug: 'ui-libraries/base/scroll-area',
                 },
                 {
                   label: 'Live Region',

--- a/apps/www/src/components/PrototypeLibraryOverview.astro
+++ b/apps/www/src/components/PrototypeLibraryOverview.astro
@@ -23,6 +23,42 @@ const isZh = locale === 'zh-cn';
 const entriesByLibrary: Record<LibraryId, PrototypeEntry[]> = {
   base: [
     {
+      id: 'button',
+      name: 'Button',
+      demoId: 'demo-base-button',
+      description: isZh
+        ? '可聚焦、可禁用的离散 command control。'
+        : 'A focusable, disable-able discrete command control.',
+      href: './button/',
+    },
+    {
+      id: 'toggle',
+      name: 'Toggle',
+      demoId: 'demo-base-toggle',
+      description: isZh
+        ? '拥有持久 active 状态的 button-like control。'
+        : 'A button-like control with persistent active state.',
+      href: './toggle/',
+    },
+    {
+      id: 'switch',
+      name: 'Switch',
+      demoId: 'demo-base-switch',
+      description: isZh
+        ? 'Root 拥有状态的 on/off value control。'
+        : 'A root-owned on/off value control.',
+      href: './switch/',
+    },
+    {
+      id: 'tabs',
+      name: 'Tabs',
+      demoId: 'demo-base-tabs',
+      description: isZh
+        ? '单选标签、焦点导航与内容投射。'
+        : 'Single selection, focus navigation, and panel projection.',
+      href: './tabs/',
+    },
+    {
       id: 'checkbox',
       name: 'Checkbox',
       demoId: 'demo-base-checkbox',
@@ -47,6 +83,7 @@ const entriesByLibrary: Record<LibraryId, PrototypeEntry[]> = {
       description: isZh
         ? '集合导航、输入查找与提交关闭。'
         : 'Collection navigation, typeahead, and commit-close behavior.',
+      href: './dropdown-menu/',
     },
     {
       id: 'select',
@@ -83,6 +120,24 @@ const entriesByLibrary: Record<LibraryId, PrototypeEntry[]> = {
         ? '进入、退出与 presence 生命周期。'
         : 'Enter, exit, and presence lifecycle semantics.',
       href: './transition/',
+    },
+    {
+      id: 'separator',
+      name: 'Separator',
+      demoId: 'demo-base-separator',
+      description: isZh
+        ? '无交互的方向与装饰性分隔语义。'
+        : 'Non-interactive orientation and decorative separation semantics.',
+      href: './separator/',
+    },
+    {
+      id: 'scroll-area',
+      name: 'Scroll Area',
+      demoId: 'demo-base-scroll-area',
+      description: isZh
+        ? 'Viewport 拥有、由宿主投射的滚动域。'
+        : 'A viewport-owned, host-projected scrolling domain.',
+      href: './scroll-area/',
     },
     {
       id: 'live-region',

--- a/apps/www/src/components/PrototypePreviewer/prototype-modules.ts
+++ b/apps/www/src/components/PrototypePreviewer/prototype-modules.ts
@@ -27,6 +27,38 @@ const manualPrototypeModules: Record<string, PrototypeModuleLoader> = {
     const mod = await import('@proto.ui/prototypes-base');
     registerPrototype('base-button', mod.button);
   },
+  'base-toggle': async () => {
+    const mod = await import('@proto.ui/prototypes-base/toggle');
+    registerPrototype('base-toggle', mod.toggle);
+  },
+  'base-switch-root': async () => {
+    const mod = await import('@proto.ui/prototypes-base/switch');
+    registerPrototype('base-switch-root', mod.switchRoot);
+  },
+  'base-switch-thumb': async () => {
+    const mod = await import('@proto.ui/prototypes-base/switch');
+    registerPrototype('base-switch-thumb', mod.switchThumb);
+  },
+  'base-tabs-root': async () => {
+    const mod = await import('@proto.ui/prototypes-base/tabs');
+    registerPrototype('base-tabs-root', mod.tabsRoot);
+  },
+  'base-tabs-list': async () => {
+    const mod = await import('@proto.ui/prototypes-base/tabs');
+    registerPrototype('base-tabs-list', mod.tabsList);
+  },
+  'base-tabs-trigger': async () => {
+    const mod = await import('@proto.ui/prototypes-base/tabs');
+    registerPrototype('base-tabs-trigger', mod.tabsTrigger);
+  },
+  'base-tabs-content': async () => {
+    const mod = await import('@proto.ui/prototypes-base/tabs');
+    registerPrototype('base-tabs-content', mod.tabsContent);
+  },
+  'base-tabs-indicator': async () => {
+    const mod = await import('@proto.ui/prototypes-base/tabs');
+    registerPrototype('base-tabs-indicator', mod.tabsIndicator);
+  },
   'shadcn-button': async () => {
     const mod = await import('../../../../../packages/prototypes/shadcn/src/button/index');
     registerPrototype('shadcn-button', mod.default);
@@ -66,6 +98,22 @@ const manualPrototypeModules: Record<string, PrototypeModuleLoader> = {
   'base-separator-root': async () => {
     const mod = await import('@proto.ui/prototypes-base/separator');
     registerPrototype('base-separator-root', mod.default);
+  },
+  'base-scroll-area-root': async () => {
+    const mod = await import('@proto.ui/prototypes-base/scroll-area');
+    registerPrototype('base-scroll-area-root', mod.scrollAreaRoot);
+  },
+  'base-scroll-area-viewport': async () => {
+    const mod = await import('@proto.ui/prototypes-base/scroll-area');
+    registerPrototype('base-scroll-area-viewport', mod.scrollAreaViewport);
+  },
+  'base-scroll-area-scrollbar': async () => {
+    const mod = await import('@proto.ui/prototypes-base/scroll-area');
+    registerPrototype('base-scroll-area-scrollbar', mod.scrollAreaScrollbar);
+  },
+  'base-scroll-area-thumb': async () => {
+    const mod = await import('@proto.ui/prototypes-base/scroll-area');
+    registerPrototype('base-scroll-area-thumb', mod.scrollAreaThumb);
   },
   'base-textarea-root': async () => {
     const mod = await import('@proto.ui/prototypes-base/textarea');

--- a/apps/www/src/content/docs/en/ui-libraries/base/button.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/button.mdx
@@ -1,0 +1,45 @@
+---
+title: 'Button'
+description: 'Base Button command semantics, public surface, evidence, and current boundaries.'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+Base Button is a focusable command control for one discrete action. It owns activation, disabled gating, focus, transient interaction facts, and the outward `click` signal; it deliberately does not own a visual language.
+
+<PrototypePreviewer
+  demoId="demo-base-button"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  codePanel={false}
+/>
+
+## Protocol boundary
+
+`P-BASE-BUTTON` catalogs two authoring entries for the same protocol:
+
+- the direct `base-button` Prototype, exported as `button` from `@proto.ui/prototypes-base/button`;
+- the authored `asButton()` hook for a derived Prototype that needs to retain Button semantics.
+
+The public props surface currently contains only `disabled`. Exposed facts are `disabled`, `hovered`, `focused`, `focusVisible`, and held-down `pressed`; `focusSelf()` requests focus, and successful activation emits `click`. The signal is protocol output, not a props callback and not a promise of a native DOM `click` implementation.
+
+## Interaction and accessibility
+
+Button uses the official trigger route for pointer and keyboard activation. Space participates in the press lifecycle and prevents its scrolling default; Enter activation follows the host trigger path. A disabled Button rejects activation and active focus requests, emits no `click`, and clears transient interaction state.
+
+The Web profile projects command-control accessibility and takes the accessible name from authored content. Form submission, `type`, `name`, command integration, and visual variants are outside the current Base guarantee.
+
+## 0.2 delivery and evidence
+
+The stable 0.2.0 package exports `@proto.ui/prototypes-base/button`, and the CLI registry exposes `base-button`. The focused protocol evidence is `T-BASE-BUTTON-0001` and `packages/prototypes/base/test/as-button.test.ts`. This page's preview exercises the same Web host profile through the Web Component, React, and Vue adapters.
+
+## Lifecycle
+
+`P-BASE-BUTTON` is **draft**. Package publication makes the implementation consumable; it does not turn the draft protocol into a frozen compatibility guarantee.
+
+## References
+
+- [P-BASE-BUTTON](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-BUTTON.yaml)
+- [Button source](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/button)
+- [Button evidence](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/as-button.test.ts)
+- Styled projections: [Shadcn Button](/en/ui-libraries/shadcn/button/) and [Brutalist Button](/en/ui-libraries/brutalist/components/button/)

--- a/apps/www/src/content/docs/en/ui-libraries/base/dropdown-menu.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/dropdown-menu.mdx
@@ -1,0 +1,43 @@
+---
+title: 'Dropdown Menu'
+description: 'Base Dropdown Menu action-menu ownership, anatomy, evidence, and boundaries.'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+Base Dropdown Menu is a compound action-menu opened by a Trigger. Root owns visibility, request arbitration, collection order, entry policy, and shared facts; transient active navigation never becomes persistent selection.
+
+<PrototypePreviewer
+  demoId="demo-base-dropdown-menu"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  codePanel={false}
+/>
+
+## Family and request ownership
+
+The canonical family contains one Root, at most one Trigger and Content, and up to 100 Items. All visibility changes—methods, Trigger activation, dismissal, and Item commit—enter Root's `openChange` request channel.
+
+Root accepts `open`, `defaultOpen`, `disabled`, `closeOnItemCommit`, `openEntry`, and `openEntryValue`. It exposes open state, collection facts, and `openDropdown()`, `close()`, `toggle()`, and `requestOpen()`. Controlled mode retains owner-provided `open` until new input arrives.
+
+Content composes overlay, transition, collection navigation, typeahead, and anchor positioning. Item accepts `value`, `textValue`, `disabled`, and `closeOnCommit`; it exposes active/interaction facts and emits `select`. Closing clears transient active state, so reopening follows the new entry policy instead of restoring a false “selection.”
+
+## Accessibility boundary
+
+This family represents actions or functions opened by a button. It must not disguise ordinary navigation, arbitrary forms, or persistent selection as a menu. Group, Label, Separator, Checkbox Item, Radio Item, and Submenu are not current Base guarantees.
+
+## 0.2 delivery and evidence
+
+The stable 0.2.0 package exports `@proto.ui/prototypes-base/dropdown`. The CLI component ID is `base-dropdown` and generates Root, Trigger, Content, and Item. `T-BASE-DROPDOWN-MENU-0001` maps the family criteria to `packages/prototypes/base/test/dropdown.test.ts`; the preview runs through the Web Component, React, and Vue adapters.
+
+## Lifecycle
+
+`P-BASE-DROPDOWN-MENU` and its Trigger, Content, and Item entities are **draft**. Published package availability does not promote them to active guarantees.
+
+## References
+
+- [P-BASE-DROPDOWN-MENU](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-DROPDOWN-MENU.yaml)
+- Parts: [Trigger](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-DROPDOWN-MENU-TRIGGER.yaml), [Content](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-DROPDOWN-MENU-CONTENT.yaml), [Item](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-DROPDOWN-MENU-ITEM.yaml)
+- [Dropdown source](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/dropdown)
+- [Dropdown evidence](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/dropdown.test.ts)
+- Styled projection: [Brutalist Dropdown Menu](/en/ui-libraries/brutalist/components/dropdown-menu/)

--- a/apps/www/src/content/docs/en/ui-libraries/base/index.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/index.mdx
@@ -9,7 +9,13 @@ Base prescribes no default visual language. It provides testable interaction sem
 
 The Base entities currently remain in the draft catalog lifecycle. These previews describe the current official working surface, not a frozen stable API guarantee.
 
-For interactive families, the Base prototype should stop at semantics that are broadly reusable. For dropdown-menu, that boundary is:
+## Released 0.2 family inventory
+
+The stable 0.2.0 package exports 16 intentionally documented component families: Button, Toggle, Switch, Tabs, Checkbox, Dialog, Dropdown Menu, Select, Hover Card, Tooltip, Transition, Separator, Scroll Area, Textarea, Live Region, and Async Region. Non-component `behaviors` and `tools` exports are library utilities and do not require component detail routes.
+
+Package exports and the CLI registry are related but not identical inventories. The CLI calls the package's `dropdown` family `base-dropdown`; its `base-tabs` facade currently omits the optional Indicator authoring surface; and it has no `base-scroll-area` facade, while exposing the complete `brutalist-scroll-area` projection. Those differences are stated on the affected detail pages instead of being hidden or treated as missing protocols.
+
+For interactive families, the Base prototype should stop at semantics that are broadly reusable. For Dropdown Menu, that boundary is:
 
 - overlay open/close coordination
 - collection ordering and item snapshots

--- a/apps/www/src/content/docs/en/ui-libraries/base/scroll-area.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/scroll-area.mdx
@@ -1,0 +1,46 @@
+---
+title: 'Scroll Area'
+description: 'Base Scroll Area host-projected scrolling domain, anatomy, evidence, and boundaries.'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+Base Scroll Area models one logical scrolling domain rather than wrapping a Web DOM scrollbar. Viewport owns the surface and reaches host scrolling through a privileged capability; Root and composed controls stay layout and projection parts.
+
+<PrototypePreviewer
+  demoId="demo-base-scroll-area"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  codePanel={false}
+/>
+
+## Family and host ownership
+
+The canonical family contains:
+
+- Root `1..1`: anatomy and JSON-only family scope, with no offset, geometry, focus, event, or default-size ownership;
+- Viewport `1..1`: the single logical scroll-surface owner;
+- Scrollbar `0..2`: horizontal or vertical composed-control route;
+- Thumb `0..2`: a feedback-only hit subregion inside Scrollbar.
+
+Viewport exposes normalized axes, position, visible ratio, direction availability, scrolling state, and resolved projection. Raw DOM nodes, pixels, widgets, physics, and input recognizers remain host responsibilities.
+
+`system` and `composed` are projection strategies for the same protocol. The host adapter and design-language preference resolve the default; they are not separate Base Prototypes. In composed mode the host maps normalized facts to Thumb geometry and routes movement through the existing scroll engine. Thumb owns no independent offset state, focus target, `scrollbar` role, or drag-and-drop semantics.
+
+## 0.2 delivery and evidence
+
+The stable 0.2.0 package exports `@proto.ui/prototypes-base/scroll-area`. Unlike the other six families on this page set, the current CLI registry has no `base-scroll-area` component facade; it exposes the complete `brutalist-scroll-area` projection instead. Base library authors can consume the public subpath directly, while app-facing generated usage currently starts from the styled projection.
+
+`T-BASE-SCROLL-AREA-0001` and the related Scroll/Move tests map the host boundary to `packages/prototypes/base/test/scroll-area.test.ts` and cross-adapter Web conformance. This preview renders the same logical family through all three Web adapters.
+
+## Lifecycle and current limitations
+
+The Root, Viewport, Scrollbar, and Thumb entities are **draft**. Current evidence covers system/composed projection, normalized facts and requests, host cleanup, and composed Thumb movement. Track-page press, full keyboard scrollbar semantics, RTL/writing-mode normalization, velocity, and general Drag and Drop remain outside the guarantee.
+
+## References
+
+- [P-BASE-SCROLL-AREA](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-SCROLL-AREA.yaml)
+- Parts: [Viewport](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-SCROLL-AREA-VIEWPORT.yaml), [Scrollbar](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-SCROLL-AREA-SCROLLBAR.yaml), [Thumb](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-SCROLL-AREA-THUMB.yaml)
+- [Scroll Area source](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/scroll-area)
+- [Scroll Area evidence](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/scroll-area.test.ts)
+- Styled projection: [Brutalist Scroll Area](/en/ui-libraries/brutalist/components/scroll-area/)

--- a/apps/www/src/content/docs/en/ui-libraries/base/separator.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/separator.mdx
@@ -1,0 +1,43 @@
+---
+title: 'Separator'
+description: 'Base Separator orientation and accessibility semantics without interaction.'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+Base Separator is a contentless, non-interactive boundary for horizontal or vertical separation. It owns orientation and whether the separator is decorative; layout, color, thickness, and rhythm belong to the design language.
+
+<PrototypePreviewer
+  demoId="demo-base-separator"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  codePanel={false}
+/>
+
+## Public surface
+
+`@proto.ui/prototypes-base/separator` exports `separatorRoot` and `asSeparatorRoot()`. Current props are:
+
+- `orientation?: 'horizontal' | 'vertical'`, defaulting to `horizontal`;
+- `decorative?: boolean`, defaulting to `true`.
+
+The root exposes `orientation` and `decorative` state. It intentionally exposes no focus, tab stop, event, command, activation, or mutable-value channel, and its renderer is contentless so decorative semantics cannot accidentally hide authored descendants.
+
+## Accessibility boundary
+
+Decorative mode is hidden from the accessibility tree and emits neither `separator` role nor orientation state. Semantic mode projects `role="separator"` and the corresponding orientation. Whether a divider is meaningful to assistive technology is an authoring decision, not a styling side effect.
+
+## 0.2 delivery and evidence
+
+The stable 0.2.0 package exports the Separator subpath, and the CLI registry exposes `base-separator`. `T-BASE-SEPARATOR-0001` maps the protocol to `packages/prototypes/base/test/separator.test.ts`; the preview verifies both decorative and semantic cases across the Web adapters.
+
+## Lifecycle
+
+`P-BASE-SEPARATOR` is **draft**. Its small surface is fully evidenced, but it has not been promoted to an active protocol guarantee.
+
+## References
+
+- [P-BASE-SEPARATOR](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-SEPARATOR.yaml)
+- [Separator source](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/separator)
+- [Separator evidence](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/separator.test.ts)
+- Styled projection: [Brutalist Separator](/en/ui-libraries/brutalist/components/separator/)

--- a/apps/www/src/content/docs/en/ui-libraries/base/switch.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/switch.mdx
@@ -1,0 +1,46 @@
+---
+title: 'Switch'
+description: 'Base Switch root-owned on/off semantics, anatomy, evidence, and boundaries.'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+Base Switch is an on/off value control. Root owns the persistent checked value and activation route; Thumb is an optional same-domain indicator and never becomes a second input target.
+
+<PrototypePreviewer
+  demoId="demo-base-switch"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  codePanel={false}
+/>
+
+## Family and ownership
+
+The cataloged family contains:
+
+- `base-switch-root` (`1..1`): semantic owner, value owner, focus and activation target;
+- `base-switch-thumb` (`0..*`): presentational indicator that consumes Root context.
+
+Root and Thumb are exported from `@proto.ui/prototypes-base/switch` together with `asSwitchRoot()` and `asSwitchThumb()`. Root accepts `checked`, `defaultChecked`, and `disabled`, exposes checked and interaction facts, offers `focusSelf()`, and emits `checkedChange`.
+
+Controlled mode keeps the owner-provided `checked` fact until updated input arrives. Uncontrolled activation commits the next checked value locally. Mixed/indeterminate state is not part of Switch; use a Checkbox boundary when that state is required.
+
+## Accessibility boundary
+
+Root projects the `switch` role and checked state on the single focusable control. Thumb is presentational: it has no activation, value ownership, focus target, or independent accessibility control semantics. Base does not prescribe track geometry, motion, color, or variants.
+
+## 0.2 delivery and evidence
+
+The stable 0.2.0 package exports the Switch family, and the CLI registry exposes the Root and Thumb through `base-switch`. `T-BASE-SWITCH-0001` maps Root criteria to `packages/prototypes/base/test/switch.test.ts`; current Web adapter projection can be compared directly in this preview.
+
+## Lifecycle
+
+`P-BASE-SWITCH` and `P-BASE-SWITCH-THUMB` are **draft**. Their presence in a stable package is release evidence, not lifecycle promotion.
+
+## References
+
+- [P-BASE-SWITCH](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-SWITCH.yaml)
+- [P-BASE-SWITCH-THUMB](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-SWITCH-THUMB.yaml)
+- [Switch source](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/switch)
+- [Switch evidence](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/switch.test.ts)
+- Styled projections: [Shadcn Switch](/en/ui-libraries/shadcn/switch/) and [Brutalist Switch](/en/ui-libraries/brutalist/components/switch/)

--- a/apps/www/src/content/docs/en/ui-libraries/base/tabs.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/tabs.mdx
@@ -1,0 +1,49 @@
+---
+title: 'Tabs'
+description: 'Base Tabs selection, anatomy, focus ownership, evidence, and current boundaries.'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+Base Tabs is a compound single-selection protocol. Root owns the selected value; List owns roving focus; Trigger requests selection; Content projects the current panel; Indicator only reflects context for downstream visual treatment.
+
+<PrototypePreviewer
+  demoId="demo-base-tabs"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  codePanel={false}
+/>
+
+## Family and ownership
+
+The canonical family is:
+
+- Root `1..1`
+- List `0..1`
+- Trigger `0..*`
+- Content `0..*`
+- Indicator `0..*`
+
+Root accepts `value`, `defaultValue`, `orientation`, and `activationMode`, and emits `valueChange`. A controlled Root treats selection as a request until the owner provides a new value. List adds `loop`, optional `a11yLabel`, orientation-aware arrow navigation, Home/End, and focus methods. Trigger owns its `value`, disabled gate, interaction facts, focus request, selected projection, and tab accessibility. Content matches its `value`, exposes `current`/`hidden`, and can retain an inactive host view with `keepMounted`.
+
+Indicator is a presentational context consumer. It exposes current value, active value, and orientation, but owns no selection, event route, focus target, measurement, positioning, or visual variant.
+
+## Accessibility and presence
+
+The Web profile projects tablist, tab, and tabpanel relationships. Disabled triggers remain outside selection. Automatic activation selects while focus moves; manual activation keeps focus navigation and selection separate. Inactive Content detaches by default; `keepMounted` preserves the complete host view while accessibility-hidden.
+
+## 0.2 delivery and evidence
+
+The stable 0.2.0 package exports all five authoring surfaces from `@proto.ui/prototypes-base/tabs`. The current `base-tabs` CLI facade generates Root, List, Trigger, and Content; Indicator remains a public package authoring surface but is not included in that generated facade. The mapped `T-BASE-TABS-*` entities cover `packages/prototypes/base/test/tabs.test.ts`, and this preview exercises the family through all three Web adapters.
+
+## Lifecycle
+
+The five `P-BASE-TABS*` entities are **draft**. Current implementation and evidence are reviewable working surfaces, not a frozen compatibility promise.
+
+## References
+
+- [P-BASE-TABS](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-TABS.yaml)
+- Parts: [List](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-TABS-LIST.yaml), [Trigger](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-TABS-TRIGGER.yaml), [Content](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-TABS-CONTENT.yaml), [Indicator](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-TABS-INDICATOR.yaml)
+- [Tabs source](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/tabs)
+- [Tabs evidence](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/tabs.test.ts)
+- Styled projections: [Shadcn Tabs](/en/ui-libraries/shadcn/tabs/) and [Brutalist Tabs](/en/ui-libraries/brutalist/components/tabs/)

--- a/apps/www/src/content/docs/en/ui-libraries/base/toggle.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/toggle.mdx
@@ -1,0 +1,44 @@
+---
+title: 'Toggle'
+description: 'Base Toggle persistent active-state semantics, evidence, and current boundaries.'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+Base Toggle is a button-like control that owns a persistent binary `active` state. It is for modes such as pinning or text-format activation—not a one-shot Button action and not a Switch on/off value.
+
+<PrototypePreviewer
+  demoId="demo-base-toggle"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  codePanel={false}
+/>
+
+## Protocol boundary
+
+`P-BASE-TOGGLE` owns `active`, activation, disabled and focus behavior, transient interaction facts, and `activeChange`. The direct `base-toggle` Prototype and `asToggle()` are authoring entries of that same protocol; Toggle does not obtain its semantics from Button- or Switch-specific hooks.
+
+Current props are `active`, `defaultActive`, and `disabled`. In uncontrolled mode, successful activation flips `active`. In controlled mode it emits the requested next `{ active }` value while retaining the owner-provided fact until new input arrives.
+
+Toggle is a single subject. Toggle Group, exclusive or multiple selection, collection membership, and separate anatomy parts are outside this protocol. Icons and visual indicators remain authored content rather than Toggle parts.
+
+## Interaction and accessibility
+
+The root exposes `active`, disabled/focus/press facts, `focusSelf()`, and `activeChange`. Its Web accessibility projection is button-like with pressed-state semantics. Disabled controls suppress activation and clear transient state.
+
+Form integration, group policy, and visual variants remain downstream responsibilities.
+
+## 0.2 delivery and evidence
+
+The stable 0.2.0 package exports `@proto.ui/prototypes-base/toggle`, and the CLI registry exposes `base-toggle`. `T-BASE-TOGGLE-0001` maps the draft criteria to `packages/prototypes/base/test/toggle.test.ts`; the preview runs the Web profile through all three Web adapters.
+
+## Lifecycle
+
+`P-BASE-TOGGLE` is **draft**. The 0.2.0 package contains this surface, but its catalog lifecycle still permits refinement.
+
+## References
+
+- [P-BASE-TOGGLE](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-TOGGLE.yaml)
+- [Toggle source](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/toggle)
+- [Toggle evidence](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/toggle.test.ts)
+- Styled projections: [Shadcn Toggle](/en/ui-libraries/shadcn/toggle/) and [Brutalist Toggle](/en/ui-libraries/brutalist/components/toggle/)

--- a/apps/www/src/content/docs/zh-cn/demo-base-button.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-button.demo.ts
@@ -1,0 +1,22 @@
+export default {
+  type: 'demo',
+  root: {
+    kind: 'box',
+    className: 'flex flex-wrap items-center gap-3',
+    children: [
+      {
+        kind: 'proto',
+        prototypeId: 'base-button',
+        className: 'rounded border px-3 py-2 text-sm font-medium',
+        children: ['Run action'],
+      },
+      {
+        kind: 'proto',
+        prototypeId: 'base-button',
+        props: { disabled: true },
+        className: 'rounded border px-3 py-2 text-sm opacity-50',
+        children: ['Disabled'],
+      },
+    ],
+  },
+};

--- a/apps/www/src/content/docs/zh-cn/demo-base-scroll-area.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-scroll-area.demo.ts
@@ -1,0 +1,51 @@
+export default {
+  type: 'demo',
+  root: {
+    kind: 'proto',
+    prototypeId: 'base-scroll-area-root',
+    className: 'relative h-48 w-full max-w-80 overflow-hidden rounded border',
+    children: [
+      {
+        kind: 'proto',
+        prototypeId: 'base-scroll-area-viewport',
+        className: 'h-full w-full overflow-auto',
+        children: [
+          {
+            kind: 'box',
+            className: 'flex flex-col gap-2 p-3',
+            children: [
+              'Host-projected scrolling surface',
+              'Row 2',
+              'Row 3',
+              'Row 4',
+              'Row 5',
+              'Row 6',
+              'Row 7',
+              'Row 8',
+              'Row 9',
+              'Row 10',
+              'Row 11',
+              'Row 12',
+              'Row 13',
+              'Row 14',
+              'Row 15',
+            ],
+          },
+        ],
+      },
+      {
+        kind: 'proto',
+        prototypeId: 'base-scroll-area-scrollbar',
+        props: { orientation: 'vertical' },
+        className: 'absolute inset-y-0 right-0 w-2 bg-gray-100',
+        children: [
+          {
+            kind: 'proto',
+            prototypeId: 'base-scroll-area-thumb',
+            className: 'block min-h-8 w-full rounded bg-gray-500',
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/apps/www/src/content/docs/zh-cn/demo-base-separator.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-separator.demo.ts
@@ -1,0 +1,30 @@
+export default {
+  type: 'demo',
+  root: {
+    kind: 'box',
+    className: 'flex flex-col gap-3',
+    children: [
+      'Today',
+      {
+        kind: 'proto',
+        prototypeId: 'base-separator-root',
+        className: 'block h-px w-full bg-black',
+      },
+      'Yesterday',
+      {
+        kind: 'box',
+        className: 'flex h-12 items-stretch gap-3',
+        children: [
+          'Vertical',
+          {
+            kind: 'proto',
+            prototypeId: 'base-separator-root',
+            props: { orientation: 'vertical', decorative: false },
+            className: 'block h-full w-px bg-black',
+          },
+          'Rule',
+        ],
+      },
+    ],
+  },
+};

--- a/apps/www/src/content/docs/zh-cn/demo-base-switch.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-switch.demo.ts
@@ -1,0 +1,35 @@
+export default {
+  type: 'demo',
+  root: {
+    kind: 'box',
+    className: 'flex flex-wrap items-center gap-4',
+    children: [
+      {
+        kind: 'proto',
+        prototypeId: 'base-switch-root',
+        props: { defaultChecked: false },
+        className: 'inline-flex h-7 w-12 items-center rounded-full border p-1',
+        children: [
+          {
+            kind: 'proto',
+            prototypeId: 'base-switch-thumb',
+            className: 'block size-5 rounded-full border bg-white',
+          },
+        ],
+      },
+      {
+        kind: 'proto',
+        prototypeId: 'base-switch-root',
+        props: { defaultChecked: true },
+        className: 'inline-flex h-7 w-12 items-center justify-end rounded-full border p-1',
+        children: [
+          {
+            kind: 'proto',
+            prototypeId: 'base-switch-thumb',
+            className: 'block size-5 rounded-full border bg-white',
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/apps/www/src/content/docs/zh-cn/demo-base-tabs.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-tabs.demo.ts
@@ -1,0 +1,65 @@
+export default {
+  type: 'demo',
+  root: {
+    kind: 'proto',
+    prototypeId: 'base-tabs-root',
+    className: 'w-full max-w-md',
+    props: { defaultValue: 'account' },
+    children: [
+      {
+        kind: 'proto',
+        prototypeId: 'base-tabs-list',
+        className: 'flex gap-1 border-b',
+        children: [
+          {
+            kind: 'proto',
+            prototypeId: 'base-tabs-trigger',
+            props: { value: 'account' },
+            className: 'px-3 py-2 text-sm font-medium',
+            children: ['Account'],
+          },
+          {
+            kind: 'proto',
+            prototypeId: 'base-tabs-trigger',
+            props: { value: 'security' },
+            className: 'px-3 py-2 text-sm font-medium',
+            children: ['Security'],
+          },
+          {
+            kind: 'proto',
+            prototypeId: 'base-tabs-trigger',
+            props: { value: 'billing', disabled: true },
+            className: 'px-3 py-2 text-sm opacity-50',
+            children: ['Billing'],
+          },
+        ],
+      },
+      {
+        kind: 'proto',
+        prototypeId: 'base-tabs-indicator',
+        className: 'block h-0.5 bg-black',
+      },
+      {
+        kind: 'proto',
+        prototypeId: 'base-tabs-content',
+        props: { value: 'account' },
+        className: 'py-4 text-sm',
+        children: ['Account settings'],
+      },
+      {
+        kind: 'proto',
+        prototypeId: 'base-tabs-content',
+        props: { value: 'security' },
+        className: 'py-4 text-sm',
+        children: ['Security settings'],
+      },
+      {
+        kind: 'proto',
+        prototypeId: 'base-tabs-content',
+        props: { value: 'billing' },
+        className: 'py-4 text-sm',
+        children: ['Billing is disabled in this preview.'],
+      },
+    ],
+  },
+};

--- a/apps/www/src/content/docs/zh-cn/demo-base-toggle.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-toggle.demo.ts
@@ -1,0 +1,29 @@
+export default {
+  type: 'demo',
+  root: {
+    kind: 'box',
+    className: 'flex flex-wrap items-center gap-3',
+    children: [
+      {
+        kind: 'proto',
+        prototypeId: 'base-toggle',
+        className: 'rounded border px-3 py-2 text-sm font-medium',
+        children: ['Pin'],
+      },
+      {
+        kind: 'proto',
+        prototypeId: 'base-toggle',
+        props: { defaultActive: true },
+        className: 'rounded border px-3 py-2 text-sm font-medium',
+        children: ['Bold'],
+      },
+      {
+        kind: 'proto',
+        prototypeId: 'base-toggle',
+        props: { disabled: true, defaultActive: true },
+        className: 'rounded border px-3 py-2 text-sm opacity-50',
+        children: ['Disabled'],
+      },
+    ],
+  },
+};

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/button.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/button.mdx
@@ -1,0 +1,45 @@
+---
+title: 'Button'
+description: 'Base Button 的 command 语义、公开表面、证据与当前边界。'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+Base Button 是用于一次离散 action 的可聚焦 command control。它拥有 activation、disabled gate、focus、瞬时交互事实与 `click` outward signal；它刻意不拥有视觉语言。
+
+<PrototypePreviewer
+  demoId="demo-base-button"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  codePanel={false}
+/>
+
+## Protocol 边界
+
+`P-BASE-BUTTON` 为同一个 protocol 编目了两个 authoring entries：
+
+- direct `base-button` Prototype，由 `@proto.ui/prototypes-base/button` 导出为 `button`；
+- authored `asButton()` hook，供需要保留 Button 语义的 derived Prototype 使用。
+
+当前 props 只有 `disabled`。它 expose `disabled`、`hovered`、`focused`、`focusVisible` 和表示“正被按住”的 `pressed` facts；`focusSelf()` 请求焦点，成功 activation 后发出 `click`。这个 signal 是 protocol output，不是 props callback，也不承诺以原生 DOM `click` 实现。
+
+## 交互与可访问性
+
+Button 通过官方 trigger route 处理指针与键盘 activation。Space 参与 press lifecycle 并阻止滚动默认行为；Enter activation 服从宿主 trigger path。disabled Button 拒绝 activation 和主动 focus 请求，不发出 `click`，并清理瞬时交互状态。
+
+Web profile 投射 command-control accessibility，并以 authored content 作为 accessible name。Form submission、`type`、`name`、command integration 与视觉 variant 不属于当前 Base guarantee。
+
+## 0.2 交付与证据
+
+稳定版 0.2.0 package 导出了 `@proto.ui/prototypes-base/button`，CLI registry 提供 `base-button`。聚焦证据是 `T-BASE-BUTTON-0001` 和 `packages/prototypes/base/test/as-button.test.ts`。本页 Preview 通过 Web Component、React 与 Vue Adapter 运行同一个 Web host profile。
+
+## Lifecycle
+
+`P-BASE-BUTTON` 当前是 **draft**。Package 发布使实现可被消费，但不会把 draft protocol 变成冻结的兼容性保证。
+
+## 参考
+
+- [P-BASE-BUTTON](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-BUTTON.yaml)
+- [Button source](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/button)
+- [Button evidence](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/as-button.test.ts)
+- 风格化投射：[Shadcn Button](/zh-cn/ui-libraries/shadcn/button/) 与 [Brutalist Button](/zh-cn/ui-libraries/brutalist/components/button/)

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/dropdown-menu.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/dropdown-menu.mdx
@@ -1,0 +1,43 @@
+---
+title: 'Dropdown Menu'
+description: 'Base Dropdown Menu 的 action-menu ownership、anatomy、证据与边界。'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+Base Dropdown Menu 是由 Trigger 打开的 compound action-menu。Root 拥有 visibility、request arbitration、collection order、entry policy 与 shared facts；瞬时 active navigation 永远不会变成 persistent selection。
+
+<PrototypePreviewer
+  demoId="demo-base-dropdown-menu"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  codePanel={false}
+/>
+
+## Family 与 request ownership
+
+Canonical family 包含一个 Root、至多一个 Trigger 和 Content，以及最多 100 个 Items。所有 visibility 变化——methods、Trigger activation、dismissal 与 Item commit——都进入 Root 的 `openChange` request channel。
+
+Root 接受 `open`、`defaultOpen`、`disabled`、`closeOnItemCommit`、`openEntry` 与 `openEntryValue`。它 expose open state、collection facts，以及 `openDropdown()`、`close()`、`toggle()`、`requestOpen()`。受控模式在新 input 到达前保持 owner 提供的 `open`。
+
+Content 组合 overlay、transition、collection navigation、typeahead 与 anchor positioning。Item 接受 `value`、`textValue`、`disabled`、`closeOnCommit`，expose active/interaction facts，并发出 `select`。关闭会清空瞬时 active state，因此重新打开时服从新的 entry policy，而不会恢复虚假的“selection”。
+
+## Accessibility 边界
+
+这个 family 表示由按钮打开的一组 action/function。它不得把普通导航、任意 form 或 persistent selection 伪装成 menu。Group、Label、Separator、Checkbox Item、Radio Item 与 Submenu 不属于当前 Base guarantee。
+
+## 0.2 交付与证据
+
+稳定版 0.2.0 package 导出了 `@proto.ui/prototypes-base/dropdown`。CLI component ID 是 `base-dropdown`，会生成 Root、Trigger、Content 与 Item。`T-BASE-DROPDOWN-MENU-0001` 把 family criteria 映射到 `packages/prototypes/base/test/dropdown.test.ts`；Preview 通过 Web Component、React 与 Vue Adapter 运行。
+
+## Lifecycle
+
+`P-BASE-DROPDOWN-MENU` 及其 Trigger、Content、Item entities 当前都是 **draft**。Package 可用性不会把它们提升为 active guarantees。
+
+## 参考
+
+- [P-BASE-DROPDOWN-MENU](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-DROPDOWN-MENU.yaml)
+- Parts：[Trigger](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-DROPDOWN-MENU-TRIGGER.yaml)、[Content](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-DROPDOWN-MENU-CONTENT.yaml)、[Item](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-DROPDOWN-MENU-ITEM.yaml)
+- [Dropdown source](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/dropdown)
+- [Dropdown evidence](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/dropdown.test.ts)
+- 风格化投射：[Brutalist Dropdown Menu](/zh-cn/ui-libraries/brutalist/components/dropdown-menu/)

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/index.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/index.mdx
@@ -9,7 +9,13 @@ Base 不规定默认视觉，只提供可测试、可跨宿主迁移的交互语
 
 当前 catalog 中的 Base 原型仍处于 draft 生命周期，以下是现阶段可交互的官方预览，不代表已冻结的稳定 API 保证。
 
-对于交互 family，Base 原型应停在可广泛复用的语义边界。以 dropdown-menu 为例，目前边界是：
+## 已发布的 0.2 family inventory
+
+稳定版 0.2.0 package 导出了 16 个有意纳入文档的 component families：Button、Toggle、Switch、Tabs、Checkbox、Dialog、Dropdown Menu、Select、Hover Card、Tooltip、Transition、Separator、Scroll Area、Textarea、Live Region 与 Async Region。非组件的 `behaviors` 和 `tools` exports 属于 library utilities，不要求 component detail route。
+
+Package exports 与 CLI registry 是相关但不完全相同的 inventory。CLI 把 package 的 `dropdown` family 称为 `base-dropdown`；当前 `base-tabs` facade 没有包含可选 Indicator authoring surface；CLI 也没有 `base-scroll-area` facade，而是提供完整的 `brutalist-scroll-area` projection。这些差异会在相应 detail page 中明确说明，而不是被隐藏或误判为缺失 protocol。
+
+对于交互 family，Base 原型应停在可广泛复用的语义边界。以 Dropdown Menu 为例，目前边界是：
 
 - 浮层开合协作
 - collection 顺序与 item snapshot

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/scroll-area.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/scroll-area.mdx
@@ -1,0 +1,46 @@
+---
+title: 'Scroll Area'
+description: 'Base Scroll Area 的 host-projected scrolling domain、anatomy、证据与边界。'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+Base Scroll Area 建模一个 logical scrolling domain，而不是包装 Web DOM scrollbar。Viewport 拥有 surface，并通过特权 capability 接入 host scrolling；Root 与 composed controls 只作为 layout/projection parts。
+
+<PrototypePreviewer
+  demoId="demo-base-scroll-area"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  codePanel={false}
+/>
+
+## Family 与 host ownership
+
+Canonical family 包含：
+
+- Root `1..1`：只拥有 anatomy 与 JSON-only family scope，不拥有 offset、geometry、focus、event 或 default size；
+- Viewport `1..1`：唯一 logical scroll-surface owner；
+- Scrollbar `0..2`：horizontal/vertical composed-control route；
+- Thumb `0..2`：Scrollbar 内的 feedback-only hit subregion。
+
+Viewport expose normalized axes、position、visible ratio、direction availability、scrolling state 与 resolved projection。Raw DOM node、pixel、widget、physics 与 input recognizer 仍由 host 负责。
+
+`system` 与 `composed` 是同一 protocol 的投射策略。默认值由 Host Adapter 和 design-language preference 共同解析；它们不是两个 Base Prototype。composed mode 中，host 把 normalized facts 映射为 Thumb geometry，并通过现有 scroll engine 路由 movement。Thumb 不拥有独立 offset state、focus target、`scrollbar` role 或 Drag and Drop 语义。
+
+## 0.2 交付与证据
+
+稳定版 0.2.0 package 导出了 `@proto.ui/prototypes-base/scroll-area`。与本组另外六个 family 不同，当前 CLI registry 没有 `base-scroll-area` component facade；它提供的是完整的 `brutalist-scroll-area` projection。Base library author 可以直接消费 public subpath，而面向 App 的 generated usage 当前从风格化投射进入。
+
+`T-BASE-SCROLL-AREA-0001` 及相关 Scroll/Move tests 把 host boundary 映射到 `packages/prototypes/base/test/scroll-area.test.ts` 与 cross-adapter Web conformance。本页 Preview 通过三个 Web Adapter 渲染同一个 logical family。
+
+## Lifecycle 与当前限制
+
+Root、Viewport、Scrollbar 与 Thumb entities 当前都是 **draft**。现有证据覆盖 system/composed projection、normalized facts/requests、host cleanup 与 composed Thumb movement。Track-page press、完整 keyboard scrollbar semantics、RTL/writing-mode normalization、velocity 与通用 Drag and Drop 仍不在 guarantee 内。
+
+## 参考
+
+- [P-BASE-SCROLL-AREA](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-SCROLL-AREA.yaml)
+- Parts：[Viewport](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-SCROLL-AREA-VIEWPORT.yaml)、[Scrollbar](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-SCROLL-AREA-SCROLLBAR.yaml)、[Thumb](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-SCROLL-AREA-THUMB.yaml)
+- [Scroll Area source](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/scroll-area)
+- [Scroll Area evidence](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/scroll-area.test.ts)
+- 风格化投射：[Brutalist Scroll Area](/zh-cn/ui-libraries/brutalist/components/scroll-area/)

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/separator.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/separator.mdx
@@ -1,0 +1,43 @@
+---
+title: 'Separator'
+description: 'Base Separator 的 orientation 与无交互 accessibility 语义。'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+Base Separator 是用于 horizontal/vertical separation 的 contentless、non-interactive boundary。它拥有 orientation 与 decorative 状态；layout、color、thickness 与 visual rhythm 属于设计语言。
+
+<PrototypePreviewer
+  demoId="demo-base-separator"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  codePanel={false}
+/>
+
+## 公开表面
+
+`@proto.ui/prototypes-base/separator` 导出 `separatorRoot` 与 `asSeparatorRoot()`。当前 props 是：
+
+- `orientation?: 'horizontal' | 'vertical'`，默认 `horizontal`；
+- `decorative?: boolean`，默认 `true`。
+
+Root expose `orientation` 与 `decorative` state。它刻意不提供 focus、tab stop、event、command、activation 或 mutable-value channel；renderer 也是 contentless 的，避免 decorative semantics 意外隐藏 authored descendants。
+
+## Accessibility 边界
+
+Decorative mode 会从 accessibility tree 隐藏，既不输出 `separator` role，也不输出 orientation state。Semantic mode 投射 `role="separator"` 和对应 orientation。Divider 是否对辅助技术有意义，是 authoring decision，不是 styling side effect。
+
+## 0.2 交付与证据
+
+稳定版 0.2.0 package 导出了 Separator subpath，CLI registry 提供 `base-separator`。`T-BASE-SEPARATOR-0001` 把 protocol 映射到 `packages/prototypes/base/test/separator.test.ts`；Preview 通过三个 Web Adapter 验证 decorative 与 semantic cases。
+
+## Lifecycle
+
+`P-BASE-SEPARATOR` 当前是 **draft**。它的小型 surface 已有完整证据，但尚未提升为 active protocol guarantee。
+
+## 参考
+
+- [P-BASE-SEPARATOR](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-SEPARATOR.yaml)
+- [Separator source](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/separator)
+- [Separator evidence](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/separator.test.ts)
+- 风格化投射：[Brutalist Separator](/zh-cn/ui-libraries/brutalist/components/separator/)

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/switch.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/switch.mdx
@@ -1,0 +1,46 @@
+---
+title: 'Switch'
+description: 'Base Switch 的 Root-owned on/off 语义、anatomy、证据与边界。'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+Base Switch 是 on/off value control。Root 拥有持久 checked value 与 activation route；Thumb 是可选的 same-domain indicator，不会成为第二个 input target。
+
+<PrototypePreviewer
+  demoId="demo-base-switch"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  codePanel={false}
+/>
+
+## Family 与 ownership
+
+Cataloged family 包含：
+
+- `base-switch-root`（`1..1`）：semantic owner、value owner、focus 与 activation target；
+- `base-switch-thumb`（`0..*`）：消费 Root context 的 presentational indicator。
+
+Root 与 Thumb 连同 `asSwitchRoot()`、`asSwitchThumb()` 一起由 `@proto.ui/prototypes-base/switch` 导出。Root 接受 `checked`、`defaultChecked`、`disabled`，expose checked 与交互事实，提供 `focusSelf()`，并发出 `checkedChange`。
+
+受控模式在更新 input 到达前保持 owner 提供的 `checked` fact；非受控 activation 会在本地提交下一个 checked value。Switch 不包含 mixed/indeterminate state；需要该状态时应使用 Checkbox 边界。
+
+## Accessibility 边界
+
+Root 在唯一可聚焦 control 上投射 `switch` role 与 checked state。Thumb 是 presentational part：它不拥有 activation、value、focus target 或独立 accessibility control 语义。Base 不规定 track geometry、motion、color 或 variant。
+
+## 0.2 交付与证据
+
+稳定版 0.2.0 package 导出了 Switch family，CLI registry 通过 `base-switch` 提供 Root 与 Thumb。`T-BASE-SWITCH-0001` 把 Root criteria 映射到 `packages/prototypes/base/test/switch.test.ts`；本页可直接比较三个 Web Adapter 的投射。
+
+## Lifecycle
+
+`P-BASE-SWITCH` 与 `P-BASE-SWITCH-THUMB` 当前都是 **draft**。它们出现在稳定 package 中是 release evidence，不是 lifecycle promotion。
+
+## 参考
+
+- [P-BASE-SWITCH](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-SWITCH.yaml)
+- [P-BASE-SWITCH-THUMB](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-SWITCH-THUMB.yaml)
+- [Switch source](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/switch)
+- [Switch evidence](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/switch.test.ts)
+- 风格化投射：[Shadcn Switch](/zh-cn/ui-libraries/shadcn/switch/) 与 [Brutalist Switch](/zh-cn/ui-libraries/brutalist/components/switch/)

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/tabs.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/tabs.mdx
@@ -1,0 +1,49 @@
+---
+title: 'Tabs'
+description: 'Base Tabs 的 selection、anatomy、focus ownership、证据与当前边界。'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+Base Tabs 是 compound single-selection protocol。Root 拥有 selected value；List 拥有 roving focus；Trigger 请求 selection；Content 投射当前 panel；Indicator 只反映 context，供下游添加视觉处理。
+
+<PrototypePreviewer
+  demoId="demo-base-tabs"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  codePanel={false}
+/>
+
+## Family 与 ownership
+
+Canonical family 是：
+
+- Root `1..1`
+- List `0..1`
+- Trigger `0..*`
+- Content `0..*`
+- Indicator `0..*`
+
+Root 接受 `value`、`defaultValue`、`orientation`、`activationMode`，并发出 `valueChange`。受控 Root 把 selection 作为 request，直到 owner 提供新 value。List 增加 `loop`、可选 `a11yLabel`、orientation-aware arrow navigation、Home/End 与 focus methods。Trigger 拥有自身 `value`、disabled gate、交互事实、focus request、selected projection 与 tab accessibility。Content 匹配自身 `value`，expose `current`/`hidden`，并可用 `keepMounted` 保留 inactive host view。
+
+Indicator 是 presentational context consumer。它 expose 当前 value、active value 与 orientation，但不拥有 selection、event route、focus target、measurement、positioning 或视觉 variant。
+
+## Accessibility 与 presence
+
+Web profile 投射 tablist、tab 与 tabpanel relations。disabled Trigger 不参与 selection。automatic activation 会随 focus 移动选择；manual activation 将 focus navigation 与 selection 分开。inactive Content 默认 detach；`keepMounted` 会保留完整 host view，同时在 accessibility tree 中隐藏。
+
+## 0.2 交付与证据
+
+稳定版 0.2.0 package 从 `@proto.ui/prototypes-base/tabs` 导出全部五个 authoring surfaces。当前 `base-tabs` CLI facade 生成 Root、List、Trigger 与 Content；Indicator 是 public package authoring surface，但尚未进入该 generated facade。映射的 `T-BASE-TABS-*` entities 覆盖 `packages/prototypes/base/test/tabs.test.ts`，本页 Preview 通过三个 Web Adapter 运行整个 family。
+
+## Lifecycle
+
+五个 `P-BASE-TABS*` entities 当前都是 **draft**。当前实现与证据是可审查的工作表面，不是冻结的兼容性承诺。
+
+## 参考
+
+- [P-BASE-TABS](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-TABS.yaml)
+- Parts：[List](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-TABS-LIST.yaml)、[Trigger](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-TABS-TRIGGER.yaml)、[Content](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-TABS-CONTENT.yaml)、[Indicator](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-TABS-INDICATOR.yaml)
+- [Tabs source](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/tabs)
+- [Tabs evidence](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/tabs.test.ts)
+- 风格化投射：[Shadcn Tabs](/zh-cn/ui-libraries/shadcn/tabs/) 与 [Brutalist Tabs](/zh-cn/ui-libraries/brutalist/components/tabs/)

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/toggle.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/toggle.mdx
@@ -1,0 +1,44 @@
+---
+title: 'Toggle'
+description: 'Base Toggle 的持久 active-state 语义、证据与当前边界。'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+Base Toggle 是拥有持久二值 `active` 状态的 button-like control。它适合 pin、文字格式启用等 mode；它既不是一次性的 Button action，也不是 Switch 的 on/off value。
+
+<PrototypePreviewer
+  demoId="demo-base-toggle"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  codePanel={false}
+/>
+
+## Protocol 边界
+
+`P-BASE-TOGGLE` 拥有 `active`、activation、disabled 与 focus 行为、瞬时交互事实和 `activeChange`。direct `base-toggle` Prototype 与 `asToggle()` 是同一 protocol 的 authoring entries；Toggle 不从 Button 或 Switch 专属 hook 借取自身语义。
+
+当前 props 是 `active`、`defaultActive` 与 `disabled`。非受控模式会在成功 activation 后翻转 `active`；受控模式会发出所请求的下一个 `{ active }` 值，并在 owner 提供新 input 之前保持 owner fact。
+
+Toggle 是单一 subject。Toggle Group、exclusive/multiple selection、collection membership 与独立 anatomy part 不属于这个 protocol。图标与视觉 indicator 仍是 authored content，而不是 Toggle part。
+
+## 交互与可访问性
+
+Root expose `active`、disabled/focus/press facts、`focusSelf()` 和 `activeChange`。Web accessibility projection 是带 pressed-state 语义的 button-like control。disabled control 会抑制 activation 并清理瞬时状态。
+
+Form integration、group policy 与视觉 variant 仍由下游负责。
+
+## 0.2 交付与证据
+
+稳定版 0.2.0 package 导出了 `@proto.ui/prototypes-base/toggle`，CLI registry 提供 `base-toggle`。`T-BASE-TOGGLE-0001` 把 draft criteria 映射到 `packages/prototypes/base/test/toggle.test.ts`；Preview 通过三个 Web Adapter 运行当前 Web profile。
+
+## Lifecycle
+
+`P-BASE-TOGGLE` 当前是 **draft**。0.2.0 package 包含这个 surface，但 catalog lifecycle 仍允许它继续收敛。
+
+## 参考
+
+- [P-BASE-TOGGLE](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-TOGGLE.yaml)
+- [Toggle source](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/toggle)
+- [Toggle evidence](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/toggle.test.ts)
+- 风格化投射：[Shadcn Toggle](/zh-cn/ui-libraries/shadcn/toggle/) 与 [Brutalist Toggle](/zh-cn/ui-libraries/brutalist/components/toggle/)


### PR DESCRIPTION
## Summary

- derive the released Base 0.2 component-family inventory from the package BOM, package exports, CLI registry, catalog entities, implementation, tests, and demos
- add bilingual detail routes for Button, Toggle, Switch, Tabs, Dropdown Menu, Separator, and Scroll Area
- expand the Base overview from 10 to 16 intentionally documented component families
- add every new route to the localized Base sidebar
- add/reuse live demos and public-subpath prototype loaders for all seven families
- state lifecycle, ownership, adapter coverage, accessibility boundaries, CLI/package differences, limitations, evidence, and styled projections without promoting draft entities

## Inventory decisions

The overview now treats the 16 package-exported component families as the released documentation inventory. Non-component `behaviors` and `tools` exports remain utility surfaces rather than component routes.

The pages explicitly preserve current differences instead of forcing false parity:

- the CLI calls the package's `dropdown` family `base-dropdown`
- the `base-tabs` facade omits the optional Indicator authoring surface
- there is no `base-scroll-area` facade; `brutalist-scroll-area` is the current complete generated projection

Stable npm 0.2.0 publication is kept separate from catalog lifecycle: the applicable Base entities remain `draft`.

## Validation

- `corepack pnpm@10.32.1 --filter apps-www check` — 148 files, 0 errors/warnings/hints
- 8 focused Base/overview test files — 50 tests passed
- `corepack pnpm@10.32.1 check:prototype-catalog` — 118 declarations, 161 authoring entries, 117 P entities
- `corepack pnpm@10.32.1 --filter apps-www build` — 210 pages built; all 14 localized routes emitted
- all seven pages manually verified in Web Component, React, and Vue modes (21 adapter/page combinations)
- both locales, themes, narrow layout, sidebar, language-preserving route switch, overview links, Pagefind indexing, and representative interactions verified

## Validation dependency

The new canonical Dropdown page exposed an existing Web Component runtime phase violation while moving focus into an Item. It is isolated in #441 and fixed by draft PR #442; no runtime change is included here. Keep this PR draft until #442 lands, then rebase and repeat the Dropdown console check.

Closes #413