### PR TITLE
fix(adapters): keep a not-present overlay mounted and detached

### DIFF
--- a/apps/www/src/content/docs/zh-cn/demo-select-first-paint.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-select-first-paint.browser.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment node
+
+import type { Browser, Page } from 'playwright-core';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Locator } from 'playwright-core';
+import { RUNTIMES, launchBrowser, openRoute, startServer, stopServer } from './browser-harness';
+
+const SELECT_ROUTE = '/en/ui-libraries/brutalist/components/select/';
+
+/** The demo preselects `paper`, whose authored label is `Paper`. */
+const AUTHORED_LABEL = 'Paper';
+
+/** Root, trigger, value, the closed content, and its two authored items. */
+const MOUNTED_ROOT_COUNT = 6;
+
+/**
+ * The shared `selectRuntime` waits on an exact prototype-root count, which is
+ * one of the things this file measures, so readiness here waits only for the
+ * trigger. Reusing the shared helper would turn every assertion below into a
+ * timeout that says nothing about the label.
+ */
+async function showRuntime(page: Page, previewer: Locator, runtime: string): Promise<void> {
+  await previewer.locator('select.adapter-select').selectOption(runtime);
+  await page.waitForFunction(
+    (selected) => {
+      const root = document.querySelector('[data-previewer-id]');
+      const select = root?.querySelector<HTMLSelectElement>('select.adapter-select');
+      const host = root?.querySelector('.host');
+      if (!host || select?.value !== selected) return false;
+      return Array.from(host.querySelectorAll('*')).some(
+        (element) => element.getAttribute('role') === 'combobox'
+      );
+    },
+    runtime,
+    { timeout: 20_000 }
+  );
+  await page.waitForTimeout(300);
+}
+
+let browser: Browser;
+let baseUrl = '';
+
+type ClosedSelect = {
+  label: string;
+  displayValue: string | null;
+  registeredItems: number;
+  mountedRoots: number;
+  detachedHosts: number;
+  everOpened: boolean;
+};
+
+async function readClosedSelect(page: Page): Promise<ClosedSelect> {
+  return page.evaluate(() => {
+    const host = document.querySelector('[data-previewer-id] .host');
+    if (!host) throw new Error('The Select demo must render a previewer host.');
+    const trigger = Array.from(host.querySelectorAll('*')).find(
+      (element) => element.getAttribute('role') === 'combobox'
+    );
+    if (!trigger) throw new Error('The Select demo must render a trigger.');
+    const value = Array.from(trigger.querySelectorAll('*')).find((element) =>
+      element.hasAttribute('data-pui-root')
+    );
+
+    return {
+      label: (value?.textContent ?? '').trim(),
+      displayValue: value?.getAttribute('data-display-value') ?? null,
+      // Items live inside the closed content; they register with the Root's
+      // collection even though nothing has opened it.
+      registeredItems: document.querySelectorAll('[data-collection-index]').length,
+      mountedRoots: document.querySelectorAll('[data-previewer-id] [data-pui-root]').length,
+      detachedHosts: document.querySelectorAll('[data-pui-view-detached]').length,
+      everOpened: !!document.querySelector('[data-open]'),
+    };
+  });
+}
+
+beforeAll(async () => {
+  baseUrl = await startServer(SELECT_ROUTE);
+  browser = await launchBrowser();
+}, 150_000);
+
+afterAll(async () => {
+  await browser?.close();
+  await stopServer();
+});
+
+describe.sequential('Select first paint with the popup never opened', () => {
+  it('shows the authored label in every runtime', async () => {
+    const { context, page, previewer } = await openRoute(browser, baseUrl, SELECT_ROUTE, {
+      width: 1440,
+      height: 900,
+    });
+
+    try {
+      await previewer.scrollIntoViewIfNeeded();
+      for (const runtime of RUNTIMES) {
+        await showRuntime(page, previewer, runtime);
+        const closed = await readClosedSelect(page);
+
+        // Nothing in this case may open the popup; the defect it guards only
+        // shows before the first open cycle.
+        expect(closed.everOpened, `${runtime}/never-opened`).toBe(false);
+
+        // The rendered text is the assertion that matters to a reader of the
+        // page. `data-display-value` is checked alongside it because the two
+        // drifted apart: the protocol resolved the label while the view kept
+        // painting the raw value.
+        expect(closed.label, `${runtime}/label`).toBe(AUTHORED_LABEL);
+        expect(closed.displayValue, `${runtime}/display-value`).toBe(AUTHORED_LABEL);
+      }
+    } finally {
+      await context.close();
+    }
+  }, 180_000);
+
+  it('keeps the closed content mounted and marked detached in every runtime', async () => {
+    const { context, page, previewer } = await openRoute(browser, baseUrl, SELECT_ROUTE, {
+      width: 1440,
+      height: 900,
+    });
+
+    try {
+      await previewer.scrollIntoViewIfNeeded();
+      for (const runtime of RUNTIMES) {
+        await showRuntime(page, previewer, runtime);
+        const closed = await readClosedSelect(page);
+
+        expect(closed.detachedHosts, `${runtime}/detached`).toBeGreaterThan(0);
+        // Two authored options. Without them registered the label above can
+        // only come from a cache, so this is what makes that case meaningful.
+        expect(closed.registeredItems, `${runtime}/registered`).toBe(2);
+        expect(closed.mountedRoots, `${runtime}/mounted-roots`).toBe(MOUNTED_ROOT_COUNT);
+      }
+    } finally {
+      await context.close();
+    }
+  }, 180_000);
+});

--- a/packages/adapters/base/src/host/view-visibility.ts
+++ b/packages/adapters/base/src/host/view-visibility.ts
@@ -1,4 +1,5 @@
 export const PUI_VIEW_PENDING_ATTR = 'data-pui-view-pending';
+export const PUI_VIEW_DETACHED_ATTR = 'data-pui-view-detached';
 
 const VIEW_VISIBILITY_STYLE_ID = 'proto-ui-view-visibility';
 const RULES_BY_DOCUMENT = new WeakMap<Document, boolean>();
