### PR TITLE
test(cli): cover commas in joined arbitrary tokens

### DIFF
--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -186,4 +186,36 @@ describe('collectProtoStyleTokens', () => {
     expect(tokens).toContain('data-[busy]:opacity-50');
     expect(tokens).toContain('data-[busy]:cursor-wait');
   });
+  it('keeps commas inside arbitrary tokens when an array literal is joined', async () => {
+    await writeFile(
+      path.join(dir, 'field.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const BASE_TOKENS = [',
+        "  'flex',",
+        "  'transition-[color,box-shadow]',",
+        "  'duration-150',",
+        "].join(' ');",
+        '',
+        'const field = definePrototype({',
+        "  name: 'styled-field',",
+        '  setup(def) {',
+        '    def.feedback.style.use(tw(BASE_TOKENS));',
+        '  },',
+        '});',
+        'export default field;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+
+    // The comma belongs to the token, not to the element list, so joining must
+    // not hand the splitter an element boundary it never had.
+    expect(tokens).toContain('transition-[color,box-shadow]');
+    expect(tokens).not.toContain('transition-[color');
+    expect(tokens).not.toContain('box-shadow]');
+    expect(tokens).toContain('flex');
+    expect(tokens).toContain('duration-150');
+  });
 });


### PR DESCRIPTION
## Summary

Adds the CLI scanner unit case I said I would open separately once #436 landed: an array literal joined into a class string must keep a comma-containing arbitrary token whole.

Test-only. One file, one new `it()`. No source, spec, or generated output changes.

## Related context

- Follow-up to #436, where the scanner fix shipped without its own focused case. The fix lives in `packages/cli/src/services/prototype-style-tokens.ts` — array literals kept an `elements` list so `.join()` re-joins elements instead of re-splitting a comma-joined string.
- `packages/cli/test/prototype-style-tokens.test.ts` is not registered as a `T` implementation, so no spec entity changes.

## Why this case and not a broader one

The scanner already had cases for template interpolation, cross-file constants, and the four rule-lowering shapes. The uncovered edge was narrow and specific: `transition-[color,box-shadow]` is the only token in the tree where a comma is *inside* a token rather than between two, and it only reaches the array path through the Textarea's `[...].join(' ')` shape. The case reproduces exactly that shape.

## Verification

- Reverted both fix lines locally and re-ran: the new case fails with `expected [ 'box-shadow]', 'duration-150', …(2) ] to include 'transition-[color,box-shadow]'`; the other five stay green. Restored, all six green.
- `vitest run packages/cli/test` — 40 passed.
- `check:prototype-catalog`, `check:styles:preset`, `check:release-version`, `check:types:workspace` — OK.
- `prettier --check` on the touched file — clean.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs.
- [x] Normative behavior changes include coherent P/C/T criteria, revisions, executable evidence, and affected projections.
- [x] This change does not create an empty catalog identity or silently widen a draft/active public guarantee.
