### PR TITLE
docs: replace Specifications and Reference placeholders

### DIFF
--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -567,13 +567,11 @@ export default defineConfig({
               label: 'Introduction',
               translations: { en: 'Introduction', 'zh-CN': '规范导读' },
               slug: 'specifications/introduction',
-              badge: inProgressBadge,
             },
             {
               label: 'Core',
               translations: { en: 'Core', 'zh-CN': '核心' },
               slug: 'specifications/core',
-              badge: inProgressBadge,
             },
             {
               label: 'Lifecycle',
@@ -653,13 +651,11 @@ export default defineConfig({
               label: 'Prototype API',
               translations: { en: 'Prototype API', 'zh-CN': 'Prototype API' },
               slug: 'reference/prototype-api',
-              badge: inProgressBadge,
             },
             {
               label: 'Compatibility',
               translations: { en: 'Compatibility', 'zh-CN': '兼容性' },
               slug: 'reference/compatibility',
-              badge: inProgressBadge,
             },
           ],
         },

--- a/apps/www/src/content/docs/en/reference/compatibility.md
+++ b/apps/www/src/content/docs/en/reference/compatibility.md
@@ -1,12 +1,56 @@
 ---
 title: 'Compatibility'
-description: 'A lightweight overview of current adapter and host support.'
+description: 'The reviewed Adapter profile slice and the limits of current compatibility evidence.'
 ---
 
-This page tracks Proto UI support from a compatibility point of view rather than as a full ecosystem roadmap.
+Compatibility in Proto UI is recorded through Adapter profile entities and their typed relations to Modules, host capabilities, and executable evidence. This page reports the slice that has actually been reviewed; it is not an inferred feature matrix or an ecosystem roadmap.
 
-- which hosts are currently represented by adapters
-- which adapters are official or reference implementations
-- where support is still partial or experimental
+## Official Adapter profiles
 
-For contribution paths, continue to [Build / Contribute](/en/build/contribute/).
+| Profile | Public package | Target | Framework range | Lifecycle |
+| --- | --- | --- | --- | --- |
+| `A-WEB-COMPONENT-0001` | `@proto.ui/adapter-web-component` | Web / Custom Elements | Platform APIs | `active` since 0.2.0-rc.7 |
+| `A-REACT-18-19-0001` | `@proto.ui/adapter-react` | Web / React | `>=18.2.0 <20` | `active` since 0.2.0-rc.7 |
+| `A-VUE-3-0001` | `@proto.ui/adapter-vue` | Web / Vue | `>=3.4.0 <4` | `active` since 0.2.0-rc.7 |
+
+All three are official Web profiles. React and Vue provide cross-Adapter evidence across framework runtimes; they do **not** constitute multi-host evidence for native mobile, desktop, or server UI. No official profile for those hosts is currently cataloged.
+
+## Reviewed common slice
+
+Each current profile records required support for the same semantic Modules:
+
+| Module entity         | Capability              |
+| --------------------- | ----------------------- |
+| `M-PROPS-0001`        | Props ingress           |
+| `M-EVENT-0001`        | Semantic event binding  |
+| `M-STATE-0001`        | Owned State projection  |
+| `M-EXPOSE-0001`       | External expose surface |
+| `M-EXPOSE-STATE-0001` | Exposed State           |
+| `M-EXPOSE-EVENT-0001` | Exposed Event           |
+
+Each profile also records translated provision of these host capabilities:
+
+| Host capability entity        | Host-facing responsibility          |
+| ----------------------------- | ----------------------------------- |
+| `HC-PROPS-SOURCE-0001`        | Supply Props values and presence    |
+| `HC-EVENT-BINDING-0001`       | Bind host events to semantic events |
+| `HC-DEFAULT-ACTION-0001`      | Represent default-action control    |
+| `HC-EXPOSES-RECORD-SINK-0001` | Receive the exposed record          |
+| `HC-EXPOSE-EVENT-SINK-0001`   | Receive exposed events              |
+
+This means the listed slice has been reviewed positively for all three profiles. It does **not** mean every Module package or every Core capability has been classified. The profiles currently contain no `omits` relations: an unlisted Module is **uncataloged**, not implicitly supported, unsupported, or deferred.
+
+## Evidence and interpretation
+
+`D-ADAPTER-PROFILE-0001` governs how a partial profile must be read. `T-ADAPTER-PROFILE-0001` verifies profile schema and graph integrity, while the profiles point to executable conformance entities for the Props, Event, Lifecycle, State, and Expose slices.
+
+Use these labels precisely:
+
+- **Cataloged support:** a reviewed `supports.modules` relation with a role.
+- **Cataloged omission:** a reviewed `omits.modules` relation with a reason. None are recorded in the current three profiles.
+- **Uncataloged:** no support or omission decision has been made in the profile.
+- **No official profile:** the catalog has no official Adapter identity for that host.
+
+Package availability and entity lifecycle are separate. Proto UI 0.2.0 is a published stable ecosystem release (`V-PROTO-UI-0008`), while the current workspace can contain later draft entities and the draft 0.3.0-alpha.0 train. Always combine the release identity, profile lifecycle, exact relations, and executable evidence before making a compatibility claim.
+
+For the underlying protocol model, read [Core](/en/specifications/core/). For implementation and contribution paths, continue to [Build / Contribute](/en/build/contribute/).

--- a/apps/www/src/content/docs/en/reference/prototype-api.md
+++ b/apps/www/src/content/docs/en/reference/prototype-api.md
@@ -1,7 +1,82 @@
 ---
 title: 'Prototype API'
-desp: 'API surface for prototypes'
-description: 'API surface for prototypes'
+desp: 'Public authoring entry points and their protocol roles'
+description: 'Public authoring entry points and their protocol roles'
 ---
 
-Coming soon.
+This page maps the public TypeScript authoring API to Proto UI's protocol surfaces. It is an engineering reference, not an independent specification: when API behavior and a spec entity disagree, the applicable entity governs.
+
+The entry points below exist in the published 0.2.0 packages and in the current workspace. That API availability does not promote related `draft` entities to `active`, and the current workspace may also carry changes for the draft 0.3.0-alpha.0 train.
+
+## Definition shape
+
+`definePrototype` creates a normal Prototype definition. `defineAsHook` creates the special composable form. Both can share one setup function:
+
+```ts
+import type { DefHandle } from '@proto.ui/core';
+import { defineAsHook, definePrototype } from '@proto.ui/core';
+import { asFocusable, asTrigger } from '@proto.ui/hooks';
+
+type ToggleProps = { disabled?: boolean };
+
+function setupToggle(def: DefHandle<ToggleProps>) {
+  asTrigger();
+  asFocusable<ToggleProps>();
+
+  def.props.define({ disabled: { type: 'boolean', empty: 'fallback' } });
+  const active = def.state.bool('active', false);
+  def.expose.state('active', active);
+
+  def.event.on('press.commit', (run) => {
+    active.set(!active.get(), 'toggle');
+    run.expose.emit('activeChange', { active: active.get() });
+  });
+}
+
+export const asToggle = defineAsHook({ name: 'as-toggle', setup: setupToggle });
+export default definePrototype({ name: 'base-toggle', setup: setupToggle });
+```
+
+This is a reduced example of the shared setup pattern used by the official Base Toggle. Production behavior also declares controlled Props, focus behavior, accessibility, and transient interaction State.
+
+## Public entry points
+
+| Package | API | Role |
+| --- | --- | --- |
+| `@proto.ui/core` | `definePrototype` | Create a normal Prototype definition |
+| `@proto.ui/core` | `defineAsHook` | Create a special composable prototype form with a structured result |
+| `@proto.ui/core` | `moduleDeclaration` / `declareModule` | Identify and declare semantic Module capabilities |
+| `@proto.ui/core` | `createAnatomyFamily` | Create a stable, static Anatomy family token whose canonical spec includes a root role |
+| `@proto.ui/hooks` | `asBoundary`, `asCollection`, `asCollectionItem`, `asFocusable`, `asFocusEntry`, `asFocusRoving`, `asFocusScope`, `asHitParticipation`, `asTextControl`, `asOverlay`, `asScrollSurface`, `asTrigger` | Official privileged semantic hooks used during setup |
+
+The hooks package is a semantic authoring surface, not a collection of React-style state hooks. Call these hooks from a Prototype setup frame.
+
+## Handles by phase
+
+### `DefHandle`: declare during setup
+
+`DefHandle` exposes the declaration families for lifecycle, Props, Feedback, Expose, Rule, Event, State, Context, Anatomy, and accessibility. Declarations establish identity and wiring; they should not be used as an escape hatch into a host framework.
+
+### Renderer handle: describe one root
+
+When setup returns a renderer, the renderer builds portable template children for one Root Node. Prototype-level component composition is deliberately outside this language; see [Template](/en/specifications/template/) and `K-PROTOTYPE-COMPOSITION-0001`.
+
+### `RunHandle`: act inside callbacks
+
+Registered callbacks receive `run`, which supplies the callback-time surfaces: current Props reads, Context reads and updates, allowed lifecycle/presence operations, Expose event emission, Feedback patches, and Anatomy queries. Phase guards are part of the contract; do not retain a callback handle and use it from arbitrary code later.
+
+## Composition and external surface
+
+`asHook` composes semantic behavior inside the current setup frame. Its returned State handles use the State declaration's stable name; nested asHooks remain structured children rather than being flattened into the parent result. Exposed names are App Maker-facing output and do not redefine internal State identity.
+
+Compound prototypes share an Anatomy family created with `createAnatomyFamily`, claim root and part roles, and let the host assemble the concrete part structure. A stable family is identified by its token reference, not by its diagnostic `debugName`.
+
+## Boundaries to keep visible
+
+- API presence is not lifecycle stability; check the related `C-*`, `D-*`, and `P-*` entities.
+- Templates do not embed other Prototype definitions.
+- Portable authoring APIs do not grant raw React, Vue, or Custom Element access.
+- A missing API or catalog relation is not automatically a prohibition; it may be an uncataloged gap.
+- State, Props, Expose, and Context have distinct ownership and phase rules. Follow their focused specifications rather than treating them as interchangeable storage.
+
+Continue to [Core](/en/specifications/core/) for the protocol model, [asHook](/en/specifications/as-hook/) for composition semantics, or [Compatibility](/en/reference/compatibility/) for the reviewed Adapter surface.

--- a/apps/www/src/content/docs/en/specifications/core.md
+++ b/apps/www/src/content/docs/en/specifications/core.md
@@ -1,7 +1,55 @@
 ---
 title: 'Core'
-desp: 'Core specification'
-description: 'Core specification'
+desp: 'Portable protocol boundaries and the shared authoring model'
+description: 'Portable protocol boundaries and the shared authoring model'
 ---
 
-Coming soon.
+Core describes the portable boundary shared by prototypes, semantic Modules, Runtime, and Adapters. It is a map of the cataloged contracts—not a substitute for the individual capability specifications.
+
+> **Lifecycle note:** the current `C-CORE-*` entities are `draft` since 0.1.0. They describe the cataloged direction implemented by the project, but are not yet an `active` stable guarantee.
+
+## Portable semantics, host translation
+
+A Prototype is a protocol actor. It declares semantic information channels without owning React components, Vue components, Custom Elements, or a particular rendering engine. Modules add reusable semantic capabilities. Host capabilities describe what an environment must supply or receive. An Adapter translates between those portable declarations and one host surface.
+
+This split produces two responsibilities:
+
+- Prototype and Module authors preserve channel meaning, execution phase, and cross-Adapter semantics.
+- Adapter authors translate those semantics without reinterpreting them, while keeping host-only mechanics at the boundary.
+
+Current official Adapter profiles all target the Web; see [Compatibility](/en/reference/compatibility/) for the exact reviewed slice.
+
+## Three authoring surfaces
+
+The Core syntax separates work by execution time:
+
+| Surface | Handle | Responsibility |
+| --- | --- | --- |
+| Setup | `def` | Declare props, state, events, lifecycle callbacks, exposure, anatomy, a11y, and other semantic structure |
+| Render | renderer handle | Produce `TemplateChildren` for one Root Node |
+| Callback | `run` | Read current inputs, update allowed runtime surfaces, emit exposed events, and query anatomy |
+
+A definition object has a stable `name` and a `setup(def)` function. Setup may return a renderer or return nothing. Callbacks registered during setup receive `run`; phase-restricted operations must not leak into setup or render work.
+
+Read the focused specifications for the exact rules: [Lifecycle](/en/specifications/lifecycle/), [Template](/en/specifications/template/), [Props](/en/specifications/props/), [Event](/en/specifications/event/), [Expose](/en/specifications/expose/), [State](/en/specifications/state/), [Context](/en/specifications/context/), [Anatomy](/en/specifications/anatomy/), [Feedback](/en/specifications/feedback/), [asHook](/en/specifications/as-hook/), and [Rule](/en/specifications/rule/).
+
+## Information channels
+
+`K-COMPONENT-ACTOR-0001` and `K-INFORMATION-CHANNEL-0001` provide the current conceptual model: a component actor exchanges information through declared channels rather than by reaching into a host implementation. Different channels have different ownership and timing—for example, Props ingress is not interchangeable with Expose egress, and owned State is not an arbitrary external store.
+
+The channel model is why an operation can be syntactically available yet invalid in the current phase. It is also why Adapters may differ mechanically while preserving the same observable protocol meaning.
+
+## Composition boundary
+
+The template language describes structure **inside one Root Node**. It does not compose one Prototype by embedding another Prototype in a template (`K-PROTOTYPE-COMPOSITION-0001`). Semantic reuse instead happens through Modules and the special `asHook` prototype form. Compound structures use shared Anatomy families and host-side part assembly.
+
+This boundary keeps host ownership explicit and prevents a framework-specific component tree from becoming portable protocol syntax.
+
+## How to interpret gaps
+
+- A `draft` entity is usable as current formal direction, but must be labeled as draft.
+- An uncataloged behavior is not automatically forbidden or guaranteed.
+- A source path or passing test is evidence, not an amendment to a conflicting entity.
+- Open questions remain explicit gaps until the catalog resolves them.
+
+For API-shaped examples of these surfaces, continue to [Prototype API](/en/reference/prototype-api/). For catalog authority and lifecycle, read [How to Read Specs](/en/specifications/introduction/).

--- a/apps/www/src/content/docs/en/specifications/introduction.md
+++ b/apps/www/src/content/docs/en/specifications/introduction.md
@@ -1,7 +1,67 @@
 ---
 title: 'How to Read Specs'
-desp: 'How to approach the specs'
-description: 'How to approach the specs'
+desp: 'Authority, lifecycle, relations, and a practical reading path for the Proto UI catalog'
+description: 'Authority, lifecycle, relations, and a practical reading path for the Proto UI catalog'
 ---
 
-Coming soon.
+The Specifications section is the public reading guide to Proto UI's machine-governed entity catalog. It helps you answer “what does the project currently guarantee?”, trace a rule to evidence, and distinguish a stable contract from work that is only cataloged as current direction.
+
+The catalog is intentionally incomplete. Presence does not imply stability, and absence does not imply that an implementation has no behavior.
+
+## Authority
+
+When sources disagree, use this order:
+
+1. An applicable entity in `spec/**` is authoritative.
+2. Internal contract prose can fill an uncataloged gap, but cannot override an entity.
+3. Engineering records preserve observations, alternatives, and time-bound direction; they are not normative.
+4. Implementation and tests show current behavior. A mismatch with an entity is drift to investigate, not an implicit contract change.
+5. This website and package READMEs are reader-facing projections and should be corrected when they drift.
+
+The pages in this section explain the catalog; they do not create a second source of truth. Use the entity ID and criterion ID when a review or implementation needs an exact, stable reference.
+
+## Entity types
+
+| Prefix | Entity | Responsibility |
+| --- | --- | --- |
+| `C-` | Contract | Cross-cutting protocol rules and acceptance criteria |
+| `P-` | Prototype | Official prototype or prototype-part identity and behavior |
+| `M-` | Module | Semantic module identity and the contracts it satisfies |
+| `A-` | Adapter | Official Adapter profile, target runtime, and reviewed support decisions |
+| `D-` | Decision | Stabilized design or governance choice |
+| `HC-` | Host capability | Capability expected from or projected to a host |
+| `T-` | Test | Conformance case and executable evidence mapping |
+| `V-` | Version | Release identity, channel, package policy, and publication evidence |
+| `K-` | Knowledge | Shared vocabulary and explanatory model |
+
+Entities form a typed graph. Relations such as `satisfies`, `verifies`, `supports`, `provides`, and `omits` connect a rule to ownership and evidence. For Adapter profiles specifically, a module missing from both `supports` and `omits` is **uncataloged**—not implicitly supported or unsupported.
+
+## Lifecycle is separate from release version
+
+Every entity has a `since` version and a lifecycle status:
+
+| Status       | Meaning                                                                      |
+| ------------ | ---------------------------------------------------------------------------- |
+| `active`     | Current applicable guarantee                                                 |
+| `draft`      | Cataloged current direction, not a stable public guarantee                   |
+| `deprecated` | Kept for compatibility or migration; read `deprecatedSince` and `replacedBy` |
+| `removed`    | Historical and unavailable from `removedSince` onward                        |
+
+Do not collapse three different things into one “current version”:
+
+- `V-PROTO-UI-0008` records the published, immutable **0.2.0 stable** ecosystem snapshot.
+- The checked-out catalog is the current workspace projection and may include later draft work.
+- At the time of this page, `V-PROTO-UI-0009` describes a **draft 0.3.0-alpha.0** release train; it is not publication evidence.
+
+A package being published in 0.2.0 does not automatically make every related entity `active`. Read the entity lifecycle and the release evidence independently.
+
+## A practical reading path
+
+Start with [Core](/en/specifications/core/) for the portable boundary and authoring phases. Then follow the capability that owns your question:
+
+- [Lifecycle](/en/specifications/lifecycle/), [Template](/en/specifications/template/), and [Props](/en/specifications/props/)
+- [Event](/en/specifications/event/), [Expose](/en/specifications/expose/), and [State](/en/specifications/state/)
+- [Context](/en/specifications/context/), [Anatomy](/en/specifications/anatomy/), and [Feedback](/en/specifications/feedback/)
+- [asHook](/en/specifications/as-hook/) and [Rule](/en/specifications/rule/)
+
+For an exact claim, continue from the named entity to its criteria, relations, sources, and `T-*` evidence. For motivation, return to the Whitepaper. For implementation mechanics, continue to Engineering or Reference.

--- a/apps/www/src/content/docs/zh-cn/reference/compatibility.md
+++ b/apps/www/src/content/docs/zh-cn/reference/compatibility.md
@@ -1,12 +1,56 @@
 ---
 title: '兼容性'
-description: '当前适配器与宿主支持情况的轻量概览。'
+description: '已审计的 Adapter profile 切片，以及当前兼容性证据的边界。'
 ---
 
-这页从兼容性角度整理 Proto UI 当前的支持面，而不是承担完整的生态路线图说明。
+Proto UI 通过 Adapter profile 实体及其指向 Module、host capability 与可执行证据的类型关系记录兼容性。本文只报告实际完成审计的切片，不从 package inventory 推导完整 feature matrix，也不承担生态路线图。
 
-- 当前有哪些宿主已有适配器承接
-- 哪些适配器属于官方或参考实现
-- 哪些支持仍处于部分完成或实验阶段
+## 官方 Adapter profile
 
-如果你想参与建设，继续前往 [Build / 参与贡献](/zh-cn/build/contribute/)。
+| Profile | 公开 package | 目标 | Framework 范围 | 生命周期 |
+| --- | --- | --- | --- | --- |
+| `A-WEB-COMPONENT-0001` | `@proto.ui/adapter-web-component` | Web / Custom Elements | Platform APIs | 从 0.2.0-rc.7 起 `active` |
+| `A-REACT-18-19-0001` | `@proto.ui/adapter-react` | Web / React | `>=18.2.0 <20` | 从 0.2.0-rc.7 起 `active` |
+| `A-VUE-3-0001` | `@proto.ui/adapter-vue` | Web / Vue | `>=3.4.0 <4` | 从 0.2.0-rc.7 起 `active` |
+
+三者都是官方 Web profile。React 与 Vue 提供跨 framework runtime 的 cross-Adapter 证据，但这**不是** native mobile、desktop 或 server UI 的 multi-host 证据；目录当前没有这些宿主的官方 profile。
+
+## 已审计的共同切片
+
+三个 profile 都记录了对以下语义 Module 的 required support：
+
+| Module entity         | 能力                   |
+| --------------------- | ---------------------- |
+| `M-PROPS-0001`        | Props ingress          |
+| `M-EVENT-0001`        | 语义 event binding     |
+| `M-STATE-0001`        | Owned State projection |
+| `M-EXPOSE-0001`       | 外部 expose surface    |
+| `M-EXPOSE-STATE-0001` | Exposed State          |
+| `M-EXPOSE-EVENT-0001` | Exposed Event          |
+
+三个 profile 还以 translated 方式提供以下 host capability：
+
+| Host capability entity        | 宿主侧职责                         |
+| ----------------------------- | ---------------------------------- |
+| `HC-PROPS-SOURCE-0001`        | 提供 Props value 与 presence       |
+| `HC-EVENT-BINDING-0001`       | 把宿主 event 绑定到 semantic event |
+| `HC-DEFAULT-ACTION-0001`      | 表达 default-action control        |
+| `HC-EXPOSES-RECORD-SINK-0001` | 接收 exposed record                |
+| `HC-EXPOSE-EVENT-SINK-0001`   | 接收 exposed event                 |
+
+这说明上述切片已在三个 profile 中完成正向审计，并不表示所有 Module package 或 Core capability 都已分类。当前 profile 没有 `omits` relation：未列出的 Module 只是**尚未登记**，不能被自动解释为支持、不支持或延期。
+
+## 证据与解释方式
+
+`D-ADAPTER-PROFILE-0001` 规定 partial profile 的阅读方式。`T-ADAPTER-PROFILE-0001` 验证 profile schema 与 graph integrity；各 profile 还指向 Props、Event、Lifecycle、State 与 Expose 切片的可执行 conformance entity。
+
+请精确使用以下表述：
+
+- **已登记支持：**存在带 role 的、经过审计的 `supports.modules` relation。
+- **已登记省略：**存在带原因的、经过审计的 `omits.modules` relation；当前三个 profile 均没有此类记录。
+- **尚未登记：**profile 尚未作出支持或省略决策。
+- **没有官方 profile：**目录没有该宿主的官方 Adapter identity。
+
+Package availability 与 entity lifecycle 彼此独立。Proto UI 0.2.0 是已经发布的稳定生态版本（`V-PROTO-UI-0008`），当前工作区则可以包含此后的 draft entity 与 draft 0.3.0-alpha.0 train。兼容性判断必须同时读取发行身份、profile lifecycle、精确 relation 与可执行证据。
+
+底层协议模型见[核心规范](/zh-cn/specifications/core/)；实现与参与路径见 [Build / 参与贡献](/zh-cn/build/contribute/)。

--- a/apps/www/src/content/docs/zh-cn/reference/prototype-api.md
+++ b/apps/www/src/content/docs/zh-cn/reference/prototype-api.md
@@ -1,53 +1,82 @@
 ---
 title: 'Prototype API'
-desp: '原型 API'
-description: '原型 API'
+desp: '公开作者入口及其协议职责'
+description: '公开作者入口及其协议职责'
 ---
 
-## 这篇解决什么工程问题？
+本文把公开 TypeScript 作者 API 映射到 Proto UI 的协议表面。它是工程参考，不是独立规范；当 API 行为与 spec entity 冲突时，以适用实体为准。
 
-写作提示：
+下列入口同时存在于已发布的 0.2.0 package 和当前工作区中。API 已经可用，不会自动把相关 `draft` 实体提升为 `active`；当前工作区还可能包含面向 draft 0.3.0-alpha.0 train 的变化。
 
-- 解释原型作者在代码层如何表达 Proto UI 的能力。
-- 解释原型 API 如何把规范语义组织成可编写、可组合的形式。
+## Definition 结构
 
-## 主要读者是谁？
+`definePrototype` 创建普通 Prototype definition，`defineAsHook` 创建特殊的可组合形态。两者可以共享同一个 setup 函数：
 
-写作提示：
+```ts
+import type { DefHandle } from '@proto.ui/core';
+import { defineAsHook, definePrototype } from '@proto.ui/core';
+import { asFocusable, asTrigger } from '@proto.ui/hooks';
 
-- 给想理解原型表达层的人。
-- 给研究原型 API 与协议语义映射关系的人。
+type ToggleProps = { disabled?: boolean };
 
-## 前置阅读
+function setupToggle(def: DefHandle<ToggleProps>) {
+  asTrigger();
+  asFocusable<ToggleProps>();
 
-写作提示：
+  def.props.define({ disabled: { type: 'boolean', empty: 'fallback' } });
+  const active = def.state.bool('active', false);
+  def.expose.state('active', active);
 
-- 指向 `Whitepaper / 信息通路模型`
-- 指向 `Specifications / Core` 及各单项能力规范
+  def.event.on('press.commit', (run) => {
+    active.set(!active.get(), 'toggle');
+    run.expose.emit('activeChange', { active: active.get() });
+  });
+}
 
-## 核心结构 / 机制
+export const asToggle = defineAsHook({ name: 'as-toggle', setup: setupToggle });
+export default definePrototype({ name: 'base-toggle', setup: setupToggle });
+```
 
-写作提示：
+这是官方 Base Toggle 共享 setup 模式的精简示例。生产实现还声明了 controlled Props、focus 行为、accessibility 与 transient interaction State。
 
-- 解释原型 API 如何围绕执行时期、能力分层、组合边界被组织。
-- 解释 `asHook`、能力声明、组合方式等在代码层的位置。
+## 公开入口
 
-## 关键 API / SPI
+| Package | API | 职责 |
+| --- | --- | --- |
+| `@proto.ui/core` | `definePrototype` | 创建普通 Prototype definition |
+| `@proto.ui/core` | `defineAsHook` | 创建具有结构化结果的特殊可组合原型形态 |
+| `@proto.ui/core` | `moduleDeclaration` / `declareModule` | 标识并声明语义 Module 能力 |
+| `@proto.ui/core` | `createAnatomyFamily` | 创建稳定、static-only 的 Anatomy family token，其 canonical spec 必须包含 root role |
+| `@proto.ui/hooks` | `asBoundary`, `asCollection`, `asCollectionItem`, `asFocusable`, `asFocusEntry`, `asFocusRoving`, `asFocusScope`, `asHitParticipation`, `asTextControl`, `asOverlay`, `asScrollSurface`, `asTrigger` | 在 setup 阶段使用的官方 privileged semantic hooks |
 
-写作提示：
+hooks package 是语义作者表面，不是 React 风格的 state hook 集合；这些 hook 应在 Prototype setup frame 中调用。
 
-- 列出最值得理解的 API 家族，而不是完整参考表。
+## 按 phase 划分的 Handle
 
-## 常见误解或边界
+### `DefHandle`：在 setup 中声明
 
-写作提示：
+`DefHandle` 提供 lifecycle、Props、Feedback、Expose、Rule、Event、State、Context、Anatomy 与 accessibility 的声明入口。Declaration 建立身份和 wiring，不能被当作进入宿主 framework 的逃生口。
 
-- 区分“原型 API”与“正式规范”。
-- 区分“能在代码里这么写”与“协议层语义允许这么做”。
+### Renderer handle：描述一个 root
 
-## 下一步读什么？
+当 setup 返回 renderer 时，renderer 为一个 Root Node 构造可移植 template children。Prototype-level component composition 被明确排除在这门语言之外；见 [Template](/zh-cn/specifications/template/) 与 `K-PROTOTYPE-COMPOSITION-0001`。
 
-写作提示：
+### `RunHandle`：在 callback 中执行
 
-- 如果想看执行承载层：前往 `Runtime 架构`
-- 如果想看宿主翻译层：前往 `Adapter 指南`
+登记的 callback 会收到 `run`，其中包括 callback-time 的当前 Props 读取、Context 读取与更新、允许的 lifecycle/presence 操作、Expose event 发出、Feedback patch 与 Anatomy query。Phase guard 是 contract 的一部分；不要保留 callback handle 并在之后的任意代码中使用。
+
+## 组合与外部表面
+
+`asHook` 在当前 setup frame 内组合语义行为。返回的 State handle 以 State declaration 的稳定名称命名；嵌套 asHook 保持为结构化 child，不会被摊平到父结果中。Expose name 是面向 App Maker 的输出，不会反向定义内部 State identity。
+
+复合原型通过 `createAnatomyFamily` 共享 Anatomy family，声明 root 与 part role，再由宿主组装实际 part 结构。稳定 family 以 token 引用身份区分，而不是以诊断用的 `debugName` 区分。
+
+## 必须保持可见的边界
+
+- API 存在不等于生命周期稳定；仍需检查相关 `C-*`、`D-*` 与 `P-*` 实体。
+- Template 不嵌入其他 Prototype definition。
+- 可移植作者 API 不提供原始 React、Vue 或 Custom Element 访问。
+- 缺少 API 或 catalog relation 不一定表示禁止，也可能只是尚未登记的空白。
+- State、Props、Expose 与 Context 的所有权和 phase 规则不同，不能被当作可互换的存储。
+
+接下来可阅读[核心规范](/zh-cn/specifications/core/)理解协议模型，阅读 [asHook](/zh-cn/specifications/as-hook/)理解组合语义，或阅读[兼容性](/zh-cn/reference/compatibility/)查看已审计的 Adapter 表面。

--- a/apps/www/src/content/docs/zh-cn/specifications/core.md
+++ b/apps/www/src/content/docs/zh-cn/specifications/core.md
@@ -1,54 +1,55 @@
 ---
 title: '核心规范'
-desp: '核心规范内容'
-description: '核心规范内容'
+desp: '可移植协议边界与共享作者模型'
+description: '可移植协议边界与共享作者模型'
 ---
 
-## 摘要
+Core 描述 Prototype、语义 Module、Runtime 与 Adapter 共享的可移植边界。它是现有 contract 的导航图，不取代各项能力规范。
 
-写作提示：
+> **生命周期提示：**当前 `C-CORE-*` 实体从 0.1.0 起均为 `draft`。它们描述项目已实现并登记的当前方向，但尚不是 `active` 稳定保证。
 
-- 用一小段连续可读的文字说明 `Core` 是所有规范的总入口。
-- 这里要定义 Proto UI 的基础术语、共通不变量与跨能力共享的判断原则。
+## 可移植语义与宿主翻译
 
-## 这篇规范定义什么？
+Prototype 是协议 actor。它声明语义信息通路，但不拥有 React component、Vue component、Custom Element 或特定渲染引擎。Module 提供可复用的语义能力，Host capability 描述环境需要提供或接收的能力，Adapter 则在可移植声明与某个宿主表面之间进行翻译。
 
-写作提示：
+因此有两组责任：
 
-- 定义 Proto UI 里的基础概念，例如 Prototype、Adapter、Host、信息通路、执行时期、生命周期相位等。
-- 定义哪些概念属于协议核心，哪些概念属于宿主边界或工程实现。
+- Prototype 与 Module 作者需要保持通路含义、执行时期和跨 Adapter 语义一致。
+- Adapter 作者需要在不重解释语义的前提下完成翻译，并把宿主专属机制留在边界上。
 
-## 对原型作者意味着什么？
+当前官方 Adapter profile 均以 Web 为目标；已审计的准确切片见[兼容性](/zh-cn/reference/compatibility/)。
 
-写作提示：
+## 三个作者表面
 
-- 说明原型作者在任何单项能力之外，默认必须遵守的共通语义。
-- 例如执行时期、生命周期顺序、原型与宿主的责任边界。
+Core syntax 按执行时间把工作分开：
 
-## 对适配器作者意味着什么？
+| 表面 | Handle | 职责 |
+| --- | --- | --- |
+| Setup | `def` | 声明 props、state、event、lifecycle callback、expose、anatomy、a11y 等语义结构 |
+| Render | renderer handle | 为一个 Root Node 生成 `TemplateChildren` |
+| Callback | `run` | 读取当前输入、更新允许的运行时表面、发出 expose event、查询 anatomy |
 
-写作提示：
+Definition object 具有稳定 `name` 与 `setup(def)` 函数。Setup 可以返回 renderer，也可以不返回。Setup 中登记的 callback 会收到 `run`；受 phase 限制的操作不能泄漏到 setup 或 render 阶段。
 
-- 说明适配器作者必须守住的核心不变量。
-- 例如生命周期相位顺序不得颠倒、信息通路语义不得被重解释。
+具体规则请阅读对应规范：[生命周期](/zh-cn/specifications/lifecycle/)、[Template](/zh-cn/specifications/template/)、[Props](/zh-cn/specifications/props/)、[Event](/zh-cn/specifications/event/)、[Expose](/zh-cn/specifications/expose/)、[State](/zh-cn/specifications/state/)、[Context](/zh-cn/specifications/context/)、[Anatomy](/zh-cn/specifications/anatomy/)、[Feedback](/zh-cn/specifications/feedback/)、[asHook](/zh-cn/specifications/as-hook/) 与 [Rule](/zh-cn/specifications/rule/)。
 
-## 正式语义
+## 信息通路
 
-写作提示：
+`K-COMPONENT-ACTOR-0001` 与 `K-INFORMATION-CHANNEL-0001` 给出当前概念模型：component actor 通过声明过的信息通路交换信息，而不是直接进入宿主实现。不同通路的所有权和时机不同——例如 Props ingress 不能与 Expose egress 互换，owned State 也不是任意外部 store。
 
-- 用规范性语言定义核心术语与全局不变量。
-- 这里适合写跨所有能力共享的 MUST / SHOULD / MUST NOT 级别约束。
+通路模型解释了为什么一个操作即使语法上存在，也可能在当前 phase 无效；它也允许 Adapter 的机械实现不同，同时保持可观察的协议含义一致。
 
-## 有效行为 / 无效行为 / 未定义行为
+## 组合边界
 
-写作提示：
+Template language 描述的是**一个 Root Node 内部**的结构，不通过在 template 中嵌入另一个 Prototype 来完成 prototype composition（`K-PROTOTYPE-COMPOSITION-0001`）。语义复用通过 Module 与特殊的 `asHook` 原型形态完成；复合结构则使用共享 Anatomy family，并由宿主侧组装各 part。
 
-- 把一些常见边界情况放在这里裁决。
-- 尤其是“允许不同宿主推进速度不同，但不允许相位顺序颠倒”这类全局问题。
+这一边界让宿主所有权保持明确，也避免某个 framework 的 component tree 变成可移植协议语法。
 
-## 与其他规范的关系
+## 如何理解目录空白
 
-写作提示：
+- `draft` 实体可以作为当前正式方向使用，但必须明确标示 draft。
+- 尚未被目录登记的行为，不能自动判定为禁止或保证。
+- source path 或通过的测试是证据，不能暗中修改与其冲突的实体。
+- open question 在目录解决前始终是明确的空白。
 
-- 说明各单项能力规范都受 `Core` 约束。
-- 说明 `Core` 不替代单项能力规范，只提供共享基础。
+需要查看这些表面对应的 API 示例，请继续阅读 [Prototype API](/zh-cn/reference/prototype-api/)；需要理解目录权威性和生命周期，请阅读[规范导读](/zh-cn/specifications/introduction/)。

--- a/apps/www/src/content/docs/zh-cn/specifications/introduction.md
+++ b/apps/www/src/content/docs/zh-cn/specifications/introduction.md
@@ -1,53 +1,67 @@
 ---
 title: '规范导读'
-desp: '如何阅读规范'
-description: '如何阅读规范'
+desp: 'Proto UI 实体目录的权威性、生命周期、关系与阅读路径'
+description: 'Proto UI 实体目录的权威性、生命周期、关系与阅读路径'
 ---
 
-## 这篇文章要回答什么？
+Specifications 是 Proto UI 机器治理实体目录的公开阅读指南。它帮助你判断“项目当前保证什么”、把规则追溯到证据，并区分稳定契约与仅作为当前方向登记的工作。
 
-- `Specifications` 这一章在整个文档站里承担什么职责。
-- 规范文与白皮书、工程文档分别有什么分工。
-- 这一章应该如何阅读、如何查阅、如何引用。
+目录有意保持不完整。一个实体已经存在，不代表它已经稳定；一个实体尚未出现，也不代表实现中不存在相关行为。
 
-## 这一章不负责什么？
+## 权威顺序
 
-写作提示：
+当不同来源出现冲突时，按以下顺序处理：
 
-- 说明它不承担项目动机论证，那是 `Whitepaper` 的职责。
-- 说明它不承担工程实现与 API 教程，那是 `Engineering` 的职责。
-- 说明它也不是新读者的 onboarding 入口，那是 `Start Here` 的职责。
+1. `spec/**` 中适用的实体是权威来源。
+2. 内部 contract prose 可以补充尚未被目录登记的空白，但不能覆盖已有实体。
+3. 工程记录保存观察、备选方案与阶段性方向，不具有规范性。
+4. 实现与测试是当前行为的证据。它们与实体不一致时，应调查 drift，而不是默认契约已经改变。
+5. 本站和 package README 是面向读者的投影；发生漂移时应修正投影。
 
-## 这一章负责什么？
+本章负责解释目录，不建立第二套事实来源。评审或实现需要精确引用时，请使用 entity ID 与 criterion ID。
 
-写作提示：
+## 九类实体
 
-- 说明它定义的是 Proto UI 的正式语义与契约边界。
-- 说明它需要同时服务原型作者与适配器作者。
-- 说明它更适合被查阅、引用与裁决歧义，而不是连续读完。
+| 前缀  | 实体            | 职责                                             |
+| ----- | --------------- | ------------------------------------------------ |
+| `C-`  | Contract        | 跨领域协议规则与验收条件                         |
+| `P-`  | Prototype       | 官方原型或原型部件的身份与行为                   |
+| `M-`  | Module          | 语义模块身份及其满足的 contract                  |
+| `A-`  | Adapter         | 官方 Adapter profile、目标运行时与已审计支持决策 |
+| `D-`  | Decision        | 已稳定的设计或治理选择                           |
+| `HC-` | Host capability | 宿主应提供或被投影出的能力                       |
+| `T-`  | Test            | 一致性案例与可执行证据映射                       |
+| `V-`  | Version         | 发行身份、channel、package policy 与发布证据     |
+| `K-`  | Knowledge       | 共享术语与解释模型                               |
 
-## 建议如何阅读这一章？
+实体通过带类型的关系组成图。`satisfies`、`verifies`、`supports`、`provides`、`omits` 等关系把规则、所有权与证据连接起来。尤其对 Adapter profile 而言，一个 Module 同时不在 `supports` 和 `omits` 中，只表示它**尚未被目录审计**，不能据此判断支持或不支持。
 
-写作提示：
+## 生命周期不等于发行版本
 
-- 给首次进入规范区的读者一个建议顺序，例如先读 `Core`，再按能力逐项阅读。
-- 告诉读者每篇规范文前半适合顺读，后半适合按需查阅。
-- 告诉读者当问题涉及“为什么要这样设计”时，应回到 `Whitepaper`。
+每个实体同时声明 `since` 与生命周期状态：
 
-## 每篇规范文建议使用统一结构
+| 状态         | 含义                                                           |
+| ------------ | -------------------------------------------------------------- |
+| `active`     | 当前适用的保证                                                 |
+| `draft`      | 已登记的当前方向，但不是稳定公开保证                           |
+| `deprecated` | 为兼容或迁移保留；需继续阅读 `deprecatedSince` 与 `replacedBy` |
+| `removed`    | 从 `removedSince` 起不再可用，只保留历史                       |
 
-写作提示：
+不要把三种不同的“当前版本”混在一起：
 
-- 摘要：这项规范定义什么，解决什么语义问题。
-- 术语：本篇使用的核心术语。
-- 对原型作者意味着什么。
-- 对适配器作者意味着什么。
-- 正式语义。
-- 有效行为 / 无效行为 / 未定义行为。
-- 与其他规范的关系。
+- `V-PROTO-UI-0008` 记录已经发布且不可变的 **0.2.0 stable** 生态快照。
+- checkout 中的目录是当前工作区投影，可以包含此后的 draft 工作。
+- 在本文编写时，`V-PROTO-UI-0009` 描述的是 **draft 0.3.0-alpha.0** release train，并不构成已经发布的证据。
 
-## 这篇要把读者带到哪里？
+一个 package 已随 0.2.0 发布，不会自动把相关实体都变为 `active`；实体生命周期与发行证据必须分别阅读。
 
-写作提示：
+## 建议阅读路径
 
-- 把读者带到 `Core`，作为具体规范阅读的起点。
+先读[核心规范](/zh-cn/specifications/core/)，理解可移植边界与作者执行时期，再按问题所属能力继续：
+
+- [生命周期](/zh-cn/specifications/lifecycle/)、[Template](/zh-cn/specifications/template/) 与 [Props](/zh-cn/specifications/props/)
+- [Event](/zh-cn/specifications/event/)、[Expose](/zh-cn/specifications/expose/) 与 [State](/zh-cn/specifications/state/)
+- [Context](/zh-cn/specifications/context/)、[Anatomy](/zh-cn/specifications/anatomy/) 与 [Feedback](/zh-cn/specifications/feedback/)
+- [asHook](/zh-cn/specifications/as-hook/) 与 [Rule](/zh-cn/specifications/rule/)
+
+需要精确裁决时，从页面中点名的实体继续追踪 criteria、relations、sources 与 `T-*` 证据。需要理解设计动机时回到 Whitepaper；需要了解实现机制时前往 Engineering 或 Reference。


### PR DESCRIPTION
Closes #416

## Summary

- replace the bilingual Specifications Introduction and Core placeholders with a catalog-backed reading guide and portable protocol overview
- replace the bilingual Prototype API placeholder with a reference to the real 0.2 public authoring exports, handles, phases, and composition boundaries
- replace the lightweight Compatibility copy with the reviewed matrix from `A-WEB-COMPONENT-0001`, `A-REACT-18-19-0001`, and `A-VUE-3-0001`
- distinguish stable 0.2.0 release evidence, current workspace projection, entity lifecycle, cataloged support, uncataloged surface, and absent official host profiles
- remove the WIP badges from the four completed routes

## Scope notes

- this PR changes no spec entity, lifecycle status, protocol behavior, or generated projection
- the compatibility matrix intentionally reports only the currently reviewed shared Adapter slice; it does not infer a complete support matrix

## Validation

- `corepack pnpm@10.32.1 --filter apps-www check` — 142 files, 0 diagnostics
- `corepack pnpm@10.32.1 check:agent-doc`
- `corepack pnpm@10.32.1 check:prototype-catalog` — 118 declarations / 161 static entries / 117 cataloged prototypes
- `corepack pnpm@10.32.1 --filter apps-www build` — 196 pages
- browser audit of all 8 localized routes: expected headings/tables/code, no placeholder copy, no route WIP badge, no console errors