### PR TITLE
test: share one dev server across the browser suites

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "test:release": "node --test scripts/release/test/*.test.mjs",
     "test:types": "echo \"[types] checking type contracts...\" && tsc -p internal/contracts/types/tsconfig.json && echo \"[types] OK\"",
     "test:web-conformance": "vitest run packages/web-conformance/test",
-    "test:runtime": "vitest run",
+    "test:runtime": "node scripts/test/run-runtime-tests.mjs",
     "styles:variant-order:generate": "node --import tsx scripts/styles/generate-lowered-variant-order.ts",
     "check:styles:variant-order": "node --import tsx scripts/styles/generate-lowered-variant-order.ts --check"
   },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "test:release": "node --test scripts/release/test/*.test.mjs",
     "test:types": "echo \"[types] checking type contracts...\" && tsc -p internal/contracts/types/tsconfig.json && echo \"[types] OK\"",
     "test:web-conformance": "vitest run packages/web-conformance/test",
-    "test:runtime": "node scripts/test/run-runtime-tests.mjs",
+    "test:runtime": "node --test scripts/test/run-runtime-tests.test.mjs && node scripts/test/run-runtime-tests.mjs",
     "styles:variant-order:generate": "node --import tsx scripts/styles/generate-lowered-variant-order.ts",
     "check:styles:variant-order": "node --import tsx scripts/styles/generate-lowered-variant-order.ts --check"
   },

--- a/scripts/test/run-runtime-tests.mjs
+++ b/scripts/test/run-runtime-tests.mjs
@@ -1,0 +1,165 @@
+// Starts one apps-www dev server, hands its URL to vitest through
+// PROTO_UI_BROWSER_BASE_URL, and tears it down afterwards.
+//
+// The browser suites can each spawn their own server, which is what makes them
+// usable on their own. Run together they share `apps/www/.astro`, and two Astro
+// content stores writing `data-store.json.tmp` race on the rename, so one dev
+// server exits and its suite fails. One server for the whole run removes that.
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+// Astro dev compiles a route on first request, so a suite probing a cold route
+// can exceed its own hook timeout and fall back to spawning its own server.
+// Warm every route the suites wait on.
+const READY_ROUTES = [
+  '/en/ui-libraries/base/textarea/',
+  '/en/ui-libraries/brutalist/components/switch/',
+  '/en/ui-libraries/brutalist/components/tabs/',
+  '/en/ui-libraries/shadcn/textarea/',
+];
+const READY_TIMEOUT_MS = 180_000;
+
+const vitestArgs = process.argv.slice(2);
+let devServer = null;
+let serverOutput = '';
+let shuttingDown = false;
+
+function recordOutput(chunk) {
+  serverOutput = `${serverOutput}${chunk.toString()}`.slice(-20_000);
+}
+
+async function availablePort() {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.unref();
+    probe.on('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address();
+      if (!address || typeof address === 'string') {
+        probe.close();
+        reject(new Error('Unable to reserve a port for the documentation dev server.'));
+        return;
+      }
+      probe.close((error) => (error ? reject(error) : resolve(address.port)));
+    });
+  });
+}
+
+async function waitForServer(url) {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (devServer && devServer.exitCode !== null) {
+      throw new Error(`Documentation dev server exited early.\n${serverOutput}`);
+    }
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(2_000) });
+      if (response.ok) return;
+    } catch {
+      // Still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Timed out waiting for ${url}.\n${serverOutput}`);
+}
+
+async function startServer() {
+  const port = await availablePort();
+  const executable = process.platform === 'win32' ? 'corepack.cmd' : 'corepack';
+  devServer = spawn(
+    executable,
+    [
+      'pnpm@10.32.1',
+      '--filter',
+      'apps-www',
+      'dev',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      String(port),
+      '--strictPort',
+    ],
+    {
+      cwd: root,
+      detached: process.platform !== 'win32',
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
+  devServer.stdout?.on('data', recordOutput);
+  devServer.stderr?.on('data', recordOutput);
+
+  const url = `http://127.0.0.1:${port}`;
+  for (const route of READY_ROUTES) await waitForServer(`${url}${route}`);
+  return url;
+}
+
+// The child is detached into its own process group, so signal the group to take
+// the dev server's own children with it.
+async function stopServer() {
+  if (shuttingDown || !devServer || devServer.exitCode !== null || !devServer.pid) return;
+  shuttingDown = true;
+  const target = process.platform === 'win32' ? devServer.pid : -devServer.pid;
+  try {
+    process.kill(target, 'SIGTERM');
+  } catch {
+    return;
+  }
+  const exited = await Promise.race([
+    new Promise((resolve) => devServer.once('exit', () => resolve(true))),
+    new Promise((resolve) => setTimeout(() => resolve(false), 5_000)),
+  ]);
+  if (!exited && devServer.exitCode === null) {
+    try {
+      process.kill(target, 'SIGKILL');
+    } catch {
+      // Already gone.
+    }
+  }
+}
+
+async function runVitest(baseUrl) {
+  return new Promise((resolve, reject) => {
+    // spawn() does not go through a shell, so resolve the workspace binary
+    // rather than relying on node_modules/.bin being on PATH.
+    const vitestBin = path.join(
+      root,
+      'node_modules',
+      '.bin',
+      process.platform === 'win32' ? 'vitest.cmd' : 'vitest'
+    );
+    const child = spawn(vitestBin, ['run', ...vitestArgs], {
+      cwd: root,
+      env: { ...process.env, PROTO_UI_BROWSER_BASE_URL: baseUrl },
+      stdio: 'inherit',
+    });
+    child.on('error', reject);
+    child.on('exit', (code, signal) => resolve(signal ? 1 : (code ?? 1)));
+  });
+}
+
+// A signal reaches the whole foreground group, so vitest gets it too and this
+// process only has to make sure the dev server does not outlive the run.
+for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+  process.on(signal, () => {
+    void stopServer().finally(() => {
+      process.exit(signal === 'SIGINT' ? 130 : 143);
+    });
+  });
+}
+
+let exitCode = 1;
+try {
+  const baseUrl = await startServer();
+  console.log(`[test:runtime] sharing ${baseUrl} across the browser suites`);
+  exitCode = await runVitest(baseUrl);
+} catch (error) {
+  console.error(`[test:runtime] ${error instanceof Error ? error.message : String(error)}`);
+  exitCode = 1;
+} finally {
+  await stopServer();
+}
+process.exit(exitCode);

--- a/scripts/test/run-runtime-tests.mjs
+++ b/scripts/test/run-runtime-tests.mjs
@@ -10,6 +10,7 @@ import { spawn } from 'node:child_process';
 import { createServer } from 'node:net';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createRuntimeTestPlan } from './runtime-test-plan.mjs';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 // Astro dev compiles a route on first request, so a suite probing a cold route