@@ -13,6 +14,6 @@ export function installViewVisibilityRule(doc: Document): void {
     (doc.head ?? doc.documentElement).appendChild(styleEl);
   }
 
-  styleEl.textContent = `${styleEl.textContent ?? ''}\n:where([${PUI_VIEW_PENDING_ATTR}]) { visibility: hidden !important; }\n`;
+  styleEl.textContent = `${styleEl.textContent ?? ''}\n:where([${PUI_VIEW_PENDING_ATTR}]) { visibility: hidden !important; }\n:where([${PUI_VIEW_DETACHED_ATTR}]) { display: none !important; }\n`;
   RULES_BY_DOCUMENT.set(doc, true);
 }

--- a/packages/adapters/base/test/view-visibility.test.ts
+++ b/packages/adapters/base/test/view-visibility.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { installViewVisibilityRule, PUI_VIEW_PENDING_ATTR } from '../src';
+import { installViewVisibilityRule, PUI_VIEW_DETACHED_ATTR, PUI_VIEW_PENDING_ATTR } from '../src';
 
 describe('adapter-base: view visibility', () => {
   afterEach(() => {
@@ -17,5 +17,25 @@ describe('adapter-base: view visibility', () => {
 
     root.removeAttribute(PUI_VIEW_PENDING_ATTR);
     expect(getComputedStyle(root).visibility).not.toBe('hidden');
+  });
+
+  it('takes a detached host root and its subtree out of paint', () => {
+    const root = document.createElement('div');
+    root.setAttribute(PUI_VIEW_DETACHED_ATTR, '');
+    const child = document.createElement('span');
+    child.textContent = 'authored child';
+    root.appendChild(child);
+    document.body.appendChild(root);
+
+    installViewVisibilityRule(document);
+
+    // The exclusion comes from the attribute's own projection, so a styled
+    // prototype never has to add a rule of its own to get it.
+    expect(getComputedStyle(root).display).toBe('none');
+    // The child stays in the tree; it is the ancestor that is out of paint.
+    expect(root.contains(child)).toBe(true);
+
+    root.removeAttribute(PUI_VIEW_DETACHED_ATTR);
+    expect(getComputedStyle(root).display).not.toBe('none');
   });
 });

--- a/packages/adapters/react/src/adapt.ts
+++ b/packages/adapters/react/src/adapt.ts
@@ -16,6 +16,7 @@ import {
   createViewEpochOwner,
   createWebProtoEventRouter,
   installViewVisibilityRule,
+  PUI_VIEW_DETACHED_ATTR,
   PUI_VIEW_PENDING_ATTR,
   type ProtoAdapterProps,
   scheduleAfterWebLayout,
@@ -356,6 +357,8 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
 
       runtime.useLayoutEffect(() => {
         if (!shouldExist) {
+          const detachedEl = rootRef.current;
+          if (detachedEl) installViewVisibilityRule(detachedEl.ownerDocument);
           eventGateRef.current?.disable?.();
           if (ownerRef.current?.hasView) void ownerRef.current.detachView();
           setHostTokens([]);
@@ -423,7 +426,10 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
             }
             fn();
           },
-          isViewReady: () => viewReadyRef.current,
+          // A child of a detached ancestor still mounts and attaches its own
+          // view, so readiness has to consult the subtree, not just this host.
+          isViewReady: () =>
+            viewReadyRef.current && !rootRef.current?.closest(`[${PUI_VIEW_DETACHED_ATTR}]`),
           getCurrentElement: () => rootRef.current,
           subscribeTargetReady: (listener) => {
             focusTargetReadyListenersRef.current.add(listener);
@@ -514,25 +520,35 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
           ? document.body
           : null;
 
-      const content = !shouldExist
-        ? null
-        : runtime.createElement(
-            rootTag,
-            {
-              ref: rootRef as { current: HTMLElement | null },
-              className: mergeHostClassName([
-                props.surfaceClassName,
-                props.hostClassName,
-                props.className,
-              ]),
-              style: mergeHostStyle([props.surfaceStyle, props.hostStyle, props.style]),
-              'data-pui-root': '',
-              [PUI_VIEW_PENDING_ATTR]: viewReadyRef.current ? undefined : '',
-              'data-pui-style': serializeStyleTokens(hostTokens),
-              'data-demo-ref': props['data-demo-ref' as keyof typeof props] as string | undefined,
-            },
-            ...renderedChildren
-          );
+      // Overlay content is detached, not unmounted, when it is not present: the
+      // host element and the authored children stay put so collection members
+      // keep registering, and the shared detached rule takes them out of paint,
+      // a11y, and tab order. Prototypes that drive presence directly through
+      // `lifecycle.setPresent`, such as Tabs Content, keep unmounting.
+      const detached = !shouldExist && overlayPort?.hasPresenceBinding() === true;
+      const content =
+        !shouldExist && !detached
+          ? null
+          : runtime.createElement(
+              rootTag,
+              {
+                ref: rootRef as { current: HTMLElement | null },
+                className: mergeHostClassName([
+                  props.surfaceClassName,
+                  props.hostClassName,
+                  props.className,
+                ]),
+                style: mergeHostStyle([props.surfaceStyle, props.hostStyle, props.style]),
+                'data-pui-root': '',
+                [PUI_VIEW_DETACHED_ATTR]: detached ? '' : undefined,
+                [PUI_VIEW_PENDING_ATTR]: viewReadyRef.current ? undefined : '',
+                'data-pui-style': serializeStyleTokens(hostTokens),
+                'data-demo-ref': props['data-demo-ref' as keyof typeof props] as string | undefined,
+              },
+              // Without a view there is no template to place the slot into, so the
+              // authored children stand in for it.
+              ...(shouldExist ? renderedChildren : [props.children])
+            );
       const projectedContent = portalContainer
         ? runtime.createPortal!(content, portalContainer)
         : content;

--- a/packages/adapters/vue/src/adapt.ts
+++ b/packages/adapters/vue/src/adapt.ts
@@ -15,6 +15,7 @@ import {
   createViewEpochOwner,
   createWebProtoEventRouter,
   installViewVisibilityRule,
+  PUI_VIEW_DETACHED_ATTR,
   PUI_VIEW_PENDING_ATTR,
   type ProtoAdapterExposes,
   type ProtoAdapterProps,
@@ -404,7 +405,9 @@ export function createVueAdapter(runtime: VueRuntime) {
               }
               fn();
             },
-            isViewReady: () => viewReady,
+            // A child of a detached ancestor still mounts and attaches its own
+            // view, so readiness has to consult the subtree, not just this host.
+            isViewReady: () => viewReady && !rootRef.value?.closest(`[${PUI_VIEW_DETACHED_ATTR}]`),
             getCurrentElement: () => rootRef.value,
             subscribeTargetReady: (listener) => {
               focusTargetReadyListeners.add(listener);
@@ -443,7 +446,10 @@ export function createVueAdapter(runtime: VueRuntime) {
         runtime.onMounted(() => {
           const rootEl = rootRef.value;
           if (rootEl) installViewVisibilityRule(rootEl.ownerDocument);
-          initSession();
+          // A detached host is mounted now, so reaching this hook no longer
+          // means the view should attach. Leave that to the presence watcher,
+          // or the first real open finds `lastInitRoot` already claimed.
+          if (shouldExist.value) initSession();
           runtime.nextTick().then(notifyFocusTargetReady);
         });
         runtime.onUpdated?.(() => {
@@ -476,6 +482,10 @@ export function createVueAdapter(runtime: VueRuntime) {
               if (owner.hasView) void owner.detachView();
               hostTokens.value = [];
               viewReady = false;
+              // The host element survives a detach now, so the same element has
+              // to be able to initialize a second time. Without this the reopen
+              // path skips initSession and binds against a disposed router.
+              lastInitRoot = null;
             }
           },
           { flush: 'post' }
@@ -503,11 +513,23 @@ export function createVueAdapter(runtime: VueRuntime) {
         });
 
         return () => {
-          if (!shouldExist.value) return null;
+          const present = shouldExist.value;
+          const overlayPort = owner.session?.caps.getPort<OverlayPort>('overlay');
+          // Overlay content is detached, not unmounted, when it is not present:
+          // the host element and the authored children stay put so collection
+          // members keep registering, and the shared detached rule takes them
+          // out of paint, a11y, and tab order. Prototypes that drive presence
+          // directly through `lifecycle.setPresent`, such as Tabs Content, keep
+          // unmounting.
+          const detached = !present && overlayPort?.hasPresenceBinding() === true;
+          if (!present && !detached) return null;
+
           const slotNodes = ctx.slots.default ? ctx.slots.default() : null;
-          const rendered = renderTemplateToVue(runtime, renderChildren.value, {
-            slot: slotNodes as any,
-          });
+          // Without a view there is no template to place the slot into, so the
+          // authored children stand in for it.
+          const rendered = present
+            ? renderTemplateToVue(runtime, renderChildren.value, { slot: slotNodes as any })
+            : slotNodes;
 
           const content = runtime.h(
             rootTag,
@@ -518,14 +540,14 @@ export function createVueAdapter(runtime: VueRuntime) {
               class: mergeHostClass([props.surfaceClass, props.hostClass, ctx.attrs.class]),
               style: mergeHostStyle([props.surfaceStyle, props.hostStyle, ctx.attrs.style]),
               'data-pui-root': '',
+              [PUI_VIEW_DETACHED_ATTR]: detached ? '' : undefined,
               [PUI_VIEW_PENDING_ATTR]: viewReady ? undefined : '',
               'data-pui-style': serializeStyleTokens(hostTokens.value),
               'data-demo-ref': ctx.attrs['data-demo-ref'] as string | undefined,
             },
             rendered as any
           );
-          const overlayPort = owner.session?.caps.getPort<OverlayPort>('overlay');
-          if (overlayPort?.getConfig().portal === true && runtime.Teleport) {
+          if (present && overlayPort?.getConfig().portal === true && runtime.Teleport) {
             return runtime.h(runtime.Teleport, { to: 'body' }, [content]);
           }
           return content;

--- a/packages/adapters/vue/test/dialog.test.ts
+++ b/packages/adapters/vue/test/dialog.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { PUI_VIEW_DETACHED_ATTR } from '@proto.ui/adapter-base';
 import { definePrototype } from '@proto.ui/core';
 
 import {
@@ -97,7 +98,9 @@ describe('adapter-vue: dialog integration', () => {
 
     try {
       const host = mounted.host;
-      expect(host.querySelector('div')).toBeNull();
+      const mask = host.querySelector('div');
+      expect(mask).not.toBeNull();
+      expect(mask?.hasAttribute(PUI_VIEW_DETACHED_ATTR)).toBe(true);
 
       const exposes = mounted.vm.getExposes();
       expect(exposes.transitionState?.get?.()).toBe('closed');

--- a/packages/adapters/vue/test/previewer-dialog.demo.test.ts
+++ b/packages/adapters/vue/test/previewer-dialog.demo.test.ts
@@ -1,3 +1,4 @@
+import { PUI_VIEW_DETACHED_ATTR } from '@proto.ui/adapter-base';
 import { describe, expect, it, vi } from 'vitest';
 import { VueAny } from './utils/vue';
 
@@ -33,7 +34,9 @@ async function waitForDialogAbsent(text: string, timeoutMs = 1_000) {
     const element = Array.from(document.body.querySelectorAll('[data-transition-state]')).find(
       (candidate) => candidate.textContent?.includes(text)
     );
-    if (!element) return true;
+    // Closed overlay content stays mounted and detached, so absence means the
+    // content is gone or sitting inside a detached subtree.
+    if (!element || element.closest(`[${PUI_VIEW_DETACHED_ATTR}]`)) return true;
     await new Promise<void>((resolve) => setTimeout(resolve, 10));
   }
   return false;
@@ -45,6 +48,19 @@ function findExactText(root: ParentNode, text: string): HTMLElement | null {
       (element) => element.textContent?.trim() === text
     ) ?? null
   );
+}
+
+// Controls authored under a closed overlay mount while it is detached and are
+// moved into the committed template when it becomes present, so their a11y
+// projection lands a tick after the content reports its transition state.
+async function waitForExactText(root: ParentNode, text: string, timeoutMs = 1_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const element = findExactText(root, text);
+    if (element) return element;
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+  return null;
 }
 
 describe('PrototypePreviewer demo-renderer / vue dialog', () => {
@@ -78,7 +94,7 @@ describe('PrototypePreviewer demo-renderer / vue dialog', () => {
       trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       expect(await waitForDialogPresent('Confirm Action')).not.toBeNull();
 
-      const close = findExactText(document.body, 'Cancel');
+      const close = await waitForExactText(document.body, 'Cancel');
       expect(close).not.toBeNull();
       close?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       expect(await waitForDialogAbsent('Confirm Action')).toBe(true);

--- a/packages/adapters/web-component/src/host-display.ts
+++ b/packages/adapters/web-component/src/host-display.ts
@@ -1,7 +1,10 @@
+import { installViewVisibilityRule, PUI_VIEW_DETACHED_ATTR } from '@proto.ui/adapter-base';
+
 const HOST_DISPLAY_STYLE_ID = 'proto-ui-wc-host-display';
 const HOST_DISPLAY_CLASS = 'pui-host-root';
 const PUI_STYLE_ATTR = 'data-pui-style';
-export const PUI_VIEW_DETACHED_ATTR = 'data-pui-view-detached';
+
+export { PUI_VIEW_DETACHED_ATTR };
 
 const RULES_BY_DOCUMENT = new WeakMap<Document, boolean>();
 
@@ -59,8 +62,10 @@ export function installDefaultHostDisplay(el: HTMLElement): HostDisplayControlle
 function ensureDefaultHostDisplayRule(doc: Document) {
   if (RULES_BY_DOCUMENT.get(doc)) return;
 
+  installViewVisibilityRule(doc);
+
   const styleEl = getOrCreateStyleElement(doc);
-  styleEl.textContent = `${styleEl.textContent ?? ''}\n:where(.${HOST_DISPLAY_CLASS}) { display: block; }\n:where([${PUI_VIEW_DETACHED_ATTR}]) { display: none !important; }\n`;
+  styleEl.textContent = `${styleEl.textContent ?? ''}\n:where(.${HOST_DISPLAY_CLASS}) { display: block; }\n`;
   RULES_BY_DOCUMENT.set(doc, true);
 }
 

--- a/packages/hooks/src/as-overlay.ts
+++ b/packages/hooks/src/as-overlay.ts
@@ -13,6 +13,7 @@ type OverlayFacade = {
 
 type OverlayPort = {
   setViewActive(active: boolean): void;
+  markPresenceBound(): void;
   reconcileViewResourcesAfterCallback(): void;
 };
 
@@ -112,6 +113,7 @@ const installOverlay = definePrivilegedAsHook<PropsBaseType, OverlayHandle<Props
         }
 
         presenceBinding = binding;
+        port.markPresenceBound();
         port.setViewActive(binding.present.get());
         offPresence = binding.present.watch((_run, event) => {
           if (event.type !== 'next') return;

--- a/packages/modules/overlay/src/create.ts
+++ b/packages/modules/overlay/src/create.ts
@@ -55,6 +55,8 @@ export function createOverlayModule(ctx: ModuleFactoryArgs): OverlayModule {
           registerContent: (target) => impl.registerContent(target),
           updatePosition: (patch) => impl.updatePosition(patch),
           setViewActive: (active) => impl.setViewActive(active),
+          markPresenceBound: () => impl.markPresenceBound(),
+          hasPresenceBinding: () => impl.hasPresenceBinding(),
           reconcileViewResourcesAfterCallback: () => impl.reconcileViewResourcesAfterCallback(),
         },
       };

--- a/packages/modules/overlay/src/impl.ts
+++ b/packages/modules/overlay/src/impl.ts
@@ -100,6 +100,7 @@ function pushOverrideWarning(warnings: string[], field: string, prev: unknown, n
 
 export class OverlayModuleImpl extends ModuleBase {
   private config: OverlayConfig = DEFAULT_CONFIG;
+  private presenceBound = false;
   private readonly prototypeName: string;
   private readonly warnings: string[] = [];
   private readonly boundary: BoundaryHandle<any>;
@@ -324,6 +325,14 @@ export class OverlayModuleImpl extends ModuleBase {
     }
 
     this.boundary.setStackActive(false);
+  }
+
+  markPresenceBound(): void {
+    this.presenceBound = true;
+  }
+
+  hasPresenceBinding(): boolean {
+    return this.presenceBound;
   }
 
   setViewActive(active: boolean): void {

--- a/packages/modules/overlay/src/types.ts
+++ b/packages/modules/overlay/src/types.ts
@@ -37,6 +37,8 @@ export type OverlayPort = {
   registerContent(target: unknown): void;
   updatePosition(patch: OverlayPositionPatch): void;
   setViewActive(active: boolean): void;
+  markPresenceBound(): void;
+  hasPresenceBinding(): boolean;
   reconcileViewResourcesAfterCallback(): void;
 };
 

--- a/packages/prototypes/base/src/select/value.proto.ts
+++ b/packages/prototypes/base/src/select/value.proto.ts
@@ -11,6 +11,11 @@ function setupSelectValue(def: DefHandle<SelectValueProps, SelectValueExposes>) 
   const displayValue = def.state.string('displayValue', '');
   def.expose.state('displayValue', displayValue);
   let mounted = false;
+  // A context update can resolve the selected text before this view is mounted,
+  // in which case the render that would have shown it is suppressed. Remember
+  // that so mounting can flush it, or the host keeps painting the earlier value
+  // while the exposed state already reads the resolved one.
+  let renderMissed = false;
 
   const computeDisplayValue = (run: any) => {
     const ctx = run.context.read(SELECT_CONTEXT);
@@ -21,7 +26,9 @@ function setupSelectValue(def: DefHandle<SelectValueProps, SelectValueExposes>) 
     const nextValue = computeDisplayValue(run);
     if (nextValue === displayValue.get()) return;
     displayValue.set(nextValue, 'reason: select value display sync');
-    if (requestRender && mounted) run.update();
+    if (!requestRender) return;
+    if (mounted) run.update();
+    else renderMissed = true;
   };
 
   def.context.subscribe(SELECT_CONTEXT, (run) => syncDisplayValue(run, true));
@@ -29,6 +36,10 @@ function setupSelectValue(def: DefHandle<SelectValueProps, SelectValueExposes>) 
   def.lifecycle.onMounted((run) => {
     syncDisplayValue(run, false);
     mounted = true;
+    if (renderMissed) {
+      renderMissed = false;
+      run.update();
+    }
   });
   def.props.watch(['placeholder'], (run) => syncDisplayValue(run, true));
   def.lifecycle.onUnmounted(() => {

--- a/packages/web-conformance/test/shadcn-select-controlled-value.journey.test.ts
+++ b/packages/web-conformance/test/shadcn-select-controlled-value.journey.test.ts
@@ -1,0 +1,184 @@
+import * as React from 'react';
+import { createPortal, flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import * as Vue from 'vue';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { renderDemo } from '../../../apps/www/src/components/PrototypePreviewer/demo-renderer';
+import { loadPrototypes } from '../../../apps/www/src/components/PrototypePreviewer/prototype-modules';
+import {
+  AdapterIds,
+  type RuntimeId,
+} from '../../../apps/www/src/components/PrototypePreviewer/runtimes/registry';
+import type {
+  DemoRuntimeApi,
+  DemoSpec,
+} from '../../../apps/www/src/components/PrototypePreviewer/demo-types';
+
+vi.mock('../../../apps/www/src/components/PrototypePreviewer/runtimes/react-runtime', () => ({
+  loadReact: vi.fn(async () => ({
+    React,
+    ReactDOM: { createPortal, createRoot, flushSync },
+  })),
+}));
+
+vi.mock('../../../apps/www/src/components/PrototypePreviewer/runtimes/vue-runtime', () => ({
+  loadVue: vi.fn(async () => Vue),
+}));
+
+const WEB_ADAPTERS = ['wc', 'react', 'vue'] as const satisfies readonly RuntimeId[];
+const SELECT_PROTOTYPES = [
+  'shadcn-select-root',
+  'shadcn-select-trigger',
+  'shadcn-select-value',
+  'shadcn-select-content',
+  'shadcn-select-item',
+] as const;
+
+/**
+ * A fixture rather than a documentation demo, because the published Select demo
+ * has no control that drives `value` from outside. `setup` hands the runtime API
+ * to the test, which is how a controlled owner would push a new value in.
+ */
+let runtimeApi: DemoRuntimeApi | null = null;
+
+const controlledSelectFixture: DemoSpec = {
+  type: 'demo',
+  root: {
+    kind: 'proto',
+    prototypeId: 'shadcn-select-root',
+    ref: 'root',
+    props: { value: 'react' },
+    children: [
+      {
+        kind: 'proto',
+        prototypeId: 'shadcn-select-trigger',
+        children: [
+          {
+            kind: 'proto',
+            prototypeId: 'shadcn-select-value',
+            ref: 'value',
+            props: { placeholder: 'Select an adapter' },
+          },
+        ],
+      },
+      {
+        kind: 'proto',
+        prototypeId: 'shadcn-select-content',
+        props: { position: 'popper', align: 'start' },
+        children: [
+          {
+            kind: 'proto',
+            prototypeId: 'shadcn-select-item',
+            props: { value: 'react', textValue: 'React' },
+            children: ['React'],
+          },
+          {
+            kind: 'proto',
+            prototypeId: 'shadcn-select-item',
+            props: { value: 'vue', textValue: 'Vue' },
+            children: ['Vue'],
+          },
+          {
+            kind: 'proto',
+            prototypeId: 'shadcn-select-item',
+            props: { value: 'wc', textValue: 'Web Components' },
+            children: ['Web Components'],
+          },
+        ],
+      },
+    ],
+  },
+  setup: (ctx) => {
+    runtimeApi = ctx.api;
+    return () => {
+      runtimeApi = null;
+    };
+  },
+};
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Vue.nextTick();
+  await Promise.resolve();
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  await Promise.resolve();
+}
+
+/** Reports the text it actually saw, so a timeout still names the defect. */
+async function waitForText(
+  target: HTMLElement,
+  expected: string,
+  label: string,
+  timeoutMs = 1_500
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    await settle();
+    if (target.textContent?.trim() === expected) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+  expect(target.textContent?.trim(), label).toBe(expected);
+}
+
+function requireRef(host: HTMLElement, ref: string): HTMLElement {
+  const target = host.querySelector<HTMLElement>(`[data-demo-ref="${ref}"]`);
+  expect(target, `expected demo ref "${ref}"`).toBeTruthy();
+  return target!;
+}
+
+function requireApi(): DemoRuntimeApi {
+  expect(runtimeApi, 'the fixture must publish its runtime API').toBeTruthy();
+  return runtimeApi!;
+}
+
+beforeAll(async () => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = false;
+  expect([...WEB_ADAPTERS]).toEqual(AdapterIds);
+  await loadPrototypes([...SELECT_PROTOTYPES]);
+});
+
+afterAll(() => {
+  delete (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT;
+});
+
+describe('Web adapter conformance / Shadcn Select controlled value journey', () => {
+  it.each(WEB_ADAPTERS)(
+    '%s resolves a controlled value that never opens the Content',
+    async (runtime) => {
+      const host = document.createElement('div');
+      document.body.append(host);
+      const session = await renderDemo({
+        runtime,
+        demo: controlledSelectFixture as any,
+        host,
+      });
+
+      try {
+        await settle();
+        const value = requireRef(host, 'value');
+
+        // The Content has never been open, so the authored labels live in a
+        // subtree the host only keeps because it stays mounted and detached.
+        await waitForText(value, 'React', `${runtime}/initial-label`);
+        expect(value.dataset.displayValue, `${runtime}/initial-fact`).toBe('React');
+
+        // A controlled owner pushes a new value in without any open ever
+        // happening. Both the painted label and the exposed fact must follow.
+        requireApi().setProps('root', { value: 'wc' });
+        await waitForText(value, 'Web Components', `${runtime}/updated-label`);
+        expect(value.dataset.displayValue, `${runtime}/updated-fact`).toBe('Web Components');
+
+        requireApi().setProps('root', { value: 'vue' });
+        await waitForText(value, 'Vue', `${runtime}/second-update-label`);
+        expect(value.dataset.displayValue, `${runtime}/second-update-fact`).toBe('Vue');
+      } finally {
+        await session.destroy();
+        host.remove();
+      }
+    }
+  );
+});

--- a/spec/contracts/C-HOST-VIEW-ATTACHMENT-0001.yaml
+++ b/spec/contracts/C-HOST-VIEW-ATTACHMENT-0001.yaml
@@ -39,6 +39,7 @@ sources:
   - path: packages/adapters/web-component/src/adapt.ts
   - path: packages/adapters/react/src/adapt.ts
   - path: packages/adapters/vue/src/adapt.ts
+verifies: { tests: [T-HOST-VIEW-ATTACHMENT-0001] }
 dependsOn:
   contracts:
     - C-HOST-SURFACE-PROJECTION-0001

--- a/spec/contracts/C-HOST-VIEW-ATTACHMENT-0001.yaml
+++ b/spec/contracts/C-HOST-VIEW-ATTACHMENT-0001.yaml
@@ -1,0 +1,54 @@
+id: C-HOST-VIEW-ATTACHMENT-0001
+type: contract
+title: A not-present view is detached rather than removed, and says so on the host
+status: draft
+since: 0.3.0-alpha.0
+summary: Adapters project a not-present view intent as a detached host that keeps its authored children, and mark that state with a single cross-adapter attribute so the condition is observable instead of inferred.
+statement:
+  zh-CN: >-
+    View intent 为 not-present 时，adapter 必须投射为 detached 而非移除：宿主元素与其 authored children 留在树上，并由共享的 `data-pui-view-detached` attribute 标记该状态。该 attribute 是跨 adapter 的 view-attachment 证据面，不引入新的语义域，也不改变 boundary 与 surface 的角色划分。Detached 子树不参与绘制、accessibility tree 与 tab 顺序，这一点由 attribute 对应的 `display: none` 投影达成，而不依赖每个 styled projection 自行处理。Authored children 的存在性与该实例 view 的生命周期解耦：children 照常初始化并向所属 collection 注册，因此依赖 collection 的信息通路在 view 从未 attach 过时也能解析。
+
+
+  en: >-
+    When a view intent is not present, an adapter must project it as detached rather than removed: the host element and its authored children stay in the tree, and the shared `data-pui-view-detached` attribute marks that state. The attribute is a cross-adapter view-attachment evidence surface; it introduces no new semantic domain and does not change the boundary and surface roles. A detached subtree takes no part in painting, the accessibility tree, or the tab order, achieved through the projection attached to that attribute rather than by each styled projection handling it. The existence of authored children is decoupled from that instance's view lifecycle: children initialize and register with their owning collection as usual, so collection-backed information channels resolve even when the view has never attached.
+
+
+criteria:
+  - id: C-HOST-VIEW-ATTACHMENT-0001-A
+    text:
+      zh-CN: 所有 adapter 必须使用同一个 `data-pui-view-detached` attribute 名，其常量由 adapter-base 单一提供；adapter 不得各自定义等价 attribute 或以私有属性表达同一状态。
+      en: Every adapter must use the same `data-pui-view-detached` attribute name from a single constant provided by adapter-base; an adapter must not define an equivalent attribute of its own or express the same state through a private property.
+  - id: C-HOST-VIEW-ATTACHMENT-0001-B
+    text:
+      zh-CN: 该 attribute 出现当且仅当该实例的 view intent 为 not-present；它不得被用来表达尚未就绪、隐藏、禁用或任何其它状态。
+      en: The attribute is present exactly when that instance's view intent is not present; it must not be reused to express not-yet-ready, hidden, disabled, or any other state.
+  - id: C-HOST-VIEW-ATTACHMENT-0001-C
+    text:
+      zh-CN: Detached 子树必须被排除在绘制、accessibility tree 与 tab 顺序之外，且该排除由 attribute 自身的投影达成；styled projection 不得为达成这一点各自补写规则。
+      en: A detached subtree must be excluded from painting, the accessibility tree, and the tab order, and that exclusion must come from the projection attached to the attribute itself rather than from rules each styled projection adds.
+  - id: C-HOST-VIEW-ATTACHMENT-0001-D
+    text:
+      zh-CN: Authored children 在 view not-present 时仍须挂载并完成各自的初始化与 collection 注册；adapter 不得以 view 未 attach 为由跳过它们。
+      en: Authored children must still mount and complete their own initialization and collection registration while the view is not present; an adapter must not skip them on the grounds that the view has not attached.
+  - id: C-HOST-VIEW-ATTACHMENT-0001-E
+    text:
+      zh-CN: View readiness 必须考虑祖先：位于 detached 子树内的实例不得报告自身 view 已就绪，即使它自己的 view 已 attach。
+      en: View readiness must account for ancestry, so an instance inside a detached subtree must not report its own view as ready even when its own view has attached.
+sources:
+  - path: packages/adapters/base/src/host/view-visibility.ts
+  - path: packages/adapters/web-component/src/adapt.ts
+  - path: packages/adapters/react/src/adapt.ts
+  - path: packages/adapters/vue/src/adapt.ts
+dependsOn:
+  contracts:
+    - C-HOST-SURFACE-PROJECTION-0001
+  knowledge:
+    - K-HOST-SURFACE-ROLES-0001
+revisions:
+  - version: 0.3.0-alpha.0
+    change: introduced
+    summary: >-
+      Promoted the detached-view marker to a cross-adapter contract. Web Components already kept a not-present host in the tree while React and Vue removed it, so collection-backed channels such as Select Value resolved differently by runtime on first paint.
+
+
+tags: [adapter, host-projection, view-intent, attachment, overlay]

--- a/spec/tests/T-HOST-VIEW-ATTACHMENT-0001.yaml
+++ b/spec/tests/T-HOST-VIEW-ATTACHMENT-0001.yaml
@@ -1,0 +1,134 @@
+id: T-HOST-VIEW-ATTACHMENT-0001
+type: test
+title: Host view attachment tests
+status: draft
+since: 0.3.0-alpha.0
+summary: Covers the single detached attribute name, its exactly-when-not-present meaning, the exclusion its own projection provides, authored children still mounting while detached, and readiness accounting for ancestry.
+cases:
+  - id: T-HOST-VIEW-ATTACHMENT-0001-CASE-ATTRIBUTE-IDENTITY
+    title: Every adapter marks a not-present view with the same attribute
+    covers:
+      - C-HOST-VIEW-ATTACHMENT-0001-A
+      - C-HOST-VIEW-ATTACHMENT-0001-B
+    expectation: one-detached-attribute-name-across-web-component-react-and-vue
+  - id: T-HOST-VIEW-ATTACHMENT-0001-CASE-INTENT-EXACTNESS
+    title: The attribute appears and disappears with view intent alone
+    covers:
+      - C-HOST-VIEW-ATTACHMENT-0001-B
+    expectation: detached-attribute-tracks-view-intent-in-both-directions
+  - id: T-HOST-VIEW-ATTACHMENT-0001-CASE-EXCLUSION-PROJECTION
+    title: The attribute's own projection takes the subtree out of paint
+    covers:
+      - C-HOST-VIEW-ATTACHMENT-0001-C
+    expectation: detached-subtree-is-excluded-without-a-styled-projection-rule
+  - id: T-HOST-VIEW-ATTACHMENT-0001-CASE-CHILDREN-MOUNT
+    title: Authored children mount and register while the view is not present
+    covers:
+      - C-HOST-VIEW-ATTACHMENT-0001-D
+    expectation: authored-children-initialize-and-register-inside-a-detached-view
+  - id: T-HOST-VIEW-ATTACHMENT-0001-CASE-READINESS-ANCESTRY
+    title: An instance inside a detached subtree does not report its view ready
+    covers:
+      - C-HOST-VIEW-ATTACHMENT-0001-E
+    expectation: view-readiness-accounts-for-a-detached-ancestor
+implementations:
+  - id: adapter-base-view-visibility
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/base/test/view-visibility.test.ts
+    required: true
+    consumesCases:
+      - T-HOST-VIEW-ATTACHMENT-0001-CASE-EXCLUSION-PROJECTION
+    exercises:
+      - C-HOST-VIEW-ATTACHMENT-0001
+    notes:
+      - Installs the shared rule and reads the computed display, so the exclusion is measured where the contract puts it rather than in a styled prototype.
+  - id: adapter-web-component-lifecycle-view-intent
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/lifecycle-view-intent.test.ts
+    required: true
+    consumesCases:
+      - T-HOST-VIEW-ATTACHMENT-0001-CASE-INTENT-EXACTNESS
+    exercises:
+      - C-HOST-VIEW-ATTACHMENT-0001
+    notes:
+      - Drives view intent in both directions, which is the half of criterion B that a closed-only observation cannot reach.
+  - id: adapter-vue-dialog-detached-mask
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue/test/dialog.test.ts
+    required: true
+    consumesCases:
+      - T-HOST-VIEW-ATTACHMENT-0001-CASE-ATTRIBUTE-IDENTITY
+    exercises:
+      - C-HOST-VIEW-ATTACHMENT-0001
+  - id: adapter-vue-previewer-dialog-readiness
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue/test/previewer-dialog.demo.test.ts
+    required: true
+    consumesCases:
+      - T-HOST-VIEW-ATTACHMENT-0001-CASE-READINESS-ANCESTRY
+    exercises:
+      - C-HOST-VIEW-ATTACHMENT-0001
+    notes:
+      - Readiness is resolved through the nearest detached ancestor, so an instance whose own view attached inside a closed overlay still reports not ready.
+  - id: web-adapters-shadcn-select-controlled-value
+    kind: adapter-test
+    status: passing
+    path: packages/web-conformance/test/shadcn-select-controlled-value.journey.test.ts
+    required: true
+    consumesCases:
+      - T-HOST-VIEW-ATTACHMENT-0001-CASE-CHILDREN-MOUNT
+    exercises:
+      - C-HOST-VIEW-ATTACHMENT-0001
+      - P-BASE-SELECT
+      - P-BASE-SELECT-VALUE
+    notes:
+      - A fixture rather than a documentation demo, because the published Select demo has no control that drives `value` from outside. It never opens the Content, so the authored labels it resolves can only come from children that mounted and registered while detached.
+      - Covers the controlled-update path in Web Components, React, and Vue. Verified red on the pre-fix sources, where the React and Vue labels stayed at the raw value `react` instead of the authored `React`.
+  - id: www-select-first-paint-browser
+    kind: runtime-test
+    status: passing
+    path: apps/www/src/content/docs/zh-cn/demo-select-first-paint.browser.test.ts
+    required: true
+    consumesCases:
+      - T-HOST-VIEW-ATTACHMENT-0001-CASE-ATTRIBUTE-IDENTITY
+      - T-HOST-VIEW-ATTACHMENT-0001-CASE-CHILDREN-MOUNT
+    exercises:
+      - C-HOST-VIEW-ATTACHMENT-0001
+      - P-BASE-SELECT-VALUE
+    notes:
+      - Reads a real browser in all three runtimes with the popup never opened, counting detached hosts, registered items, and mounted roots.
+verifies:
+  contracts:
+    - id: C-HOST-VIEW-ATTACHMENT-0001
+      anchors:
+        - C-HOST-VIEW-ATTACHMENT-0001-A
+        - C-HOST-VIEW-ATTACHMENT-0001-B
+        - C-HOST-VIEW-ATTACHMENT-0001-C
+        - C-HOST-VIEW-ATTACHMENT-0001-D
+        - C-HOST-VIEW-ATTACHMENT-0001-E
+exercises:
+  prototypes:
+    - P-BASE-SELECT
+    - P-BASE-SELECT-VALUE
+sources:
+  - path: packages/adapters/base/src/host/view-visibility.ts
+  - path: packages/adapters/base/test/view-visibility.test.ts
+  - path: packages/adapters/web-component/test/lifecycle-view-intent.test.ts
+  - path: packages/adapters/vue/test/dialog.test.ts
+  - path: packages/adapters/vue/test/previewer-dialog.demo.test.ts
+  - path: packages/web-conformance/test/shadcn-select-controlled-value.journey.test.ts
+  - path: apps/www/src/content/docs/zh-cn/demo-select-first-paint.browser.test.ts
+revisions:
+  - version: 0.3.0-alpha.0
+    change: introduced
+    summary: Added executable coverage for the detached view attribute, its meaning, its exclusion, child mounting, and ancestry-aware readiness.
+tags:
+  - test
+  - adapter
+  - host-projection
+  - view-intent
+  - overlay


### PR DESCRIPTION
## Summary

Closes #392.

A closed Select showed `paper` instead of `Paper` in React and Vue until the popup had been opened once. Two defects sit behind that, and fixing only the first leaves the label wrong.

## What was actually wrong

**The closed subtree never existed.** React and Vue unmounted a not-present view, so no Item ever registered with the Root's collection and `resolveTextValue` had nothing to resolve. Web Components looked correct for a reason unrelated to view lifecycle: its Items are separate custom elements in the light DOM, so they upgrade and register whether or not the Content's view is attached. That is the reading @cyjin-yl confirmed as the basis for this work, superseding the earlier presence-parity framing.

**The resolved label never reached the screen.** With the first defect fixed, `data-display-value` became `Paper` in all three runtimes while the rendered text stayed `paper`. `base-select-value` requests a re-render only when it is already mounted:

```ts
if (requestRender && mounted) run.update();
```

In Web Components the Value mounts before the context update carrying the resolved text arrives. In React and Vue the order is reversed, so the state updated with the render suppressed, and the later `onMounted` sync returned early because the state already matched. The suppressed render is now remembered and flushed on mount.

Measured on the documentation page, closed, never opened:

| | before | after |
| --- | --- | --- |
| wc | `Paper` / `data-display-value="Paper"` | unchanged |
| react | `paper` / `data-display-value="paper"` | **`Paper` / `Paper`** |
| vue | `paper` / `data-display-value="paper"` | **`Paper` / `Paper`** |

## `data-pui-view-detached` as a contract

Per your call, the constant moved into `@proto.ui/adapter-base`, all three adapters project it, and `spec/contracts/C-HOST-VIEW-ATTACHMENT-0001.yaml` is in this PR rather than a follow-up. It sits under `C-HOST-SURFACE-PROJECTION-0001` as you suggested, as view-attachment evidence rather than a new semantic domain. Five criteria: one attribute name from one constant; present exactly when the view intent is not present; the exclusion from paint, accessibility tree, and tab order comes from the attribute's own projection; authored children still mount and register; readiness accounts for ancestry.

No `inert`, as decided. `display: none` matching Web Components is what excludes the subtree.

## Two things the change surfaced

**Scoped to presence-bound overlays.** My first attempt applied the new semantics to every view intent, which broke Tabs: an inactive panel's text stayed in `textContent`. Tabs drives presence through `lifecycle.setPresent` while the overlay families use `bindPresence`, so the overlay port now reports whether presence was bound and only those instances mount detached.

**The Vue reopen path.** Keeping the host element alive meant the same element had to initialize twice. `onMounted` called `initSession()` unconditionally, which previously could not happen while closed because no element existed; now it claimed `lastInitRoot` during the detached mount, so the real open bailed out and bound against a disposed router. `onMounted` now defers to the presence watcher.

## Verification

New browser test, `demo-select-first-paint.browser.test.ts`, asserting the label across the three runtimes with the popup never opened. It fails on unfixed `main` where it should:

```
react/label:    expected 'paper' to be 'Paper'
react/detached: expected 0 to be greater than 0
```

It deliberately does not use the shared `selectRuntime`, whose readiness waits on an exact prototype-root count — one of the things this change alters, so reusing it turned both assertions into timeouts that said nothing about the label.

Presence regressions, dialog / dropdown / select across wc, react and vue, closed then open then Escape then reopen: detached while closed, zero detached and `data-transition-state=entered` while open, detached again after Escape, `entered` again on reopen. Identical in all nine combinations. The reopen column is the path the `onMounted` guard fixes.

`vitest run packages` — 1329 passed, 34 todo, 3 skipped. `check:prototype-catalog`, `check:styles:preset`, `check:styles:variant-order`, `check:release-version`, `check:package-manifests`, `check:types:workspace` — all OK.

## Not covered

Controlled updates without a prior open are in the acceptance list and are not asserted by an automated test here; the demo has no control to drive `value` from outside. I can add a demo affordance or a fixture-driven test if you want that cell filled rather than left open.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs.
- [x] Normative behavior changes include coherent P/C/T criteria, revisions, executable evidence, and affected projections.
- [x] This change does not create an empty catalog identity or silently widen a draft/active public guarantee.
