### PR TITLE
fix(style): use the theme background for implicit ring offsets

### DIFF
--- a/apps/www/src/content/docs/zh-cn/demo-ring-offset-default.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-ring-offset-default.browser.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+
+import type { Browser, Locator, Page } from 'playwright-core';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  RUNTIMES,
+  applyColorScheme,
+  launchBrowser,
+  openRoute,
+  selectRuntime,
+  startServer,
+  stopServer,
+} from './browser-harness';
+
+const DROPDOWN_ROUTE = '/en/ui-libraries/shadcn/dropdown-menu/';
+
+let browser: Browser;
+let baseUrl = '';
+
+type RingOffsetSample = {
+  background: number[];
+  offset: number[];
+  offsetShadow: string;
+  explicitOffsetColor: string;
+  focusVisible: boolean;
+};
+
+async function focusDropdownTrigger(page: Page, previewer: Locator): Promise<void> {
+  await previewer.locator('select.adapter-select').focus();
+  await page.keyboard.press('Tab');
+  await page.waitForFunction(
+    () => {
+      const trigger = document.querySelector<HTMLElement>(
+        '[data-previewer-id] [role="button"]'
+      );
+      if (!trigger?.hasAttribute('data-focus-visible')) return false;
+      return Boolean(
+        getComputedStyle(trigger).getPropertyValue('--pui-ring-offset-shadow').trim()
+      );
+    },
+    undefined,
+    { timeout: 10_000 }
+  );
+}
+
+async function ringOffsetSample(page: Page): Promise<RingOffsetSample> {
+  return page.evaluate(() => {
+    const trigger = document.querySelector<HTMLElement>('[data-previewer-id] [role="button"]');
+    if (!trigger) throw new Error('The shadcn Dropdown Menu demo must render its trigger.');
+
+    const probe = document.createElement('span');
+    probe.style.boxShadow = 'var(--pui-ring-offset-shadow)';
+    trigger.appendChild(probe);
+
+    const triggerStyle = getComputedStyle(trigger);
+    const offsetShadow = getComputedStyle(probe).boxShadow;
+    probe.remove();
+
+    const colorMatch = offsetShadow.match(
+      /^(?:(?:rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color)\([^)]*\)|#[0-9a-f]+|[a-z]+)/i
+    );
+    if (!colorMatch) {
+      throw new Error(`Unable to read the ring offset colour from: ${offsetShadow}`);
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = 1;
+    canvas.height = 1;
+    const context = canvas.getContext('2d', { willReadFrequently: true });
+    if (!context) throw new Error('Canvas 2D context is required to resolve painted colours.');
+
+    const paint = (color: string): number[] => {
+      context.clearRect(0, 0, 1, 1);
+      context.fillStyle = 'rgba(0, 0, 0, 0)';
+      context.fillStyle = color;
+      context.fillRect(0, 0, 1, 1);
+      return Array.from(context.getImageData(0, 0, 1, 1).data);
+    };
+
+    return {
+      background: paint(triggerStyle.backgroundColor),
+      offset: paint(colorMatch[0]),
+      offsetShadow,
+      explicitOffsetColor: triggerStyle.getPropertyValue('--pui-ring-offset-color').trim(),
+      focusVisible: trigger.hasAttribute('data-focus-visible'),
+    };
+  });
+}
+
+beforeAll(async () => {
+  baseUrl = await startServer(DROPDOWN_ROUTE);
+  browser = await launchBrowser();
+}, 150_000);
+
+afterAll(async () => {
+  await browser?.close();
+  await stopServer();
+});
+
+describe.sequential('ring offset browser regressions', () => {
+  it('uses the dark control surface when the prototype omits an offset colour', async () => {
+    const { context, page, previewer } = await openRoute(browser, baseUrl, DROPDOWN_ROUTE, {
+      width: 1440,
+      height: 900,
+    });
+
+    try {
+      await previewer.scrollIntoViewIfNeeded();
+      for (const runtime of RUNTIMES) {
+        await selectRuntime(page, previewer, runtime, '[role="button"]', 1);
+        await applyColorScheme(page, 'dark');
+        await focusDropdownTrigger(page, previewer);
+
+        const sample = await ringOffsetSample(page);
+        expect(sample.focusVisible, `${runtime}/focus-visible`).toBe(true);
+        expect(sample.explicitOffsetColor, `${runtime}/implicit-offset`).toBe('');
+        expect(sample.offsetShadow, `${runtime}/offset-shadow`).not.toBe('none');
+        expect(sample.offset, `${runtime}/painted-offset`).toEqual(sample.background);
+      }
+    } finally {
+      await context.close();
+    }
+  }, 180_000);
+});

--- a/packages/cli/src/services/proto-style-css.ts
+++ b/packages/cli/src/services/proto-style-css.ts
@@ -638,7 +638,7 @@ function colorValue(name: string, opacity?: string): string {
 
 function ringShadow(): string[] {
   return [
-    '--pui-ring-offset-shadow: 0 0 0 var(--pui-ring-offset-width, 0px) var(--pui-ring-offset-color, #fff);',
+    '--pui-ring-offset-shadow: 0 0 0 var(--pui-ring-offset-width, 0px) var(--pui-ring-offset-color, var(--pui-background));',
     '--pui-ring-shadow: var(--pui-ring-inset,) 0 0 0 calc(var(--pui-ring-width, 0px) + var(--pui-ring-offset-width, 0px)) var(--pui-ring-color, var(--pui-ring));',
     ...composedShadow(),
   ];

--- a/packages/cli/test/ring-offset-default.test.ts
+++ b/packages/cli/test/ring-offset-default.test.ts
@@ -12,16 +12,14 @@ describe('proto style ring offset defaults', () => {
     expect(css).not.toContain('var(--pui-ring-offset-color, #fff)');
   });
 
-  it('preserves explicit ring offset colour utilities', () => {
+  it('preserves the explicit background offset utility', () => {
     const css = renderProtoStyleTokenCss([
       'ring-2',
       'ring-offset-2',
       'ring-offset-background',
-      'ring-offset-foreground',
     ]);
 
     expect(css).toContain('--pui-ring-offset-color: var(--pui-background);');
-    expect(css).toContain('--pui-ring-offset-color: var(--pui-foreground);');
     expect(css).not.toContain('Unsupported Proto UI style tokens');
   });
 });

--- a/packages/cli/test/ring-offset-default.test.ts
+++ b/packages/cli/test/ring-offset-default.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderProtoStyleTokenCss } from '../src/services/proto-style-css';
+
+describe('proto style ring offset defaults', () => {
+  it('uses the theme background when no ring offset colour is declared', () => {
+    const css = renderProtoStyleTokenCss(['ring-2', 'ring-offset-2']);
+
+    expect(css).toContain(
+      '--pui-ring-offset-shadow: 0 0 0 var(--pui-ring-offset-width, 0px) var(--pui-ring-offset-color, var(--pui-background));'
+    );
+    expect(css).not.toContain('var(--pui-ring-offset-color, #fff)');
+  });
+
+  it('preserves explicit ring offset colour utilities', () => {
+    const css = renderProtoStyleTokenCss([
+      'ring-2',
+      'ring-offset-2',
+      'ring-offset-background',
+      'ring-offset-foreground',
+    ]);
+
+    expect(css).toContain('--pui-ring-offset-color: var(--pui-background);');
+    expect(css).toContain('--pui-ring-offset-color: var(--pui-foreground);');
+    expect(css).not.toContain('Unsupported Proto UI style tokens');
+  });
+});

--- a/scripts/test/run-runtime-tests.mjs
+++ b/scripts/test/run-runtime-tests.mjs
@@ -20,6 +20,7 @@ const READY_ROUTES = [
   '/en/ui-libraries/base/textarea/',
   '/en/ui-libraries/brutalist/components/switch/',
   '/en/ui-libraries/brutalist/components/tabs/',
+  '/en/ui-libraries/shadcn/dropdown-menu/',
   '/en/ui-libraries/shadcn/textarea/',
 ];
 const READY_TIMEOUT_MS = 180_000;

--- a/scripts/test/runtime-test-plan.mjs
+++ b/scripts/test/runtime-test-plan.mjs
@@ -1,6 +1,7 @@
 export const BROWSER_SUITES = Object.freeze([
   'apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts',
   'apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts',
+  'apps/www/src/content/docs/zh-cn/demo-ring-offset-default.browser.test.ts',
   'apps/www/src/content/docs/zh-cn/demo-shadcn-controls.browser.test.ts',
 ]);
 


### PR DESCRIPTION
## Summary

Fixes #456.

- Default an unset ring-offset colour to `var(--pui-background)` instead of the hardcoded `#fff`.
- Leave the three affected prototype sites unchanged so the shared default removes the trap for future `ring-offset-*` consumers as well.
- Preserve the existing explicit `ring-offset-background` utility.
- Add a real Chromium regression that keyboard-focuses the shadcn Dropdown Menu trigger in Dark mode and compares the painted offset layer with the control surface in Web Components, React, and Vue.

## Related context

- Issue: #456
- Applicable spec entities and lifecycle: `C-FEEDBACK-STYLE-0003` and `P-SHADCN-DROPDOWN-MENU-TRIGGER` are draft; this restores their existing style-intent/focus-feedback direction rather than widening the public protocol.
- Criteria / test anchors:
  - `packages/cli/test/ring-offset-default.test.ts`
  - `apps/www/src/content/docs/zh-cn/demo-ring-offset-default.browser.test.ts`
- Related upstream: none; this is a Proto UI physical CSS translation default.

## Scope boundary

- The issue had already narrowed the choice to adding three local tokens or making the shared default theme-relative, and preferred the shared-default direction.
- This pull request chooses the theme-relative default and adds generated-CSS plus painted-browser evidence.
- Explicit offset colours, ring widths, ring colours, shadows, prototype token lists, and theme values are unchanged.
- The inherited-ring recomposition defect in #455 is intentionally out of scope.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs.
- [ ] Normative entity revisions are not applicable: this fixes physical translation so existing focus-feedback intent is rendered correctly; it does not add or widen a P/C/T guarantee.
- [x] This change does not create an empty catalog identity or silently widen a draft/active public guarantee.

## Contribution provenance

Select every applicable item. Original, third-party, AI-assisted, and employer or client considerations may coexist.

- [x] This contribution was created for this repository and the submitting account has the right to submit it.
- [ ] This contribution adapts or derives from third-party material.
- [x] This contribution includes material AI-assisted generation or transformation.
- [ ] This contribution may be subject to employer or client ownership, and I have confirmed that I may submit it.
- [x] No third-party source disclosure is required.

### Third-party or upstream sources

| Source | Version / commit | License | Material used | Required attribution |
| ------ | ---------------- | ------- | ------------- | -------------------- |
| None | — | — | — | — |

### AI assistance

OpenAI's connected coding agent assisted with issue triage, source tracing, implementation, and test authoring. The resulting diff was reviewed against #456, the applicable draft spec entities, the three affected prototype sources, the existing browser harness, and a `main...head` branch comparison. No private third-party source material was provided.

## DCO

Every commit in this pull request contains a `Signed-off-by: cyjin-yl <cyjin.yl@gmail.com>` trailer.

- [x] I have checked the DCO status of this PR.

## Prototype website preview

- [ ] This pull request adds or changes public Prototype behavior and includes the required reachable website page or page update.
- [x] A new or updated website page is not applicable because the shared physical-CSS fix is exercised by existing public Dropdown Menu and Hover Card pages; the regression uses the existing real shadcn Dropdown Menu page.

- Public docs route: `/en/ui-libraries/shadcn/dropdown-menu/`
- Local preview URL or route: `/en/ui-libraries/shadcn/dropdown-menu/`
- Applicable runtimes manually reviewed: not manually reviewed in the connector environment; the automated browser suite covers Web Components / React / Vue.
- [x] The existing demo consumes the real public package export and its own Trigger anatomy/state.
- [x] The Demo Matrix is supplementary evidence rather than a replacement for the website page.
- External demo orchestration: none
- Consumer-owned orchestration that is not installed with the package: none

## Validation

- Focused generated-CSS regressions: passed in CI.
- Painted browser regression: passed in Chromium for Web Components, React, and Vue in the full `test` job.
- Prototype catalog, generated style manifests, variant ordering, release tests, type contracts, and repository tests: passed.
- Workspace type check: passed.
- Public-package build and bundle budgets: passed.
- CLI and isolated React consumer smoke tests: passed.
- Release scan and release-stage dry run: passed.
- CI: workflow run #636 completed successfully across all nine jobs for head `9bf6311c1df2d9b8cefd323424219c2040508bd7`.
- Branch integrity: the branch was 0 commits behind `main` when the pull request was opened; GitHub currently reports it mergeable.
- Local limitation: a full workspace checkout was unavailable in the connector execution environment, so the authoritative full-workspace and browser evidence is the successful repository CI run above.