@@ -23,7 +24,7 @@ const READY_ROUTES = [
 ];
 const READY_TIMEOUT_MS = 180_000;
 
-const vitestArgs = process.argv.slice(2);
+const testPlan = createRuntimeTestPlan(process.argv.slice(2));
 let devServer = null;
 let serverOutput = '';
 let shuttingDown = false;
@@ -121,7 +122,7 @@ async function stopServer() {
   }
 }
 
-async function runVitest(baseUrl) {
+async function runVitest(args, baseUrl) {
   return new Promise((resolve, reject) => {
     // spawn() does not go through a shell, so resolve the workspace binary
     // rather than relying on node_modules/.bin being on PATH.
@@ -131,9 +132,10 @@ async function runVitest(baseUrl) {
       '.bin',
       process.platform === 'win32' ? 'vitest.cmd' : 'vitest'
     );
-    const child = spawn(vitestBin, ['run', ...vitestArgs], {
+    const env = baseUrl ? { ...process.env, PROTO_UI_BROWSER_BASE_URL: baseUrl } : process.env;
+    const child = spawn(vitestBin, ['run', ...args], {
       cwd: root,
-      env: { ...process.env, PROTO_UI_BROWSER_BASE_URL: baseUrl },
+      env,
       stdio: 'inherit',
     });
     child.on('error', reject);
@@ -151,11 +153,16 @@ for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
   });
 }
 
-let exitCode = 1;
+let exitCode = 0;
 try {
-  const baseUrl = await startServer();
-  console.log(`[test:runtime] sharing ${baseUrl} across the browser suites`);
-  exitCode = await runVitest(baseUrl);
+  for (const phase of testPlan) {
+    const baseUrl = phase.needsServer ? await startServer() : undefined;
+    if (baseUrl) {
+      console.log(`[test:runtime] sharing ${baseUrl} across the browser suites`);
+    }
+    exitCode = await runVitest(phase.args, baseUrl);
+    if (exitCode !== 0) break;
+  }
 } catch (error) {
   console.error(`[test:runtime] ${error instanceof Error ? error.message : String(error)}`);
   exitCode = 1;

--- a/scripts/test/run-runtime-tests.test.mjs
+++ b/scripts/test/run-runtime-tests.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { BROWSER_SUITES, createRuntimeTestPlan } from './runtime-test-plan.mjs';
+
+describe('runtime test plan', () => {
+  it('preserves focused Vitest arguments without starting the documentation server', () => {
+    assert.deepEqual(
+      createRuntimeTestPlan(['--', 'packages/spec/fixtures/test/context-fixtures.test.ts']),
+      [
+        {
+          needsServer: false,
+          args: ['packages/spec/fixtures/test/context-fixtures.test.ts'],
+        },
+      ]
+    );
+  });
+
+  it('isolates browser suites behind one shared documentation server in a full run', () => {
+    assert.deepEqual(createRuntimeTestPlan([]), [
+      {
+        needsServer: false,
+        args: BROWSER_SUITES.flatMap((suite) => ['--exclude', suite]),
+      },
+      {
+        needsServer: true,
+        args: BROWSER_SUITES,
+      },
+    ]);
+  });
+});

--- a/scripts/test/runtime-test-plan.mjs
+++ b/scripts/test/runtime-test-plan.mjs
@@ -1,0 +1,21 @@
+export const BROWSER_SUITES = Object.freeze([
+  'apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts',
+  'apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts',
+  'apps/www/src/content/docs/zh-cn/demo-shadcn-controls.browser.test.ts',
+]);
+
+export function createRuntimeTestPlan(rawArgs) {
+  const args = rawArgs[0] === '--' ? rawArgs.slice(1) : rawArgs;
+  if (args.length > 0) return [{ needsServer: false, args }];
+
+  return [
+    {
+      needsServer: false,
+      args: BROWSER_SUITES.flatMap((suite) => ['--exclude', suite]),
+    },
+    {
+      needsServer: true,
+      args: BROWSER_SUITES,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

Per your call on #453: option 1, as its own PR.

`test:runtime` now starts one `apps-www` dev server, waits for it, and hands its URL to `vitest run` through `PROTO_UI_BROWSER_BASE_URL`. The three browser suites keep the code that spawns their own server, so running a file on its own still works.

## Why it raced

The suites each spawn a server, and all three point at the same `apps/www` root, so they share `apps/www/.astro`. `test:runtime` is `vitest run`, which runs files in parallel, so two Astro content stores write `data-store.json.tmp` and race the rename — the loser gets `ENOENT` and its dev server exits.

## Measured, before and after

Sampling `pgrep -f 'astro dev'` every 10s across a full run of the three suites:

| | before | after |
| --- | --- | --- |
| peak concurrent dev servers | 2 | **1** |
| leftover after the run | 1 | **0** |
| wall clock | 33s | **21s** |
| result | 1 suite failed | **5 files, 13 tests passed** |

The 12s comes from not starting two extra servers.

## One thing that was not obvious

My first attempt still showed two servers. The three suites wait on **different** readiness routes — base textarea, brutalist switch and tabs, shadcn textarea — and Astro dev compiles a route on first request. A suite probing a cold route blew its own 10s hook timeout, decided the external server was unusable, and spawned its own. The script now warms all four routes before handing the URL over. Worth knowing if a suite ever adds a route.

## Cleanup paths

- **Normal and failing runs** — `finally` stops the server; vitest's exit code is passed through.
- **Signals** — `SIGINT`/`SIGTERM`/`SIGHUP` stop the server and exit 130/143. Verified: `kill -TERM` on the orchestrator mid-run left `pgrep -f 'astro dev'` at 0 and exited 143.
- The child is detached into its own process group and signalled as a group, so the dev server's own children go with it. `SIGTERM` first, `SIGKILL` after 5s.

## Verification

- `node scripts/test/run-runtime-tests.mjs apps/www/src/content/docs/zh-cn` — 5 files, 13 tests, exit 0, peak 1 server, 0 leftover.
- `pnpm vitest run apps/www/src/content/docs/zh-cn/demo-shadcn-controls.browser.test.ts` with no env var — 3 tests pass through the fallback, 0 leftover. The fallback is intact.
- No browser assertion changed; no test file is touched by this PR.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs.
- [x] Normative behavior changes include coherent P/C/T criteria, revisions, executable evidence, and affected projections.
- [x] This change does not create an empty catalog identity or silently widen a draft/active public guarantee.
