### PR TITLE
docs: complete the public Build architecture guides

### DIFF
--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -520,7 +520,6 @@ export default defineConfig({
               label: 'Runtime Architecture',
               translations: { en: 'Runtime Architecture', 'zh-CN': 'Runtime 架构' },
               slug: 'build/runtime-architecture',
-              badge: inProgressBadge,
             },
             {
               label: 'Adapter Guide',
@@ -532,25 +531,21 @@ export default defineConfig({
               label: 'Compiler Guide',
               translations: { en: 'Compiler Guide', 'zh-CN': 'Compiler 指南' },
               slug: 'build/compiler-guide',
-              badge: inProgressBadge,
             },
             {
               label: 'Host Caps',
               translations: { en: 'Host Caps', 'zh-CN': 'Host Caps' },
               slug: 'build/host-caps',
-              badge: inProgressBadge,
             },
             {
               label: 'Module & Extension Architecture',
               translations: { en: 'Module & Extension Architecture', 'zh-CN': '模块与扩展架构' },
               slug: 'build/module-extension-architecture',
-              badge: inProgressBadge,
             },
             {
               label: 'Contracts & Tests',
               translations: { en: 'Contracts & Tests', 'zh-CN': '契约与测试' },
               slug: 'build/contracts-and-tests',
-              badge: inProgressBadge,
             },
             {
               label: 'Contribute',

--- a/apps/www/src/content/docs/en/build/adapter-guide.md
+++ b/apps/www/src/content/docs/en/build/adapter-guide.md
@@ -1,41 +1,53 @@
 ---
 title: 'Adapter Contribution Guide Deferred'
-description: 'Why Proto UI does not infer a general Adapter authoring workflow from an incomplete catalog and current implementation.'
+description: 'The evidence available today, bounded Adapter work that may proceed, and why a general authoring workflow is not yet published.'
 ---
 
-Proto UI does not currently publish a general Adapter contribution guide.
+Proto UI does not currently publish a general Adapter authoring tutorial. The shipped 0.2 execution architecture and the first reviewed profile slices are now documented, but the catalog is intentionally partial and there is no stable public SPI for constructing a new Adapter by analogy.
 
-Module, Host Capability, and official Adapter-profile cataloging is still in progress. Architecture ownership, omission strategy, lifecycle resource ownership, and executable conformance have not all converged. The React, Vue, and Web Component implementations are important evidence, but they may still contain unresolved drift and cannot by themselves define a stable authoring API.
+Use the focused architecture guides first:
 
-Until that catalog chain is complete, this page will not:
+- [Runtime Architecture](/en/build/runtime-architecture/) explains `RuntimeSession`, commit ownership, and the host handoff.
+- [Host Caps](/en/build/host-caps/) explains capability tokens, wiring, target projection, and resource lifetime.
+- [Module & Extension Architecture](/en/build/module-extension-architecture/) explains facade/port/dependency ownership and the fixed Runtime Module set.
+- [Compatibility](/en/reference/compatibility/) reports only the currently reviewed relations for the official Web Component, React, and Vue profiles.
 
-- present the current Web Adapter structure as stable cross-host architecture;
-- provide a step-by-step new-Adapter tutorial;
+Those pages describe current facts; together they still do not define a complete new-Adapter recipe.
+
+## Why the general workflow remains deferred
+
+Official Adapter profiles are cataloged one Module slice at a time. Unlisted Modules are uncataloged, not implicitly supported or unsupported. Lifecycle ownership, capability omission strategy, host target roles, and executable conformance must all be decided for a concrete target. Existing Web implementations are evidence, but Web-specific routing and framework mechanics cannot define a cross-host architecture by themselves.
+
+This page therefore will not:
+
+- present current Web Adapter structure as a stable cross-host SPI;
 - infer complete Module support from package dependencies;
-- describe uncataloged fallback or host wiring as a formal guarantee; or
+- treat uncataloged fallback or host wiring as a guarantee;
+- promise dynamic Runtime Module registration; or
 - encourage Prototype-specific patches for Adapter parity problems.
 
-## What can contributors do now?
+## Bounded work that can proceed
 
-Experienced contributors may work on a bounded Adapter parity bug when its issue states:
+Experienced contributors may implement an Adapter parity bug when its Issue states:
 
 - applicable `C-*`, `M-*`, `HC-*`, `A-*`, and `T-*` entities;
-- the owning layer;
-- expected behavior and protocol boundaries that must remain unchanged;
-- focused conformance tests;
-- evidence to preserve or align across Web Component, React, and Vue; and
-- explicit authorization to implement.
+- the owning semantic or translation layer;
+- the profile and target runtime/version range;
+- behavior that must remain unchanged across Adapters;
+- focused Runtime/Module and Adapter evidence; and
+- explicit implementation authorization.
 
-New Adapter proposals are maintainer-guided research. They may collect a host-capability inventory, omission strategy, and minimal feasibility evidence, but they do not automatically authorize an implementation pull request.
+New Adapter proposals remain maintainer-guided research. A useful proposal can inventory host capabilities, model honest support/omission decisions, identify lifecycle and target ownership, and build minimal feasibility evidence. It does not automatically authorize a production Adapter PR.
 
-## When can a complete guide be published?
+## What would unlock a complete guide
 
-At minimum:
+A trustworthy exemplar needs:
 
-- relevant Module facade, port, and Host Capability ownership is cataloged;
-- official Adapter `supports`, `omits`, and `provides` relations have reviewed evidence;
-- lifecycle attach, rebind, reset, and disposal responsibilities are executable;
-- major drift between entities and implementation is resolved or recorded; and
-- one complete vertical slice can serve as a trustworthy exemplar.
+1. a coherent set of Module facade/port and Host Capability owners;
+2. reviewed profile `supports`, `omits`, and `provides` relations;
+3. executable attach/rebind/reset/dispose responsibilities;
+4. resolved or explicitly recorded implementation/catalog drift;
+5. target-specific commit, event, projection, and diagnostics behavior; and
+6. conformance evidence that separates portable semantics from host mechanics.
 
-Until then, use the [contribution guide](/en/build/contribute/) to choose a Prototype, docs, demo, or bounded bug path.
+Until then, choose a Prototype, docs, demo, Module slice, or bounded bug through [How to Contribute](/en/build/contribute/) and use [Contracts & Tests](/en/build/contracts-and-tests/) to design evidence.

--- a/apps/www/src/content/docs/en/build/compiler-guide.md
+++ b/apps/www/src/content/docs/en/build/compiler-guide.md
@@ -1,7 +1,93 @@
 ---
 title: 'Compiler Guide'
-desp: 'How to build compilers'
-description: 'How to build compilers'
+desp: 'The current Compiler boundary: what 0.2 ships, what the catalog constrains, and what remains future work'
+description: 'The current Compiler boundary: what 0.2 ships, what the catalog constrains, and what remains future work'
 ---
 
-Coming soon.
+Proto UI 0.2 does **not** ship a Compiler implementation or a Compiler authoring workflow. There is no `@proto.ui/compiler` package, compiler entity type, official compiler profile, CLI compile command, or supported compiler input/output artifact in the 0.2 release.
+
+This guide exists to stop future direction from being mistaken for shipped behavior. It records the boundaries a future Compiler would already have to respect and points contributors back to the runtime Adapter path that works today.
+
+## Prerequisites
+
+Read [Translation Layer: Adapter / Compiler](/en/whitepaper/translation-layer/) for the conceptual distinction, [Core](/en/specifications/core/) for portable syntax, and [Runtime Architecture](/en/build/runtime-architecture/) for the current execution path.
+
+## What 0.2 actually ships
+
+| Layer | Current responsibility |
+| --- | --- |
+| `@proto.ui/core` | Prototype definition, setup/render syntax, template structures, module declarations, Rule authoring types |
+| `@proto.ui/runtime` | Materialize a Prototype, run Modules, own lifecycle/update flow, hand commits to a host |
+| Official Adapters | Translate Runtime output and semantic host capabilities for Web Component, React, and Vue profiles |
+| `@proto.ui/cli` | Initialize projects and generate themes, tokens, styles, and component preset material; it is not a Prototype compiler |
+
+The current production route is therefore:
+
+```text
+Prototype TypeScript → Runtime execution → official Adapter → Web host
+```
+
+A possible future route is only a design direction:
+
+```text
+portable analyzable input → [future Compiler] → host artifacts
+```
+
+Nothing in 0.2 promises the second route's accepted source language, optimization model, generated files, runtime footprint, or compatibility policy.
+
+## Constraints that already apply
+
+Even without a Compiler package, cataloged protocol boundaries constrain any future official translation:
+
+- `K-PROTOTYPE-COMPOSITION-0001`: templates describe one Root Node; they do not embed another Prototype definition.
+- `C-TEMPLATE-0005`: the v0 slot is anonymous, singular, and parameterless.
+- `C-TEMPLATE-0006`: an official Adapter or Compiler encountering `PrototypeRef` as a template node must reject it rather than inventing private composition.
+- `C-RULE-0003`: Rule declarations produce serializable `RuleIR` without functions, host references, closures, or live handles.
+- `C-MODULE-DECLARATION-0001`: static typed Module declarations are available before Module construction and potential host selection.
+
+These are protocol constraints, not a Compiler SPI. They do not specify a parser, AST format, incremental build graph, code generator, or deployment artifact.
+
+## Static intent versus arbitrary functions
+
+Some authoring forms preserve more analyzable intent than callbacks. Rule is the clearest current example: it separates condition from semantic intent and compiles internally to `RuleIR` for Runtime evaluation. That does **not** mean the repository has a general Prototype compiler, nor that arbitrary callback bodies can be translated losslessly.
+
+Use declarative forms when they accurately express behavior, but do not rewrite working 0.2 semantics around an imagined compiler. `internal/contracts/integration/portability-and-integration.md` discusses this longer-term direction as explanatory, non-normative material.
+
+## No supported Compiler inputs or outputs yet
+
+| Question | 0.2 answer |
+| --- | --- |
+| Can a `.proto.ts` file be compiled without Runtime? | No supported workflow |
+| Is `TemplateChildren` a stable compiler IR? | No; it is current Core/Runtime template data |
+| Is `RuleIR` a complete Prototype IR? | No; it covers Rule only |
+| Can CLI emit React/Vue/Custom Element components from a Prototype? | No |
+| Is zero-runtime delivery supported? | No; it remains future direction |
+| Is there a Compiler conformance matrix? | No Compiler entity/profile exists |
+
+If a future proposal needs one of these answers to change, it requires explicit catalog and API work rather than documentation inference.
+
+## Contribution boundary
+
+A Compiler proposal should begin as maintainer-guided research. It must identify at least:
+
+1. the portable source subset and how unsupported constructs fail;
+2. the output host and ownership of generated artifacts;
+3. semantic parity with existing Contract criteria;
+4. lifecycle, capability, and component-composition treatment;
+5. a versioned identity and executable conformance model; and
+6. migration and coexistence with the Runtime/Adapter path.
+
+Do not open an implementation PR by treating `packages/modules/rule/src/compile.ts`, CLI style generation, or a bundler transform as the missing Compiler architecture. Those are bounded implementations with different owners.
+
+## Verification of the current boundary
+
+The following checks exercise the portable template and analyzable Rule constraints that exist today:
+
+```sh
+corepack pnpm@10.32.1 vitest run packages/core/test/contract/template.normalize.contract.test.ts
+corepack pnpm@10.32.1 vitest run packages/adapters/web-component/test/contract/template.no-prototype-composition.v0.contract.test.ts
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/rule.props-style.smoke.v0.contract.test.ts
+corepack pnpm@10.32.1 check:types
+```
+
+For work that can ship now, continue to [Runtime Architecture](/en/build/runtime-architecture/), [Module & Extension Architecture](/en/build/module-extension-architecture/), or the bounded [Adapter Guide](/en/build/adapter-guide/). For future sequencing, see [Roadmap](/en/project/roadmap/).

--- a/apps/www/src/content/docs/en/build/contracts-and-tests.md
+++ b/apps/www/src/content/docs/en/build/contracts-and-tests.md
@@ -1,7 +1,123 @@
 ---
 title: 'Contracts & Tests'
-desp: 'Contracts and testing guidelines'
-description: 'Contracts and testing guidelines'
+desp: 'How Proto UI connects normative criteria to executable evidence across layers'
+description: 'How Proto UI connects normative criteria to executable evidence across layers'
 ---
 
-Coming soon.
+Proto UI tests are not one undifferentiated gate. A useful contribution proves the claim at the layer that owns it and records how that evidence connects to the catalog. A green Adapter test cannot silently amend a Contract, and a Runtime fake host cannot prove browser behavior.
+
+## Prerequisites and authority
+
+Read [How to Read Specs](/en/specifications/introduction/) and the repository `spec/README.md` before changing normative behavior. The authority order is:
+
+```text
+applicable spec entity
+→ internal contract only for an uncataloged gap or explanation
+→ relevant dated record for short-term context
+→ implementation and tests as evidence
+→ website/README as reader projection
+```
+
+The former `internal/contracts/**` layer remains useful, but must be labeled transitional when no entity catalogs the subject. It cannot override an applicable entity.
+
+## The evidence graph
+
+`T-*` entities make acceptance criteria executable and traceable:
+
+```text
+C-* criterion / D-* choice / P-* protocol
+                 │ covers + verifies
+                 ▼
+              T-* case
+                 │ consumesCases
+                 ▼
+fixture / type test / module test / runtime test / adapter test / journey
+```
+
+A `T-*` entity records cases, expected outcomes, implementation paths, required status, and typed relations. The path is evidence; the relation explains what that evidence proves. Tests may also `exercise` a surface without claiming full normative verification.
+
+For example, `T-LIFECYCLE-0003` maps epoch-aware lifecycle criteria to Runtime session/checkpoint tests and lifecycle-event tests for Web Component, React, and Vue. The Runtime fixtures prove ordering and stale-epoch rejection; Adapter fixtures prove each framework projects the structured trace.
+
+## Test layers
+
+| Layer | Typical location | What it can prove |
+| --- | --- | --- |
+| Shared spec fixture | `packages/spec/fixtures/**` | Reusable case data and criterion mapping |
+| Schema/graph | `packages/spec/{schema,engine,graph}/test/**` | Entity validity, relation types, graph projection |
+| Type contract | `internal/contracts/types/**` | Public TypeScript shape and inference |
+| Core contract | `packages/core/test/contract/**` | Portable definition/template/token syntax |
+| Module contract | `packages/modules/*/test/**` | Semantic Module behavior with controlled dependencies/caps |
+| Runtime contract | `packages/runtime/test/contract/**` | Phase guards, lifecycle, orchestration, fake-host handoff |
+| Adapter contract | `packages/adapters/*/test/**` | Framework/DOM translation, lifecycle ownership, target wiring |
+| Prototype test | `packages/prototypes/*/test/**` | Official Prototype protocol and integration behavior |
+| Web journey | `packages/web-conformance/test/**` | One scenario across all official Web Adapters |
+| Public docs/build | `apps/www` checks and browser audit | Reachability, rendering, examples, reader projection |
+
+Use the lowest layer that observes the rule directly, then add integration evidence only where the claim crosses a boundary. Duplicating the same assertion in every Adapter is not a substitute for one shared Contract fixture plus focused translation checks.
+
+## Choosing coverage for a change
+
+### Contract or Core syntax
+
+Update the applicable `C-*` criteria, a `T-*` mapping, a shared fixture when useful, Core/Runtime implementation, and executable tests. A semantic revision may also require a versioned `revisions` entry.
+
+### Module or Host Capability
+
+Trace `C-* → M-* → HC-* → T-*`. Prove host-neutral semantics in the Module or Runtime with a fake capability, then prove real host realization in each applicable Adapter profile. Do not add an `A-* provides` relation based only on a package dependency.
+
+### Adapter translation
+
+Start from the exact `A-*` profile and reviewed `supports`, `omits`, and `provides` relations. Preserve the portable Contract and add profile-specific evidence. If the Module is absent from both support and omission, record that it is uncataloged rather than inventing matrix status in a test name.
+
+### Prototype behavior
+
+Trace `P-*` criteria to `T-*`, implementation, public exports, and website preview. Compound protocols often need Base tests plus applicable Adapter or browser journeys.
+
+### Documentation only
+
+Validate every named entity/path, run the website check/build, and inspect both locales. Documentation can reveal drift, but should not change an entity merely to match prose.
+
+## Contribution workflow
+
+1. Search by entity ID, criterion ID, relation, and source path—not only filename.
+2. Read lifecycle status and version bounds before treating a statement as stable.
+3. Reproduce the gap with the smallest owning-layer test.
+4. Update source of truth, implementation, executable evidence, and public projections together when scope permits.
+5. Run focused tests first; inspect failure text for criterion and owner clarity.
+6. Run proportional catalog, type, docs, and full checks.
+7. In the PR, list exact commands and distinguish newly run evidence from status copied out of a `T-*` entity.
+
+The generated Agent project understanding explicitly warns that a `passing` status in an entity is recorded metadata—it does not mean generation reran the test.
+
+## Focused and full commands
+
+```sh
+# One implementation or contract slice
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/lifecycle.session.v1.contract.test.ts
+
+# Shared official-Web journeys
+corepack pnpm@10.32.1 test:web-conformance
+
+# Catalog and generated project understanding
+corepack pnpm@10.32.1 check:prototype-catalog
+corepack pnpm@10.32.1 spec:docs:agent
+corepack pnpm@10.32.1 check:agent-doc
+
+# Public types/docs, then the full repository gate
+corepack pnpm@10.32.1 check:types
+corepack pnpm@10.32.1 test
+```
+
+Use Node.js 22 and the repository-pinned pnpm 10.32.1 through Corepack. `test` also runs release-version/assets checks, generated style/preset checks, type contracts, and the Vitest suite; it is broader than a single semantic slice.
+
+## Common evidence mistakes
+
+- A snapshot of current output proves behavior only at the captured layer; it does not define semantics.
+- Test filenames containing “contract” are not automatically tied to a `C-*`; inspect the `T-*` relation.
+- A fake host cannot prove real Adapter timing or browser APIs.
+- One Web framework passing does not prove cross-Adapter parity.
+- Deleting an old failing case to match new behavior rewrites history; revise entities and migration deliberately.
+- Editing generated projections by hand creates drift; change the entity or generator.
+- Running only the full suite makes ownership failures harder to diagnose; keep focused commands in the PR.
+
+Continue to [Runtime Architecture](/en/build/runtime-architecture/), [Module & Extension Architecture](/en/build/module-extension-architecture/), or [How to Contribute](/en/build/contribute/) for the delivery workflow.

--- a/apps/www/src/content/docs/en/build/host-caps.md
+++ b/apps/www/src/content/docs/en/build/host-caps.md
@@ -1,7 +1,121 @@
 ---
 title: 'Host Caps'
-desp: 'Host capabilities overview'
-description: 'Host capabilities overview'
+desp: 'How semantic Modules acquire bounded host capabilities without owning a framework'
+description: 'How semantic Modules acquire bounded host capabilities without owning a framework'
 ---
 
-Coming soon.
+A Host Capability is the narrow service a semantic Module requires from an environment, or the sink through which it projects results. It keeps DOM, framework, scheduler, geometry, and native-control mechanics out of portable Prototype syntax.
+
+The catalog currently contains a reviewed subset of host-capability identities. The implementation has additional capability tokens; a package or token without an `HC-*` entity is uncataloged, not automatically stable or unsupported.
+
+## Prerequisites
+
+Read [Core](/en/specifications/core/) for the portable/host split, [Runtime Architecture](/en/build/runtime-architecture/) for `ModuleWiring`, and [Compatibility](/en/reference/compatibility/) for the current Adapter profile slice.
+
+## Four layers, four owners
+
+```text
+Contract criterion ── defines portable behavior
+       │
+Module (`M-*`) ────── owns semantic state and requests a capability
+       │ CapToken
+Host Cap (`HC-*`) ─── defines the bounded host responsibility
+       │ provides.hostCaps
+Adapter (`A-*`) ───── supplies native / translated / emulated realization
+```
+
+Behavior remains owned by `C-*`; a capability entity does not become a second contract. `D-ADAPTER-PROFILE-0001` requires an official profile to state whether a provided capability is native, translated, or emulated. If it cannot satisfy the capability faithfully, it must not claim provision.
+
+## Token, vault, and wiring
+
+Core `cap<T>(id)` creates a typed token with a globally namespaced string ID. Each Runtime Module receives a read-only `CapsVaultView`:
+
+- runtime-owned base capabilities such as `SYS_CAP` survive host reset;
+- Adapter-attached capabilities live in a replaceable attached layer;
+- `has` and `get` resolve the current value;
+- `onChange` and `epoch` let a Module rebind when capability identity changes; and
+- unavailable `get` fails with a stable diagnostic.
+
+Adapters never mutate a Module directly. `onRuntimeReady` receives flat `ModuleWiring`, and wiring attaches capability entries to the owning Module name. Unmount/reset clears only the attached host layer; terminal Module disposal remains a separate Runtime action.
+
+## Capability shapes are domain-specific
+
+Not every capability is a lease. Current shapes include:
+
+| Shape | Examples | Lifetime behavior |
+| --- | --- | --- |
+| Source | Props source | Read/invalidate current host input |
+| Sink or bridge | Expose record/event sinks, accessibility projection | Receive a semantic projection |
+| Scoped binding | Event binding/default action | Attach host input routes and revoke them with the view |
+| Lease | Anchored Positioning, Scroll Surface, Text Control, Move Gesture | `attach`, optionally `update`/`request`, then `dispose` |
+
+For example, the cataloged Positioning boundary uses a bounded host lease:
+
+```ts
+import { cap, type AnchoredPositionConnection } from '@proto.ui/core';
+
+export interface AnchoredPositionHostLease {
+  update(connection: AnchoredPositionConnection): void;
+  requestUpdate(): void;
+  dispose(): void;
+}
+
+export interface AnchoredPositionHost {
+  attach(connection: AnchoredPositionConnection): AnchoredPositionHostLease;
+}
+
+export const ANCHORED_POSITION_HOST_CAP = cap<AnchoredPositionHost>(
+  '@proto.ui/positioning/anchoredHost'
+);
+```
+
+`M-POSITIONING-0001` owns when to attach, update, and dispose that lease; `HC-ANCHORED-POSITION-0001` owns what the host must do; `T-ANCHORED-POSITIONING-0001` maps Module, host, Runtime, and Prototype evidence.
+
+## Lifetime and rebinding
+
+A capability value becoming available is not the same as a host resource being live forever. Modules declare `resourceOwnership` as `instance`, `view`, or `mixed`:
+
+- instance resources survive repeatable detach;
+- view resources belong to one mount epoch;
+- mixed Modules preserve semantic state while suspending or replacing host resources.
+
+Lease-shaped capabilities should dispose the previous lease before replacing targets and reject stale async completion through epoch or connection identity. Adapter wiring should revoke DOM listeners, observers, and host references on unmount without destroying instance-owned state.
+
+## Target and surface projection
+
+Host capability does not mean “raw root element.” `C-HOST-SURFACE-PROJECTION-0001` distinguishes a logical `boundaryTarget` from the visual `surfaceTarget`. Focus, accessibility, event, hit testing, native properties, geometry, and presentation may each have domain-specific target rules. A wrapper and a visible native control must not become competing owners merely because both are reachable from an Adapter.
+
+Portable authors receive semantic handles, not raw target access. Host-specific escape hatches remain profile-local and cannot be promoted to cross-Adapter Props or State guarantees.
+
+## What fake hosts prove
+
+Runtime fake hosts and in-memory capability doubles are excellent for Module ordering, missing-cap behavior, lease cleanup, and phase guards. They cannot prove browser layout, native focus, DOM event propagation, framework commit timing, or a concrete Adapter's target choice. Use the lowest layer that can observe the claim, then add official Adapter evidence when the claim crosses translation.
+
+## Adding or changing a capability slice
+
+1. Identify the `C-*` criteria and semantic Module owner.
+2. Add or update one coherent `M-*` and `HC-*` relation slice; do not catalog tokens by count.
+3. Define the capability shape and resource lifetime in the closest Module package.
+4. Wire each applicable Adapter without letting Adapter code reinterpret semantics.
+5. Record profile `provides.hostCaps` only after reviewed evidence exists.
+6. Add a `T-*` entity that maps criteria to Module, fake-host, Adapter, and integration implementations.
+7. Run graph/schema validation plus focused executable tests.
+
+## Common boundary mistakes
+
+- Treating a missing capability as “silently supported” hides an Adapter omission decision.
+- Reading an unlisted profile relation as unsupported violates the catalog's uncataloged state.
+- Storing host targets in portable State leaks one platform into the protocol.
+- Reusing a view lease across a replaced root lets stale observers and callbacks reach the wrong surface.
+- Creating an `HC-*` placeholder without criteria, owner, and evidence only inflates inventory.
+
+## Verification
+
+```sh
+corepack pnpm@10.32.1 vitest run packages/modules/positioning/test/floating-ui-host.test.ts
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/overlay.v0.contract.test.ts
+corepack pnpm@10.32.1 vitest run packages/spec/graph/test/adapter-profile.test.ts
+corepack pnpm@10.32.1 check:types
+```
+
+Continue to [Module & Extension Architecture](/en/build/module-extension-architecture/) for Module ownership, [Adapter Guide](/en/build/adapter-guide/) for contribution readiness, or [Contracts & Tests](/en/build/contracts-and-tests/) for evidence layers.

--- a/apps/www/src/content/docs/en/build/module-extension-architecture.md
+++ b/apps/www/src/content/docs/en/build/module-extension-architecture.md
@@ -1,7 +1,140 @@
 ---
 title: 'Module & Extension Architecture'
-desp: 'Module boundaries, SPI, and extension structure in Proto UI'
-description: 'Module boundaries, SPI, and extension structure in Proto UI'
+desp: 'Semantic Module ownership, dependency boundaries, runtime registration, and governed extension work'
+description: 'Semantic Module ownership, dependency boundaries, runtime registration, and governed extension work'
 ---
 
-Coming soon.
+Modules carry reusable protocol semantics between Prototype authoring and host translation. A Module may expose setup/runtime author handles, retain instance state, depend on another Module, and consume Host Capabilities without importing React, Vue, or Custom Elements.
+
+The implementation contains more Module packages than the catalog currently has `M-*` entities. Entity counts are not package counts: an uncataloged Module is implementation evidence, not an active public guarantee.
+
+## Prerequisites
+
+Read [Core](/en/specifications/core/) for authoring phases, [Runtime Architecture](/en/build/runtime-architecture/) for orchestration, and [Host Caps](/en/build/host-caps/) for the host boundary.
+
+## Static declaration is not runtime implementation
+
+Two APIs with similar names solve different problems:
+
+| Surface | Owner | Purpose |
+| --- | --- | --- |
+| `moduleDeclaration` / `declareModule` in `@proto.ui/core` | Prototype definition | Bind immutable typed configuration before Runtime Module construction and Adapter selection |
+| `defineModule` / `createModule` in `@proto.ui/module-base` | Runtime implementation | Define a Module's dependencies, resource ownership, facade, port, and lifecycle hooks |
+
+`C-MODULE-DECLARATION-0001` governs the first surface. A setup-time `asHook` call cannot retroactively change static requirements; authored asHooks must publish frozen requirements and callers must reuse them on the Prototype definition.
+
+## Runtime Module anatomy
+
+```text
+ModuleDef
+  ├─ name + resourceOwnership
+  ├─ deps / optionalDeps
+  └─ create(ctx)
+       ├─ facade ── safe semantic surface consumed by Kernel or dependent Modules
+       ├─ port ──── privileged Runtime/Module integration surface
+       └─ hooks ─── instance, mount, proto phase, post-commit, dispose
+```
+
+The current implementation pattern uses `defineModule` and `createModule`:
+
+```ts
+import { createModule, defineModule, type ModuleFactoryArgs } from '@proto.ui/module-base';
+
+type IdentityFacade = { prototypeName(): string };
+
+function createIdentityModule(ctx: ModuleFactoryArgs) {
+  return createModule<'identity', 'instance', IdentityFacade>({
+    name: 'identity',
+    scope: 'instance',
+    init: ctx.init,
+    caps: ctx.caps,
+    deps: ctx.deps,
+    build: () => ({
+      facade: { prototypeName: () => ctx.init.prototypeName },
+      hooks: {},
+    }),
+  });
+}
+
+export const IdentityModuleDef = defineModule({
+  name: 'identity',
+  resourceOwnership: 'instance',
+  deps: [],
+  create: createIdentityModule,
+});
+```
+
+This demonstrates the real implementation types. It is **not** a promise that a third-party package can dynamically install `IdentityModuleDef` into the stock Runtime: `createRuntimeInstance` currently registers a fixed reviewed Module list. Adding a new Runtime Module is repository architecture work unless a future public registration surface is cataloged.
+
+## Dependency graph and access
+
+`RuntimeModuleOrchestrator` topologically sorts hard and present optional dependencies. It fails on duplicate names, missing hard dependencies, and cycles. `ctx.deps` then enforces declared access:
+
+- `requireFacade` / `requirePort` fail when a declared dependency is missing;
+- `tryFacade` / `tryPort` return `undefined` only for a missing optional dependency; and
+- every accessor rejects an undeclared dependency.
+
+Do not bypass this with package-level imports into another Module's implementation object. Package dependencies are build mechanics; `deps` expresses runtime semantic ordering and access.
+
+## Facade, port, and capability
+
+Use the narrowest surface:
+
+- **Facade:** stable semantic operations another author-facing layer or Module may consume.
+- **Port:** privileged integration needed by Runtime or a declared dependent Module; it is not automatically public API.
+- **Host Capability:** a platform service or projection supplied through the Adapter, never a back door for Module-to-Module access.
+- **System Capability:** Runtime-owned phase/lifecycle guards such as `SYS_CAP`; Adapter wiring cannot override it.
+
+Kernel receives facade-only access. Runtime may inspect ports for lifecycle integration. Adapters attach capability entries through `ModuleWiring`; they should not receive or mutate internal Module instances.
+
+## Resource ownership
+
+Every `ModuleDef` declares `resourceOwnership`:
+
+| Value      | Meaning                                                               |
+| ---------- | --------------------------------------------------------------------- |
+| `instance` | Logical resource survives detach; no host-view activation is owned    |
+| `view`     | Resource belongs to one mount epoch and must be released on detach    |
+| `mixed`    | Logical state survives while host bindings suspend, rebind, or replay |
+
+The value documents intent, while lifecycle hooks and tests enforce actual cleanup. `C-LIFECYCLE-0006` requires instance and mount phases to remain orthogonal; `packages/runtime/test/contract/lifecycle.module-resources.v1.contract.test.ts` exercises mixed ownership across remount.
+
+## Governed extension workflow
+
+Before adding behavior, trace a vertical slice:
+
+```text
+knowledge/decision → C-* criteria → M-* owner → HC-* requirement
+                   → A-* support/provision → T-* cases → implementation
+```
+
+Then:
+
+1. Confirm whether an existing Module already owns the semantic channel.
+2. Use a dated record only for alternatives or unresolved direction; stabilized behavior belongs in entities.
+3. Add or revise one coherent `M-*` identity with satisfied Contracts and required Host Caps.
+4. Define facade/port/dependency boundaries and explicit resource ownership.
+5. Register implementation in Runtime only when the issue authorizes that architecture change.
+6. Add Module-level tests, Runtime integration, and Adapter evidence when host translation is involved.
+7. Update official `A-*` profile relations only for the reviewed slice; absence remains uncataloged.
+
+## Common boundary mistakes
+
+- Creating an empty `M-*` entity to mirror every package or token produces no semantic ownership.
+- Exposing a port as public API because it is convenient leaks Runtime privilege.
+- Importing an undeclared dependency hides ordering and disposal assumptions.
+- Treating `scope: 'instance'` as proof of correct cleanup ignores `resourceOwnership` and lifecycle behavior.
+- Letting a Module call `run.update()` indirectly on every mutation violates explicit Runtime update ownership.
+- Assuming the fixed Runtime list is a plugin registry promises an extension surface that does not exist.
+
+## Verification
+
+```sh
+corepack pnpm@10.32.1 vitest run packages/core/test/contract/prototype.module-declarations.v0.contract.test.ts
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/module-declarations.v0.contract.test.ts
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/lifecycle.module-resources.v1.contract.test.ts
+corepack pnpm@10.32.1 check:prototype-catalog
+corepack pnpm@10.32.1 check:types
+```
+
+Continue to [Contracts & Tests](/en/build/contracts-and-tests/) for evidence mapping, [Host Caps](/en/build/host-caps/) for host services, or [Adapter Guide](/en/build/adapter-guide/) before changing translation code.

--- a/apps/www/src/content/docs/en/build/runtime-architecture.md
+++ b/apps/www/src/content/docs/en/build/runtime-architecture.md
@@ -1,7 +1,118 @@
 ---
 title: 'Runtime Architecture'
-desp: 'Runtime architecture overview'
-description: 'Runtime architecture overview'
+desp: 'How Proto UI materializes instances, runs modules, and hands work to an Adapter host'
+description: 'How Proto UI materializes instances, runs modules, and hands work to an Adapter host'
 ---
 
-Coming soon.
+The 0.2 execution path is runtime-based: a Prototype definition is materialized into a `RuntimeSession`, semantic Modules run behind controlled facades and ports, and an Adapter supplies a `RuntimeHost` plus host capabilities. This page describes that shipped path from the current implementation and catalog.
+
+Most lifecycle entities named here are still `draft`; `C-LIFECYCLE-0008` (view intent) is `active`. A passing implementation is evidence for a draft rule, not an automatic lifecycle promotion.
+
+## Prerequisites
+
+Read [Core](/en/specifications/core/) for setup/render/callback surfaces, [Lifecycle](/en/specifications/lifecycle/) for author-visible ordering, and [Prototype API](/en/reference/prototype-api/) for definition syntax.
+
+## Ownership map
+
+```text
+Prototype definition
+  │ setup(def) / renderer
+  ▼
+RuntimeSession ── owns instance + repeatable mount epochs
+  ├─ Kernel ──── author handles, callback scope, render syntax
+  ├─ Module orchestrator ── dependency order, facades, ports, lifecycle hooks
+  └─ RuntimeHost boundary ── raw Props, scheduling, commit completion, cap wiring
+                              │
+                              ▼
+                         Adapter + host platform
+```
+
+`createRuntimeSession(proto, host)` is the main session boundary in `@proto.ui/runtime`. `createRuntimeInstance` constructs the lower-level Kernel and Module graph; official Adapters normally own that integration rather than asking application code to assemble it.
+
+## Two lifecycle axes
+
+`C-LIFECYCLE-0002` and `C-LIFECYCLE-0006` separate terminal instance lifetime from repeatable host-view lifetime:
+
+| Axis | States | Ownership |
+| --- | --- | --- |
+| Instance | `setup → alive → disposing → disposed` | One logical Proto instance; setup and created run once |
+| Mount | `detached → mounting → mounted → unmounting → detached` | One host-view epoch; may repeat while the instance stays alive |
+
+The canonical flow is:
+
+```text
+setup → created → (mount → render → commit.done → mounted
+                    → update → render → commit.done → updated
+                    → unmount → unmounted) × n
+      → beforeDispose → disposed
+```
+
+Unmount is not disposal. Instance-owned State, resolved Props, callback registries, and logical identity survive a detached interval. A new mount increments `mountEpoch`; stale completion from an older epoch must not advance the new view.
+
+## Explicit update and commit
+
+Render and commit are runtime-owned effects (`C-LIFECYCLE-0003`). `run.update()` and `session.controller.update()` express update intent. Props, State, Context, Event, or Feedback mutations do not implicitly render.
+
+The host decides when a commit is complete by calling `signal.done()`. Only then may Runtime deliver `mounted` or `updated`, bind event delivery for the active epoch, and run post-commit Module hooks. Update intent while detached only marks work dirty; the next mount renders current runtime state.
+
+## Module orchestration
+
+`RuntimeModuleOrchestrator` constructs the current fixed Module set in dependency order. It rejects duplicate names, missing hard dependencies, cycles, and undeclared dependency access. The Kernel receives facade-only access; Runtime internals may use privileged ports; Adapters inject host capabilities through flat `ModuleWiring`.
+
+Each Module receives independent instance, mount, and legacy proto-phase hooks. Logical State can remain instance-owned while DOM listeners, observers, positioning sessions, and other host resources are released or rebound per mount epoch. See [Module & Extension Architecture](/en/build/module-extension-architecture/) for the authoring boundary.
+
+## Adapter handoff
+
+`RuntimeHost` has a deliberately small responsibility set:
+
+- provide the current raw Props snapshot;
+- commit `TemplateChildren` and report commit completion;
+- schedule lifecycle work and, when used, delayed callbacks;
+- receive structured lifecycle diagnostics;
+- attach Module host capabilities in `onRuntimeReady`; and
+- make event/observer systems ineffective when an epoch unmounts.
+
+A minimal deterministic host used by runtime tests looks like this:
+
+```ts
+import type { RuntimeHost } from '@proto.ui/runtime';
+
+export function createTestHost(prototypeName: string): RuntimeHost<Record<string, unknown>> {
+  return {
+    prototypeName,
+    getRawProps: () => ({}),
+    commit(_children, signal) {
+      signal?.done();
+    },
+    schedule(task) {
+      task();
+    },
+  };
+}
+```
+
+This fake host proves runtime ordering and phase guards. It does not prove DOM event routing, framework lifecycle integration, target projection, or host-capability correctness; those require Adapter and host tests.
+
+## Common boundary mistakes
+
+- Disposing the Module hub on every unmount destroys repeatable instance semantics.
+- Calling `commit()` without eventually calling `done()` leaves the epoch incomplete.
+- Triggering render from a Module mutation bypasses explicit update ownership.
+- Letting Kernel code reach Module ports, or Modules reach undeclared dependencies, bypasses orchestration boundaries.
+- Treating the deprecated CP0–CP10 strings as the lifecycle source of truth loses epoch and revision identity; structured lifecycle events govern current traces.
+- Copying one Web Adapter's scheduling choices into Core turns host mechanics into a false cross-host guarantee.
+
+## Verification
+
+Run focused evidence before the full suite:
+
+```sh
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/lifecycle.session.v1.contract.test.ts
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/lifecycle.module-resources.v1.contract.test.ts
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/lifecycle.update-order.strict.v0.contract.test.ts
+corepack pnpm@10.32.1 check:types
+```
+
+`T-LIFECYCLE-0003`, `T-LIFECYCLE-0005`, and `T-LIFECYCLE-0006` connect the shared lifecycle criteria to Runtime and official Adapter evidence.
+
+Continue to [Host Caps](/en/build/host-caps/) for capability wiring, [Adapter Guide](/en/build/adapter-guide/) for the current contribution boundary, or [Contracts & Tests](/en/build/contracts-and-tests/) for evidence tracing.

--- a/apps/www/src/content/docs/zh-cn/build/adapter-guide.md
+++ b/apps/www/src/content/docs/zh-cn/build/adapter-guide.md
@@ -1,41 +1,53 @@
 ---
 title: 'Adapter 贡献指南暂缓发布'
-description: '为什么当前不从尚未完成的 catalog 和实现推导通用 Adapter 作者流程。'
+description: '当前已有的证据、可以推进的有界 Adapter 工作，以及为何仍不发布通用作者流程。'
 ---
 
-Proto UI 当前不发布通用 Adapter 贡献指南。
+Proto UI 当前不发布通用 Adapter authoring tutorial。0.2 已交付执行架构与第一批 reviewed profile slice 现在已有文档，但 catalog 有意保持 partial，并不存在可以让贡献者通过类比新增 Adapter 的稳定 public SPI。
 
-Module、Host Capability 和官方 Adapter profile 的实体编目仍在推进，相关架构责任、缺失策略、生命周期资源所有权和 executable conformance 还没有全部收口。现有 React、Vue 和 Web Component 实现是重要证据，但其中仍可能存在尚未处理的 drift，不能仅靠模仿当前代码推导稳定作者 API。
+请先阅读聚焦的架构指南：
 
-在这条 catalog chain 完成前，本页不会：
+- [Runtime 架构](/zh-cn/build/runtime-architecture/)解释 `RuntimeSession`、commit ownership 与 host handoff。
+- [Host Caps](/zh-cn/build/host-caps/)解释 capability token、wiring、target projection 与 resource lifetime。
+- [模块与扩展架构](/zh-cn/build/module-extension-architecture/)解释 facade/port/dependency ownership 与固定 Runtime Module set。
+- [兼容性](/zh-cn/reference/compatibility/)只报告 Web Component、React 与 Vue official profile 当前已经审计的 relation。
 
-- 把当前 Web Adapter 结构描述成跨宿主稳定架构；
-- 给出新增 Adapter 的逐步实现教程；
+这些页面描述当前事实，但合在一起仍不能定义完整的新 Adapter recipe。
+
+## 为什么通用流程仍然暂缓
+
+Official Adapter profile 按 Module slice 逐步编目。未列出的 Module 属于 uncataloged，不代表支持或不支持。Lifecycle ownership、capability omission strategy、host target role 与 executable conformance 都必须针对具体 target 决定。现有 Web implementation 是证据，但 Web-specific routing 与 framework mechanics 不能自行定义 cross-host architecture。
+
+因此本文不会：
+
+- 把当前 Web Adapter structure 描述成稳定 cross-host SPI；
 - 从 package dependency 推断完整 Module support；
-- 把未编目的 fallback 或 host wiring 描述成正式保证；
-- 鼓励贡献者通过 Prototype 私有逻辑修补 Adapter parity 问题。
+- 把 uncataloged fallback 或 host wiring 当作保证；
+- 承诺 dynamic Runtime Module registration；
+- 鼓励通过 Prototype-specific patch 修补 Adapter parity。
 
-## 现在仍可以参与什么？
+## 可以推进的有界工作
 
-边界明确的 Adapter parity bug 仍可能开放给有经验的贡献者。对应 Issue 必须说明：
+有经验的贡献者可以在 Issue 已经写清以下内容时实现 Adapter parity bug：
 
 - 适用的 `C-*`、`M-*`、`HC-*`、`A-*` 与 `T-*` 实体；
-- 问题属于哪个 owner layer；
-- 预期行为和不能改变的协议边界；
-- focused conformance test；
-- Web Component、React、Vue 中需要保持或对齐的证据；
-- implementation 是否已经被 maintainer 明确授权。
+- semantic 或 translation owning layer；
+- profile 与 target runtime/version range；
+- 跨 Adapter 不得改变的行为；
+- focused Runtime/Module 与 Adapter evidence；
+- 明确的 implementation authorization。
 
-新的 Adapter proposal 当前只用于 maintainer-guided research。它可以收集 host capability inventory、缺失策略和最小 feasibility evidence，但不自动授权实现 PR。
+新 Adapter proposal 仍属于 maintainer-guided research。有效 proposal 可以整理 host capability inventory、诚实的 support/omission decision、lifecycle/target ownership 与最小 feasibility evidence，但不会自动授权 production Adapter PR。
 
-## 何时发布完整指南？
+## 什么会解锁完整指南
 
-至少需要：
+一个可信 exemplar 至少需要：
 
-- 相关 Module 的 facade、port 和 Host Capability owner 已编目；
-- official Adapter 的 `supports`、`omits` 与 `provides` 关系有 reviewed evidence；
-- lifecycle、attach/rebind/reset/disposal 责任可执行验证；
-- 主要实现与实体 drift 已解决或显式记录；
-- 一个完整纵向切片可以作为可信 exemplar。
+1. 一组完整的 Module facade/port 与 Host Capability owner；
+2. reviewed profile `supports`、`omits`、`provides` relation；
+3. 可执行的 attach/rebind/reset/dispose responsibility；
+4. 已解决或明确记录的 implementation/catalog drift；
+5. target-specific commit、event、projection 与 diagnostics behavior；
+6. 能区分 portable semantics 与 host mechanics 的 conformance evidence。
 
-在此之前，请从[贡献指南](/zh-cn/build/contribute/)选择 Prototype、文档、Demo 或已明确边界的 bug 路径。
+在此之前，请通过[参与贡献](/zh-cn/build/contribute/)选择 Prototype、docs、demo、Module slice 或 bounded bug，并用[契约与测试](/zh-cn/build/contracts-and-tests/)设计 evidence。

--- a/apps/www/src/content/docs/zh-cn/build/compiler-guide.md
+++ b/apps/www/src/content/docs/zh-cn/build/compiler-guide.md
@@ -1,53 +1,93 @@
 ---
 title: 'Compiler 指南'
-desp: '如何编写编译器'
-description: '如何编写编译器'
+desp: '当前 Compiler 边界：0.2 已交付什么、catalog 已约束什么、哪些仍属未来工作'
+description: '当前 Compiler 边界：0.2 已交付什么、catalog 已约束什么、哪些仍属未来工作'
 ---
 
-## 这篇解决什么工程问题？
+Proto UI 0.2 **没有**交付 Compiler 实现或 Compiler authoring workflow。0.2 release 中不存在 `@proto.ui/compiler` package、compiler entity type、official compiler profile、CLI compile command 或受支持的 compiler input/output artifact。
 
-写作提示：
-
-- 说明 Compiler 在 Proto UI 体系中的角色与当前阶段状态。
-- 解释它为什么是后续主路径，而不是当前文档站里的默认实现入口。
-
-## 主要读者是谁？
-
-写作提示：
-
-- 给研究 Proto UI 长期执行路径的人。
-- 给未来可能进入编译层设计的人。
+本文的作用是避免把未来方向误解成已交付行为。它整理未来 Compiler 已经需要服从的边界，并把贡献者带回今天实际可用的 Runtime Adapter 路径。
 
 ## 前置阅读
 
-写作提示：
+先读[翻译层：Adapter / Compiler](/zh-cn/whitepaper/translation-layer/)理解概念差异，读[核心规范](/zh-cn/specifications/core/)理解 portable syntax，再读 [Runtime 架构](/zh-cn/build/runtime-architecture/)理解当前执行路径。
 
-- 指向 `Whitepaper / 翻译层：Adapter / Compiler`
-- 指向 `Project / 里程碑`
+## 0.2 实际交付的内容
 
-## 核心结构 / 机制
+| 层 | 当前职责 |
+| --- | --- |
+| `@proto.ui/core` | Prototype definition、setup/render syntax、template structure、module declaration、Rule authoring type |
+| `@proto.ui/runtime` | 物化 Prototype、运行 Module、拥有 lifecycle/update flow、把 commit 交给 host |
+| 官方 Adapter | 为 Web Component、React 与 Vue profile 翻译 Runtime output 和 semantic host capability |
+| `@proto.ui/cli` | 初始化项目并生成 theme、token、style 与 component preset material；它不是 Prototype compiler |
 
-写作提示：
+当前 production route 是：
 
-- 解释 Compiler 与 Adapter 的职责差异。
-- 解释编译层在未来将如何承载稳定性与性能目标。
+```text
+Prototype TypeScript → Runtime execution → official Adapter → Web host
+```
 
-## 关键 API / SPI
+可能的未来路径目前只是一项设计方向：
 
-写作提示：
+```text
+portable analyzable input → [future Compiler] → host artifacts
+```
 
-- 如果当前阶段尚未稳定，这里只列出已明确的方向性接口，不要假装已经定稿。
+0.2 不承诺第二条路径接受什么 source language、如何优化、生成哪些文件、是否包含 runtime 或采用什么 compatibility policy。
 
-## 常见误解或边界
+## 已经适用的约束
 
-写作提示：
+即使没有 Compiler package，已经编目的协议边界仍会约束任何未来 official translation：
 
-- 明确当前阶段哪些内容仍属规划。
-- 区分“文档中提到 Compiler”与“已经建议大规模使用 Compiler”。
+- `K-PROTOTYPE-COMPOSITION-0001`：template 描述一个 Root Node，不嵌入另一个 Prototype definition。
+- `C-TEMPLATE-0005`：v0 slot 是 anonymous、singular、parameterless。
+- `C-TEMPLATE-0006`：official Adapter 或 Compiler 遇到 `PrototypeRef` template node 时必须拒绝，不能私自发明 composition。
+- `C-RULE-0003`：Rule declaration 生成 serializable `RuleIR`，其中不保留 function、host reference、closure 或 live handle。
+- `C-MODULE-DECLARATION-0001`：static typed Module declaration 在 Module construction 和潜在 host selection 之前可见。
 
-## 下一步读什么？
+这些是协议约束，不是 Compiler SPI；它们没有定义 parser、AST format、incremental build graph、code generator 或 deployment artifact。
 
-写作提示：
+## Static intent 与任意 function
 
-- 如果想理解当前主路径：回到 `Adapter 指南`
-- 如果想理解项目阶段：前往 `Project / 里程碑`
+有些作者形式比 callback 更能保留可分析 intent。Rule 是当前最清楚的例子：它把 condition 与 semantic intent 分开，并在内部编译为 `RuleIR` 供 Runtime evaluation。这不代表仓库已经有通用 Prototype compiler，也不意味着任意 callback body 都可以无损翻译。
+
+当 declarative form 能准确表达行为时应优先使用，但不要围绕想象中的 Compiler 改写已经成立的 0.2 semantics。`internal/contracts/integration/portability-and-integration.md` 对长期方向有更多解释，但它属于 non-normative material。
+
+## 当前没有受支持的 Compiler input/output
+
+| 问题 | 0.2 回答 |
+| --- | --- |
+| `.proto.ts` 能否脱离 Runtime 编译？ | 没有受支持流程 |
+| `TemplateChildren` 是稳定 compiler IR 吗？ | 不是；它是当前 Core/Runtime template data |
+| `RuleIR` 是完整 Prototype IR 吗？ | 不是；它只覆盖 Rule |
+| CLI 能否从 Prototype 生成 React/Vue/Custom Element component？ | 不能 |
+| 是否支持 zero-runtime delivery？ | 不支持，仍属未来方向 |
+| 是否有 Compiler conformance matrix？ | 没有 Compiler entity/profile |
+
+如果未来 proposal 要改变这些回答，必须显式新增 catalog 与 API 工作，不能从文档推断。
+
+## 贡献边界
+
+Compiler proposal 应先作为 maintainer-guided research，并至少说明：
+
+1. portable source subset，以及 unsupported construct 如何失败；
+2. output host 与 generated artifact ownership；
+3. 如何与现有 Contract criteria 保持 semantic parity；
+4. lifecycle、capability 与 component composition 如何处理；
+5. versioned identity 与 executable conformance model；
+6. 如何迁移并与 Runtime/Adapter path 共存。
+
+不要把 `packages/modules/rule/src/compile.ts`、CLI style generation 或 bundler transform 当成缺失的 Compiler architecture 并直接发起实现 PR；它们是由其他层拥有的局部实现。
+
+## 验证当前边界
+
+以下检查覆盖今天已经存在的 portable template 与 analyzable Rule 约束：
+
+```sh
+corepack pnpm@10.32.1 vitest run packages/core/test/contract/template.normalize.contract.test.ts
+corepack pnpm@10.32.1 vitest run packages/adapters/web-component/test/contract/template.no-prototype-composition.v0.contract.test.ts
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/rule.props-style.smoke.v0.contract.test.ts
+corepack pnpm@10.32.1 check:types
+```
+
+希望现在就能交付的工作，请继续阅读 [Runtime 架构](/zh-cn/build/runtime-architecture/)、[模块与扩展架构](/zh-cn/build/module-extension-architecture/)或边界明确的 [Adapter 指南](/zh-cn/build/adapter-guide/)；未来顺序见[里程碑](/zh-cn/project/roadmap/)。

--- a/apps/www/src/content/docs/zh-cn/build/contracts-and-tests.md
+++ b/apps/www/src/content/docs/zh-cn/build/contracts-and-tests.md
@@ -1,36 +1,123 @@
 ---
 title: '契约与测试'
-desp: '契约与测试指南'
-description: '契约与测试指南'
+desp: 'Proto UI 如何跨层把规范 criteria 连接到可执行证据'
+description: 'Proto UI 如何跨层把规范 criteria 连接到可执行证据'
 ---
 
-## 这篇文章要回答什么？
+Proto UI 的测试不是一个没有分层的单一 gate。有效贡献需要在拥有该 claim 的层证明它，并记录证据如何连接到 catalog。通过的 Adapter test 不能暗中修改 Contract，Runtime fake host 也不能证明 browser behavior。
 
-- Proto UI 的生态建设为什么离不开契约与测试。
-- 原型、适配器与核心能力在进入生态时需要满足什么验证要求。
-- 哪些贡献必须被验证，哪些贡献可以先不碰契约层。
-- 为什么官方支持质量与契约成熟度直接相关。
+## 前置阅读与权威顺序
 
-## 这篇适合什么读者？
+修改规范行为前先读[规范导读](/zh-cn/specifications/introduction/)和仓库 `spec/README.md`。权威顺序是：
 
-- 面向准备把能力带入生态的人。
-- 面向维护语义一致性的贡献者。
-- 也面向不知道“测试是不是门槛太高”的新贡献者。
+```text
+applicable spec entity
+→ internal contract only for an uncataloged gap or explanation
+→ relevant dated record for short-term context
+→ implementation and tests as evidence
+→ website/README as reader projection
+```
 
-## 这篇应当优先讲什么？
+原有 `internal/contracts/**` 仍可以补充信息，但只有在没有实体编目的空白中才能作为 transitional fallback，并必须明确标注；它不能覆盖适用 entity。
 
-- 什么叫契约测试
-- 不同层的能力需要证明什么
-- 契约与规范、工程实现之间的关系
-- 哪些贡献可以先不碰契约层
-- 为什么这篇的目标是建立质量预期，而不是吓退新贡献者
+## Evidence graph
 
-## 这篇不打算展开什么？
+`T-*` entity 让 acceptance criteria 可执行且可追踪：
 
-- 不在这里替代正式规范
-- 不在这里展开完整测试工具文档
+```text
+C-* criterion / D-* choice / P-* protocol
+                 │ covers + verifies
+                 ▼
+              T-* case
+                 │ consumesCases
+                 ▼
+fixture / type test / module test / runtime test / adapter test / journey
+```
 
-## 下一步怎么读？
+`T-*` 记录 case、expected outcome、implementation path、required status 与 typed relation。Path 是证据，relation 则说明证据证明什么。测试也可以 `exercise` 一个表面，而不声称完整 normative verification。
 
-- 查阅 [Specifications / 规范导读](/zh-cn/specifications/introduction/)
-- 查阅 [Engineering / 工程导读](/zh-cn/build/introduction/)
+例如 `T-LIFECYCLE-0003` 把 epoch-aware lifecycle criteria 映射到 Runtime session/checkpoint test，以及 Web Component、React、Vue 的 lifecycle-event test。Runtime fixture 证明 ordering 与 stale-epoch rejection；Adapter fixture 证明各 framework 会投射 structured trace。
+
+## 测试层级
+
+| 层 | 典型位置 | 能证明什么 |
+| --- | --- | --- |
+| Shared spec fixture | `packages/spec/fixtures/**` | 可复用 case data 与 criterion mapping |
+| Schema/graph | `packages/spec/{schema,engine,graph}/test/**` | Entity validity、relation type、graph projection |
+| Type contract | `internal/contracts/types/**` | Public TypeScript shape 与 inference |
+| Core contract | `packages/core/test/contract/**` | Portable definition/template/token syntax |
+| Module contract | `packages/modules/*/test/**` | 受控 dependency/cap 下的 semantic Module behavior |
+| Runtime contract | `packages/runtime/test/contract/**` | Phase guard、lifecycle、orchestration、fake-host handoff |
+| Adapter contract | `packages/adapters/*/test/**` | Framework/DOM translation、lifecycle ownership、target wiring |
+| Prototype test | `packages/prototypes/*/test/**` | Official Prototype protocol 与 integration behavior |
+| Web journey | `packages/web-conformance/test/**` | 同一 scenario 在全部 official Web Adapter 上的表现 |
+| Public docs/build | `apps/www` check 与 browser audit | Reachability、rendering、example、reader projection |
+
+应先使用能直接观察规则的最低层，再只为跨边界 claim 增加 integration evidence。在所有 Adapter 中复制相同 assertion，不能替代 shared Contract fixture 与 focused translation check。
+
+## 为改动选择 coverage
+
+### Contract 或 Core syntax
+
+更新适用 `C-*` criteria、`T-*` mapping、需要时的 shared fixture、Core/Runtime implementation 与 executable test。Semantic revision 还可能需要带 version 的 `revisions` entry。
+
+### Module 或 Host Capability
+
+追踪 `C-* → M-* → HC-* → T-*`。先在 Module/Runtime 中用 fake capability 证明 host-neutral semantics，再在每个适用 Adapter profile 中证明真实 host realization。不能只因 package dependency 存在就增加 `A-* provides` relation。
+
+### Adapter translation
+
+从准确的 `A-*` profile 与 reviewed `supports`、`omits`、`provides` relation 出发，保持 portable Contract，再增加 profile-specific evidence。如果 Module 同时不在 support 与 omission 中，应记录 uncataloged，不能在 test name 中发明 matrix status。
+
+### Prototype behavior
+
+从 `P-*` criteria 追踪到 `T-*`、implementation、public export 与 website preview。Compound protocol 通常需要 Base test，再加适用 Adapter 或 browser journey。
+
+### 仅文档
+
+验证每个 entity/path，运行 website check/build，并检查两种语言。文档可能揭示 drift，但不应为了匹配 prose 而修改 entity。
+
+## 贡献流程
+
+1. 按 entity ID、criterion ID、relation 与 source path 搜索，不要只按 filename。
+2. 在把声明当作稳定保证前，先读 lifecycle status 与 version bound。
+3. 用 owning layer 的最小测试重现 gap。
+4. 在 scope 允许时，同时更新 source of truth、implementation、executable evidence 与 public projection。
+5. 先跑 focused test，检查 failure text 是否清楚指出 criterion 与 owner。
+6. 再运行成比例的 catalog、type、docs 与 full check。
+7. PR 中列出精确命令，并区分本次真正执行的 evidence 与从 `T-*` entity 读取的 status。
+
+生成的 Agent project understanding 会明确提醒：entity 中的 `passing` 是记录的 metadata，并不表示生成文档时重新执行了测试。
+
+## Focused 与 full command
+
+```sh
+# 单个 implementation 或 contract slice
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/lifecycle.session.v1.contract.test.ts
+
+# 全部 official Web Adapter 的 shared journey
+corepack pnpm@10.32.1 test:web-conformance
+
+# Catalog 与生成的项目理解
+corepack pnpm@10.32.1 check:prototype-catalog
+corepack pnpm@10.32.1 spec:docs:agent
+corepack pnpm@10.32.1 check:agent-doc
+
+# Public type/docs，再到完整仓库 gate
+corepack pnpm@10.32.1 check:types
+corepack pnpm@10.32.1 test
+```
+
+使用 Node.js 22，并通过 Corepack 使用仓库固定的 pnpm 10.32.1。`test` 还会运行 release-version/assets、generated style/preset、type contract 与 Vitest suite，范围大于单个 semantic slice。
+
+## 常见证据错误
+
+- Current output snapshot 只证明捕获层的行为，不会定义 semantics。
+- Filename 中出现 “contract”，不代表它已经连接到 `C-*`；必须检查 `T-*` relation。
+- Fake host 不能证明真实 Adapter timing 或 browser API。
+- 只有一个 Web framework 通过，不等于 cross-Adapter parity。
+- 为匹配新行为而删除旧失败 case 会改写历史；应显式修订 entity 与 migration。
+- 手工修改 generated projection 会制造 drift；应修改 entity 或 generator。
+- 只运行 full suite 会让 ownership failure 更难诊断；PR 中应保留 focused command。
+
+接下来阅读 [Runtime 架构](/zh-cn/build/runtime-architecture/)、[模块与扩展架构](/zh-cn/build/module-extension-architecture/)，或前往[参与贡献](/zh-cn/build/contribute/)查看交付流程。

--- a/apps/www/src/content/docs/zh-cn/build/host-caps.md
+++ b/apps/www/src/content/docs/zh-cn/build/host-caps.md
@@ -1,52 +1,121 @@
 ---
 title: 'Host Caps'
-desp: '宿主能力概览'
-description: '宿主能力概览'
+desp: '语义 Module 如何在不拥有 framework 的前提下取得有界宿主能力'
+description: '语义 Module 如何在不拥有 framework 的前提下取得有界宿主能力'
 ---
 
-## 这篇解决什么工程问题？
+Host Capability 是语义 Module 向环境请求的窄服务，或向宿主投射结果的 sink。它让 DOM、framework、scheduler、geometry 与 native-control 机制留在 portable Prototype syntax 之外。
 
-写作提示：
-
-- 解释为什么 Proto UI 需要显式面对宿主能力边界。
-- 解释哪些语义依赖宿主能力，缺失能力时应如何降级。
-
-## 主要读者是谁？
-
-写作提示：
-
-- 给适配层读者。
-- 给想理解“为什么同一原型在不同宿主会有不同还原上限”的人。
+Catalog 当前只包含已经审计的一部分 host-capability identity。实现中还有更多 capability token；没有 `HC-*` 实体的 package 或 token 属于尚未编目，不能据此判断稳定或不支持。
 
 ## 前置阅读
 
-写作提示：
+先读[核心规范](/zh-cn/specifications/core/)理解 portable/host 分层，读 [Runtime 架构](/zh-cn/build/runtime-architecture/)理解 `ModuleWiring`，再读[兼容性](/zh-cn/reference/compatibility/)查看当前 Adapter profile slice。
 
-- 指向 `Whitepaper / 翻译层：Adapter / Compiler`
-- 指向 `Specifications / Core` 与 `Feedback`
+## 四层与四种 owner
 
-## 核心结构 / 机制
+```text
+Contract criterion ── 定义 portable behavior
+       │
+Module (`M-*`) ────── 拥有 semantic state 并请求 capability
+       │ CapToken
+Host Cap (`HC-*`) ─── 定义有界 host responsibility
+       │ provides.hostCaps
+Adapter (`A-*`) ───── 提供 native / translated / emulated realization
+```
 
-写作提示：
+行为始终由 `C-*` 拥有，capability entity 不会成为第二份 contract。`D-ADAPTER-PROFILE-0001` 要求 official profile 说明 capability 是以 native、translated 还是 emulated 方式兑现；不能忠实满足时不得声称已经提供。
 
-- 解释宿主能力模型、能力探测、能力缺失时的策略、可接受降级边界。
+## Token、vault 与 wiring
 
-## 关键 API / SPI
+Core 的 `cap<T>(id)` 创建具有全局 namespace string ID 的 typed token。每个 Runtime Module 收到只读 `CapsVaultView`：
 
-写作提示：
+- `SYS_CAP` 等 Runtime-owned base capability 在 host reset 后继续存在；
+- Adapter-attached capability 位于可替换的 attached layer；
+- `has` 与 `get` 解析当前值；
+- `onChange` 与 `epoch` 让 Module 在 capability identity 改变时 rebind；
+- 对 unavailable capability 调用 `get` 会给出稳定诊断。
 
-- 如果有宿主能力描述接口、能力矩阵、能力标注机制，可以在这里组织说明。
+Adapter 不直接修改 Module。`onRuntimeReady` 收到扁平的 `ModuleWiring`，再按 owning Module name 挂接 capability entry。Unmount/reset 只清除 attached host layer；terminal Module disposal 是另一项 Runtime action。
 
-## 常见误解或边界
+## Capability shape 由领域决定
 
-写作提示：
+不是每个 capability 都是 lease。当前形态包括：
 
-- 区分“宿主无法支持”与“适配器实现不足”。
-- 区分“可接受降级”与“语义违约”。
+| 形态 | 示例 | 生命周期行为 |
+| --- | --- | --- |
+| Source | Props source | 读取或 invalidate 当前 host input |
+| Sink / bridge | Expose record/event sink、accessibility projection | 接收 semantic projection |
+| Scoped binding | Event binding/default action | 挂接 host input route，并随 view 撤销 |
+| Lease | Anchored Positioning、Scroll Surface、Text Control、Move Gesture | `attach`，可选 `update`/`request`，最终 `dispose` |
 
-## 下一步读什么？
+例如，已编目的 Positioning boundary 使用有界 host lease：
 
-写作提示：
+```ts
+import { cap, type AnchoredPositionConnection } from '@proto.ui/core';
 
-- 如果想看如何在适配层消费这些能力：前往 `Adapter 指南`
-- 如果想看系统分层：前往 `模块与扩展架构`
+export interface AnchoredPositionHostLease {
+  update(connection: AnchoredPositionConnection): void;
+  requestUpdate(): void;
+  dispose(): void;
+}
+
+export interface AnchoredPositionHost {
+  attach(connection: AnchoredPositionConnection): AnchoredPositionHostLease;
+}
+
+export const ANCHORED_POSITION_HOST_CAP = cap<AnchoredPositionHost>(
+  '@proto.ui/positioning/anchoredHost'
+);
+```
+
+`M-POSITIONING-0001` 拥有何时 attach、update 与 dispose lease；`HC-ANCHORED-POSITION-0001` 拥有 host 要做什么；`T-ANCHORED-POSITIONING-0001` 映射 Module、host、Runtime 与 Prototype evidence。
+
+## Lifetime 与 rebinding
+
+Capability value 已经可用，不代表 host resource 永久存活。Module 通过 `resourceOwnership` 声明 `instance`、`view` 或 `mixed`：
+
+- instance resource 在 repeatable detach 后保留；
+- view resource 只属于一个 mount epoch；
+- mixed Module 保留 semantic state，同时暂停或替换 host resource。
+
+Lease-shaped capability 应在替换 target 前 dispose 旧 lease，并通过 epoch 或 connection identity 拒绝 stale async completion。Adapter wiring 应在 unmount 时撤销 DOM listener、observer 与 host reference，但不能销毁 instance-owned state。
+
+## Target 与 surface projection
+
+Host capability 不等于“原始 root element”。`C-HOST-SURFACE-PROJECTION-0001` 区分 logical `boundaryTarget` 和 visual `surfaceTarget`。Focus、accessibility、event、hit testing、native property、geometry 与 presentation 都可以有自己的 domain-specific target rule。仅仅因为 Adapter 同时能访问 wrapper 和可见 native control，并不意味着二者都成为 owner。
+
+Portable author 获得 semantic handle，而不是 raw target access。Host-specific escape hatch 保持在 profile local，不能被提升为 cross-Adapter Props 或 State guarantee。
+
+## Fake host 能证明什么
+
+Runtime fake host 与 in-memory capability double 很适合证明 Module ordering、missing-cap behavior、lease cleanup 与 phase guard，但不能证明 browser layout、native focus、DOM event propagation、framework commit timing 或具体 Adapter 的 target choice。应在能观察该 claim 的最低层验证，再为跨 translation claim 增加 official Adapter evidence。
+
+## 新增或修改 capability slice
+
+1. 找到适用 `C-*` criteria 与 semantic Module owner。
+2. 新增或更新一个完整 `M-*` / `HC-*` relation slice，不要按 token 数量批量建实体。
+3. 在最近的 Module package 中定义 capability shape 与 resource lifetime。
+4. 为每个适用 Adapter wiring，不能让 Adapter code 重解释 semantics。
+5. 只有在 reviewed evidence 存在后，才记录 profile `provides.hostCaps`。
+6. 新增 `T-*`，把 criteria 映射到 Module、fake-host、Adapter 与 integration implementation。
+7. 运行 graph/schema validation 与 focused executable tests。
+
+## 常见边界错误
+
+- 把 missing capability 当作“静默支持”，会掩盖 Adapter omission decision。
+- 把 profile 中未列出的 relation 解释为 unsupported，违反 uncataloged 状态。
+- 把 host target 存进 portable State，会让某个平台泄漏进协议。
+- 在 root 已替换后继续复用旧 view lease，会让 stale observer/callback 命中错误 surface。
+- 创建没有 criteria、owner 与 evidence 的 `HC-*` placeholder，只会膨胀 inventory。
+
+## 验证
+
+```sh
+corepack pnpm@10.32.1 vitest run packages/modules/positioning/test/floating-ui-host.test.ts
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/overlay.v0.contract.test.ts
+corepack pnpm@10.32.1 vitest run packages/spec/graph/test/adapter-profile.test.ts
+corepack pnpm@10.32.1 check:types
+```
+
+接下来阅读[模块与扩展架构](/zh-cn/build/module-extension-architecture/)理解 Module ownership，阅读 [Adapter 指南](/zh-cn/build/adapter-guide/)判断贡献是否就绪，或阅读[契约与测试](/zh-cn/build/contracts-and-tests/)理解证据层级。

--- a/apps/www/src/content/docs/zh-cn/build/module-extension-architecture.md
+++ b/apps/www/src/content/docs/zh-cn/build/module-extension-architecture.md
@@ -1,59 +1,140 @@
 ---
 title: '模块与扩展架构'
-desp: 'Proto UI 的模块边界、SPI 与扩展结构'
-description: 'Proto UI 的模块边界、SPI 与扩展结构'
+desp: '语义 Module 所有权、依赖边界、Runtime registration 与受治理的扩展工作'
+description: '语义 Module 所有权、依赖边界、Runtime registration 与受治理的扩展工作'
 ---
 
-## 这篇文章要回答什么？
+Module 在 Prototype authoring 与 host translation 之间承载可复用协议语义。一个 Module 可以暴露 setup/runtime author handle、保留 instance state、依赖其他 Module，并在不导入 React、Vue 或 Custom Elements 的情况下消费 Host Capability。
 
-写作提示：
+实现中的 Module package 数量多于 catalog 当前的 `M-*` 实体数量。Entity count 不等于 package count；尚未编目的 Module 是实现证据，不是 active public guarantee。
 
-- Proto UI 的各层模块在工程上如何分布。
-- 哪些部分属于稳定 API，哪些部分更接近 SPI 或内部结构。
-- 扩展包与模块作者应该从哪里接入系统。
+## 前置阅读
 
-## 这篇主要给谁看？
+先读[核心规范](/zh-cn/specifications/core/)理解 authoring phase，读 [Runtime 架构](/zh-cn/build/runtime-architecture/)理解 orchestration，再读 [Host Caps](/zh-cn/build/host-caps/)理解宿主边界。
 
-写作提示：
+## Static declaration 不等于 Runtime implementation
 
-- 给需要理解仓库分层与包职责的人。
-- 给研究运行时与扩展边界的读者。
-- 给未来可能编写扩展模块的人，而不是普通使用者。
+两组名称相近的 API 解决不同问题：
 
-## 需要先建立哪些分层视角？
+| 表面 | Owner | 目的 |
+| --- | --- | --- |
+| `@proto.ui/core` 的 `moduleDeclaration` / `declareModule` | Prototype definition | 在 Runtime Module construction 与 Adapter selection 前绑定 immutable typed configuration |
+| `@proto.ui/module-base` 的 `defineModule` / `createModule` | Runtime implementation | 定义 Module dependency、resource ownership、facade、port 与 lifecycle hook |
 
-写作提示：
+`C-MODULE-DECLARATION-0001` 治理第一组表面。Setup-time `asHook` 调用不能事后改变 static requirement；authored asHook 必须发布 frozen requirement，caller 则在 Prototype definition 上显式复用。
 
-- 区分协议核心、运行时承载、适配层、宿主能力层、参考原型库。
-- 说明“代码包结构”不等于“文档章节结构”，但两者之间存在映射关系。
+## Runtime Module anatomy
 
-## 模块边界要讲什么？
+```text
+ModuleDef
+  ├─ name + resourceOwnership
+  ├─ deps / optionalDeps
+  └─ create(ctx)
+       ├─ facade ── Kernel 或 dependent Module 使用的安全语义表面
+       ├─ port ──── privileged Runtime/Module integration surface
+       └─ hooks ─── instance、mount、proto phase、post-commit、dispose
+```
 
-写作提示：
+当前 implementation pattern 使用 `defineModule` 与 `createModule`：
 
-- 哪些层负责定义语义，哪些层负责承载语义，哪些层负责对接宿主。
-- 哪些依赖方向是被鼓励的，哪些跨层耦合是需要避免的。
+```ts
+import { createModule, defineModule, type ModuleFactoryArgs } from '@proto.ui/module-base';
 
-## 扩展边界要讲什么？
+type IdentityFacade = { prototypeName(): string };
 
-写作提示：
+function createIdentityModule(ctx: ModuleFactoryArgs) {
+  return createModule<'identity', 'instance', IdentityFacade>({
+    name: 'identity',
+    scope: 'instance',
+    init: ctx.init,
+    caps: ctx.caps,
+    deps: ctx.deps,
+    build: () => ({
+      facade: { prototypeName: () => ctx.init.prototypeName },
+      hooks: {},
+    }),
+  });
+}
 
-- 哪些点可以被视为扩展点。
-- 哪些能力只是内部实现细节，不应被外部模块依赖。
-- API 与 SPI 的稳定性预期应如何区分。
+export const IdentityModuleDef = defineModule({
+  name: 'identity',
+  resourceOwnership: 'instance',
+  deps: [],
+  create: createIdentityModule,
+});
+```
 
-## 这篇不打算展开什么？
+这段代码展示真实 implementation type，但**不**承诺第三方 package 可以把 `IdentityModuleDef` 动态安装进 stock Runtime：`createRuntimeInstance` 当前注册的是固定、已评审的 Module list。除非未来编目出 public registration surface，新增 Runtime Module 仍是仓库架构工作。
 
-写作提示：
+## Dependency graph 与 access
 
-- 不在这里写贡献流程。
-- 不在这里展开适配器实现手册。
-- 不在这里替代具体包的 API 文档。
+`RuntimeModuleOrchestrator` 对 hard dependency 和实际存在的 optional dependency 做 topological sort，并拒绝重复 name、缺失 hard dependency 和 cycle。之后由 `ctx.deps` 强制声明式 access：
 
-## 这篇要把读者带到哪里？
+- `requireFacade` / `requirePort` 在已声明 dependency 缺失时失败；
+- `tryFacade` / `tryPort` 只在 optional dependency 缺失时返回 `undefined`；
+- 所有 accessor 都拒绝未声明 dependency。
 
-写作提示：
+不要通过直接 import 另一个 Module 的 implementation object 绕过这套边界。Package dependency 是 build mechanics；`deps` 才表达 runtime semantic ordering 与 access。
 
-- 如果读者要理解系统承载层，前往 `Runtime 架构`。
-- 如果读者要理解原型表达层，前往 `Prototype API`。
-- 如果读者要理解宿主对接边界，前往 `Host Caps`。
+## Facade、port 与 capability
+
+始终使用最窄表面：
+
+- **Facade：**其他 author-facing layer 或 Module 可以消费的稳定语义操作。
+- **Port：**Runtime 或已声明 dependent Module 所需的 privileged integration，不会自动成为 public API。
+- **Host Capability：**由 Adapter 提供的平台服务或 projection，不能被当作 Module-to-Module back door。
+- **System Capability：**`SYS_CAP` 等 Runtime-owned phase/lifecycle guard，Adapter wiring 不得覆盖。
+
+Kernel 只能看到 facade；Runtime 可以为 lifecycle integration 读取 port；Adapter 通过 `ModuleWiring` 挂接 capability entry，不应取得或修改内部 Module instance。
+
+## Resource ownership
+
+每个 `ModuleDef` 都声明 `resourceOwnership`：
+
+| 值         | 含义                                                           |
+| ---------- | -------------------------------------------------------------- |
+| `instance` | Logical resource 在 detach 后保留，不拥有 host-view activation |
+| `view`     | Resource 只属于一个 mount epoch，detach 时必须释放             |
+| `mixed`    | Logical state 保留，host binding 则暂停、rebind 或 replay      |
+
+这个字段记录 intent，真正 cleanup 仍由 lifecycle hook 与测试执行。`C-LIFECYCLE-0006` 要求 instance phase 与 mount phase 正交；`packages/runtime/test/contract/lifecycle.module-resources.v1.contract.test.ts` 会跨 remount 验证 mixed ownership。
+
+## 受治理的扩展流程
+
+新增行为前先追踪一条 vertical slice：
+
+```text
+knowledge/decision → C-* criteria → M-* owner → HC-* requirement
+                   → A-* support/provision → T-* cases → implementation
+```
+
+然后：
+
+1. 确认 semantic channel 是否已经由现有 Module 拥有。
+2. Dated record 只保存 alternative 或 unresolved direction；稳定行为应进入实体。
+3. 新增或修订一个完整 `M-*` identity，并连接 satisfied Contract 与 required Host Cap。
+4. 定义 facade/port/dependency boundary 与明确 resource ownership。
+5. 只有 Issue 授权架构变更时，才把实现注册进 Runtime。
+6. 添加 Module-level test、Runtime integration，以及涉及 host translation 时的 Adapter evidence。
+7. 只为 reviewed slice 更新 official `A-*` profile relation；缺席仍表示 uncataloged。
+
+## 常见边界错误
+
+- 为每个 package 或 token 创建空 `M-*` 实体，无法形成 semantic ownership。
+- 因为 port 使用方便就把它暴露为 public API，会泄漏 Runtime privilege。
+- Import 未声明 dependency，会隐藏 ordering 与 disposal assumption。
+- 把 `scope: 'instance'` 当作 cleanup 正确的证据，会忽略 `resourceOwnership` 和 lifecycle behavior。
+- 让 Module 在每次 mutation 后间接调用 `run.update()`，违反显式 Runtime update ownership。
+- 把 Runtime 固定列表当作 plugin registry，会承诺一个不存在的 extension surface。
+
+## 验证
+
+```sh
+corepack pnpm@10.32.1 vitest run packages/core/test/contract/prototype.module-declarations.v0.contract.test.ts
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/module-declarations.v0.contract.test.ts
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/lifecycle.module-resources.v1.contract.test.ts
+corepack pnpm@10.32.1 check:prototype-catalog
+corepack pnpm@10.32.1 check:types
+```
+
+接下来阅读[契约与测试](/zh-cn/build/contracts-and-tests/)理解 evidence mapping，阅读 [Host Caps](/zh-cn/build/host-caps/)理解 host service，或在修改 translation code 前阅读 [Adapter 指南](/zh-cn/build/adapter-guide/)。

--- a/apps/www/src/content/docs/zh-cn/build/runtime-architecture.md
+++ b/apps/www/src/content/docs/zh-cn/build/runtime-architecture.md
@@ -1,54 +1,118 @@
 ---
 title: 'Runtime 架构'
-desp: '运行时架构概览'
-description: '运行时架构概览'
+desp: 'Proto UI 如何物化 instance、运行 Module 并把工作交给 Adapter host'
+description: 'Proto UI 如何物化 instance、运行 Module 并把工作交给 Adapter host'
 ---
 
-## 这篇解决什么工程问题？
+0.2 的执行路径以 Runtime 为基础：Prototype definition 被物化为 `RuntimeSession`，语义 Module 通过受控 facade 与 port 运行，Adapter 则提供 `RuntimeHost` 和 host capability。本文依据当前实现与 catalog 描述这条已交付路径。
 
-写作提示：
-
-- 解释 Proto UI runtime 在系统里承担什么责任。
-- 解释它如何承载白皮书中的执行语义与规范中的核心不变量。
-
-## 主要读者是谁？
-
-写作提示：
-
-- 给想理解 Proto UI 如何“真正跑起来”的读者。
-- 给需要进入运行时层的维护者、研究者与实现者。
+本文点名的大部分 lifecycle entity 仍是 `draft`；view intent 的 `C-LIFECYCLE-0008` 已是 `active`。实现已经通过测试，只能作为 draft rule 的证据，不会自动提升其生命周期。
 
 ## 前置阅读
 
-写作提示：
+先读[核心规范](/zh-cn/specifications/core/)理解 setup/render/callback 表面，读[生命周期](/zh-cn/specifications/lifecycle/)理解作者可见顺序，再读 [Prototype API](/zh-cn/reference/prototype-api/)理解 definition syntax。
 
-- 指向 `Whitepaper / 执行语义`
-- 指向 `Specifications / Core`
+## 所有权地图
 
-## 核心结构 / 机制
+```text
+Prototype definition
+  │ setup(def) / renderer
+  ▼
+RuntimeSession ── 拥有 instance 与可重复 mount epoch
+  ├─ Kernel ──── author handle、callback scope、render syntax
+  ├─ Module orchestrator ── 依赖顺序、facade、port、lifecycle hook
+  └─ RuntimeHost boundary ── raw Props、调度、commit completion、cap wiring
+                              │
+                              ▼
+                         Adapter + host platform
+```
 
-写作提示：
+`@proto.ui/runtime` 中的 `createRuntimeSession(proto, host)` 是主要 session 边界。`createRuntimeInstance` 构造更底层的 Kernel 与 Module graph；正常情况下由官方 Adapter 拥有这层集成，而不是让应用代码自行组装。
 
-- 解释 runtime 在 setup/runtime、生命周期推进、状态承载、通路联通中的位置。
-- 解释它和 adapter 之间的责任边界。
+## 两条生命周期轴
 
-## 关键 API / SPI
+`C-LIFECYCLE-0002` 与 `C-LIFECYCLE-0006` 把 terminal instance lifetime 和 repeatable host-view lifetime 分开：
 
-写作提示：
+| 轴 | 状态 | 所有权 |
+| --- | --- | --- |
+| Instance | `setup → alive → disposing → disposed` | 一个逻辑 Proto instance；setup 与 created 只运行一次 |
+| Mount | `detached → mounting → mounted → unmounting → detached` | 一个 host-view epoch；instance alive 期间可以重复 |
 
-- 只列运行时层真正关键的结构，不要把整份 API 参考粘过来。
+Canonical flow 是：
 
-## 常见误解或边界
+```text
+setup → created → (mount → render → commit.done → mounted
+                    → update → render → commit.done → updated
+                    → unmount → unmounted) × n
+      → beforeDispose → disposed
+```
 
-写作提示：
+Unmount 不等于 dispose。Instance-owned State、resolved Props、callback registry 与 logical identity 在 detached 区间继续保留。每次新 mount 都递增 `mountEpoch`，旧 epoch 的异步完成不得推进新 view。
 
-- 区分“执行语义”与“runtime 包实现”。
-- 区分“生命周期相位原则”与“具体门控实现细节”。
+## 显式 update 与 commit
 
-## 下一步读什么？
+Render 与 commit 是 Runtime-owned effect（`C-LIFECYCLE-0003`）。`run.update()` 与 `session.controller.update()` 表达 update intent；Props、State、Context、Event 或 Feedback mutation 不会隐式 render。
 
-写作提示：
+Host 通过调用 `signal.done()` 报告 commit 已完成。只有之后，Runtime 才能派发 `mounted`/`updated`、为当前 epoch 启用 event delivery，并运行 post-commit Module hook。Detached 时的 update intent 只标记 dirty，下一次 mount 从最新 runtime state 渲染。
 
-- 如果想看原型表达层：前往 `Prototype API`
-- 如果想看宿主承载层：前往 `Host Caps`
-- 如果想看适配器责任：前往 `Adapter 指南`
+## Module orchestration
+
+`RuntimeModuleOrchestrator` 按 dependency order 构造当前固定 Module set。它拒绝重复 name、缺失 hard dependency、依赖环和未声明的 dependency access。Kernel 只能访问 facade；Runtime internal 可以使用 privileged port；Adapter 通过扁平的 `ModuleWiring` 注入 host capability。
+
+每个 Module 会分别收到 instance、mount 与 legacy proto-phase hook。Logical State 可以由 instance 持有，而 DOM listener、observer、positioning session 等 host resource 则按 mount epoch 释放或重绑。作者边界见[模块与扩展架构](/zh-cn/build/module-extension-architecture/)。
+
+## Adapter handoff
+
+`RuntimeHost` 的职责有意保持很小：
+
+- 提供当前 raw Props snapshot；
+- commit `TemplateChildren` 并报告完成；
+- 调度 lifecycle work，以及需要时的 delayed callback；
+- 接收结构化 lifecycle diagnostics；
+- 在 `onRuntimeReady` 中挂接 Module host capability；
+- epoch unmount 时让 event/observer system 失效。
+
+Runtime 测试使用的最小 deterministic host 如下：
+
+```ts
+import type { RuntimeHost } from '@proto.ui/runtime';
+
+export function createTestHost(prototypeName: string): RuntimeHost<Record<string, unknown>> {
+  return {
+    prototypeName,
+    getRawProps: () => ({}),
+    commit(_children, signal) {
+      signal?.done();
+    },
+    schedule(task) {
+      task();
+    },
+  };
+}
+```
+
+这个 fake host 可以证明 Runtime ordering 与 phase guard，但不能证明 DOM event routing、framework lifecycle integration、target projection 或 host-capability 正确性；后者必须由 Adapter 与 host test 覆盖。
+
+## 常见边界错误
+
+- 每次 unmount 都 dispose Module hub，会破坏 repeatable instance semantics。
+- 调用 `commit()` 却不最终调用 `done()`，会让 epoch 永远无法完成。
+- 从 Module mutation 触发 render，会绕过显式 update ownership。
+- Kernel 直接进入 Module port，或 Module 访问未声明依赖，会绕过 orchestrator 边界。
+- 把 deprecated CP0–CP10 string 当作 lifecycle source of truth，会丢失 epoch 与 revision identity；当前 trace 以 structured lifecycle event 为准。
+- 把某个 Web Adapter 的 scheduling choice 写入 Core，会把宿主机械细节伪装成跨宿主保证。
+
+## 验证
+
+先运行 focused evidence，再扩大范围：
+
+```sh
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/lifecycle.session.v1.contract.test.ts
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/lifecycle.module-resources.v1.contract.test.ts
+corepack pnpm@10.32.1 vitest run packages/runtime/test/contract/lifecycle.update-order.strict.v0.contract.test.ts
+corepack pnpm@10.32.1 check:types
+```
+
+`T-LIFECYCLE-0003`、`T-LIFECYCLE-0005` 与 `T-LIFECYCLE-0006` 把共享 lifecycle criteria 连接到 Runtime 和官方 Adapter evidence。
+
+接下来阅读 [Host Caps](/zh-cn/build/host-caps/)理解 capability wiring，阅读 [Adapter 指南](/zh-cn/build/adapter-guide/)理解当前贡献边界，或阅读[契约与测试](/zh-cn/build/contracts-and-tests/)理解证据追踪。


### PR DESCRIPTION
Closes #417

## Summary

- replace the Runtime Architecture placeholders with a bilingual guide to `RuntimeSession`, instance/mount lifetime, explicit update/commit, module orchestration, callback scope, and Adapter host handoff
- turn Compiler Guide into an explicit shipped/future boundary: 0.2 has no `@proto.ui/compiler` package, compiler profile, CLI workflow, or supported compiler artifacts, while existing Template/Rule/Module-declaration constraints remain visible
- document Host Capability token/vault/wiring layers, domain-specific capability shapes, lease/resource lifetime, target projection, fake-host evidence, and profile relations
- document static Module declarations versus Runtime Module definitions, dependency enforcement, facade/port/capability separation, fixed Runtime registration, resource ownership, and the governed extension path
- bring English and Chinese Contracts & Tests to semantic parity across C/M/HC/A/T tracing, fixtures, type/Core/Module/Runtime/Adapter/Prototype evidence, Web journeys, commands, and contribution workflow
- reconcile the adjacent Adapter Guide around links and keep its general authoring workflow explicitly deferred
- remove WIP badges from the five completed route pairs while retaining Adapter Guide's WIP state

## Scope notes

- no spec entity, lifecycle state, Runtime/Compiler/Module API, or Adapter policy changes
- implementation packages and capability tokens without catalog entities remain explicitly uncataloged
- code examples were compiled against workspace TypeScript; they do not promise dynamic third-party Module registration

## Validation

- workspace TypeScript check, including the three documented API examples
- 11 focused passing test files / 49 passing tests across Core, Runtime, Module, Adapter, and spec graph evidence
- `corepack pnpm@10.32.1 --filter apps-www check` — 142 files, 0 diagnostics
- `corepack pnpm@10.32.1 check:agent-doc`
- `corepack pnpm@10.32.1 check:prototype-catalog`
- `corepack pnpm@10.32.1 --filter apps-www build` — 196 pages
- browser audit of 12 localized routes and 30 internal links; expected WIP state, no placeholders, no console errors

Signed-off-by: Guangliang Yang <52768321+guangliang2019@users.noreply.github.com>