### PR TITLE
[codex] docs: add LINUX DO community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Roadmap direction is recorded under [`internal/records/**`](internal/records/); 
 
 Contributions to protocols, tests, Adapters, Prototype libraries, documentation, and consumer evidence are welcome.
 
+## Community
+
+Proto UI recognizes and supports the [LINUX DO](https://linux.do/) community.
+
 ## License
 
 MIT

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,6 +132,10 @@ Module、Host Capability 与 Adapter 的系统编目会根据真实消费证据�
 
 欢迎参与协议、测试、Adapter、Prototype library、文档和消费证据建设。
 
+## 社区
+
+Proto UI 认可并支持 [LINUX DO](https://linux.do/) 社区。
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- add a Community section to the English README recognizing and supporting the LINUX DO community
- add the equivalent community link to the Chinese README

## Impact

Makes the LINUX DO community relationship visible to both English- and Chinese-speaking readers.

## Validation

- `git diff --check`
- `corepack pnpm@10.32.1 check:agent-doc` (passed after regenerating the local Git-ignored Agent snapshot; local runtime: Node.js 20.19.4)