### PR TITLE
fix(cli): give the generated import the extension the runtime needs

### DIFF
--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -5,7 +5,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import ts from 'typescript';
 
-import { canonicalizeLoweredVariants } from '../generated/lowered-variant-order';
+import { canonicalizeLoweredVariants } from '../generated/lowered-variant-order.js';
 
 export async function collectProtoStyleTokens(root) {
   const files = await collectSourceFiles(root);


### PR DESCRIPTION
## Summary

Regression from #450, which I introduced. The built CLI fails to start on a clean build; `main` is affected right now.

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  /…/packages/cli/dist/generated/lowered-variant-order
imported from /…/packages/cli/dist/services/prototype-style-tokens.js
```

## Cause

`scripts/build/public-packages.mjs:114` appends the extension only when the target is already on disk:

```js
if (existsSync(`${candidate}.js`)) return `${specifier}.js`;
```

That makes the rewrite depend on emit order. My import in #450 was the only relative import in the CLI written without an extension, so on a clean build where `dist/services/` is processed before `dist/generated/` exists, the specifier stays bare and Node ESM cannot resolve it. My local builds passed because a previous `dist` already had the file.

Every other relative import in this package writes `.js` explicitly — `packages/cli/src/legacy/type.ts:18-20` imports the three other generated modules that way. This makes mine match, and takes the outcome off the emit order entirely.

## Verification

Clean build, then import the built entry:

```
rm -rf packages/cli/dist
node scripts/build/public-packages.mjs --package @proto.ui/cli
node -e "import('./packages/cli/dist/services/prototype-style-tokens.js')"
```

Before: `ERR_MODULE_NOT_FOUND`. After: resolves, and the emitted specifier is `'../generated/lowered-variant-order.js'`.

`vitest run packages/cli` — 44 passed. `check:types:workspace`, `check:styles:variant-order` — OK.

## Note

The ordering dependency in the builder is still there for any future extensionless relative import. I did not widen this PR to it, since the convention in every package is to write the extension and a one-line fix restores `main` fastest. Happy to file that separately if you want the builder hardened.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs.
- [x] Normative behavior changes include coherent P/C/T criteria, revisions, executable evidence, and affected projections.
- [x] This change does not create an empty catalog identity or silently widen a draft/active public guarantee.
