### PR TITLE
fix(style): reset composed shadow and transform properties per element

### DIFF
--- a/apps/www/src/content/docs/zh-cn/demo-composed-style-isolation.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-composed-style-isolation.browser.test.ts
@@ -1,0 +1,244 @@
+// @vitest-environment node
+
+import type { Browser, Locator, Page } from 'playwright-core';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  COLOR_SCHEMES,
+  RUNTIMES,
+  applyColorScheme,
+  launchBrowser,
+  openRoute,
+  selectRuntime,
+  startServer,
+  stopServer,
+} from './browser-harness';
+
+/** Brutalist puts a hard offset shadow on the thumb, which is what re-composed the ring. */
+const BRUTALIST_SWITCH_ROUTE = '/en/ui-libraries/brutalist/components/switch/';
+/** Shadcn scales the pressed root, which is what the thumb applied a second time. */
+const SHADCN_SWITCH_ROUTE = '/en/ui-libraries/shadcn/switch/';
+
+/** `data-[pressed]:scale-[0.98]` on the Shadcn Switch Root. */
+const PRESSED_SCALE = 0.98;
+
+let browser: Browser;
+let baseUrl = '';
+
+type ShadowLayer = {
+  value: string;
+  alpha: number;
+};
+
+type SwitchShadows = {
+  focusVisible: boolean;
+  root: ShadowLayer[];
+  thumb: ShadowLayer[];
+};
+
+/**
+ * Splits a computed `box-shadow` into its layers and resolves each layer's
+ * colour through a canvas, because the themes emit oklch and no string
+ * comparison can tell a painted layer from a transparent one.
+ */
+const READ_SWITCH_SHADOWS = () => {
+  const root = document.querySelector<HTMLElement>('[data-previewer-id] [role="switch"]');
+  if (!root) throw new Error('The Switch demo must render a Root.');
+  const thumb = root.querySelector<HTMLElement>('[data-pui-style]');
+  if (!thumb) throw new Error('The Switch demo must render a styled Thumb.');
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 1;
+  canvas.height = 1;
+  const context = canvas.getContext('2d', { willReadFrequently: true });
+  if (!context) throw new Error('Canvas 2D context is required to resolve painted colours.');
+
+  const layers = (element: HTMLElement) => {
+    const shadow = getComputedStyle(element).boxShadow;
+    if (shadow === 'none') return [];
+
+    const parts: string[] = [];
+    let depth = 0;
+    let current = '';
+    for (const char of shadow) {
+      if (char === '(') depth += 1;
+      if (char === ')') depth -= 1;
+      if (char === ',' && depth === 0) {
+        parts.push(current.trim());
+        current = '';
+        continue;
+      }
+      current += char;
+    }
+    parts.push(current.trim());
+
+    return parts.filter(Boolean).map((value) => {
+      const color = value.match(
+        /^(?:(?:rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color)\([^)]*\)|#[0-9a-f]+|[a-z]+)/i
+      );
+      context.clearRect(0, 0, 1, 1);
+      context.fillStyle = 'rgba(0,0,0,0)';
+      context.fillStyle = color ? color[0] : 'rgba(0,0,0,0)';
+      context.fillRect(0, 0, 1, 1);
+      return { value, alpha: context.getImageData(0, 0, 1, 1).data[3] / 255 };
+    });
+  };
+
+  return {
+    focusVisible: root.hasAttribute('data-focus-visible'),
+    root: layers(root),
+    thumb: layers(thumb),
+  };
+};
+
+async function switchShadows(page: Page): Promise<SwitchShadows> {
+  return page.evaluate(READ_SWITCH_SHADOWS);
+}
+
+/** Real keyboard focus, so the ring comes from the host's own focus-visible determination. */
+async function focusFirstSwitch(page: Page, previewer: Locator): Promise<void> {
+  await previewer.locator('select.adapter-select').focus();
+  await page.keyboard.press('Tab');
+  await page.waitForFunction(
+    () =>
+      document
+        .querySelector('[data-previewer-id] [role="switch"]')
+        ?.hasAttribute('data-focus-visible') === true,
+    undefined,
+    { timeout: 10_000 }
+  );
+}
+
+/** Horizontal scale factor of each element's own resolved transform. */
+async function switchScales(page: Page): Promise<{ root: number; thumb: number }> {
+  return page.evaluate(() => {
+    const root = document.querySelector<HTMLElement>('[data-previewer-id] [role="switch"]');
+    if (!root) throw new Error('The Switch demo must render a Root.');
+    const thumb = root.querySelector<HTMLElement>('[data-pui-style]');
+    if (!thumb) throw new Error('The Switch demo must render a styled Thumb.');
+
+    const scale = (element: HTMLElement) =>
+      new DOMMatrixReadOnly(getComputedStyle(element).transform).a;
+
+    return { root: scale(root), thumb: scale(thumb) };
+  });
+}
+
+/**
+ * Samples until two consecutive reads agree. The Root assertion that follows is
+ * what makes a premature settle fail loudly rather than pass on a frame where
+ * both elements are still at 1.
+ */
+async function settledScales(page: Page): Promise<{ root: number; thumb: number }> {
+  let last = await switchScales(page);
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    await page.waitForTimeout(20);
+    const next = await switchScales(page);
+    if (next.root === last.root && next.thumb === last.thumb) return next;
+    last = next;
+  }
+  throw new Error('The Switch transform never settled.');
+}
+
+function paintedLayers(layers: ShadowLayer[]): ShadowLayer[] {
+  return layers.filter((layer) => layer.alpha > 0);
+}
+
+beforeAll(async () => {
+  baseUrl = await startServer(BRUTALIST_SWITCH_ROUTE);
+  browser = await launchBrowser();
+}, 150_000);
+
+afterAll(async () => {
+  await browser?.close();
+  await stopServer();
+}, 60_000);
+
+describe.sequential('composed style isolation browser regressions', () => {
+  it('paints the focus ring on the focused Switch and not on its thumb', async () => {
+    const { context, page, previewer } = await openRoute(browser, baseUrl, BRUTALIST_SWITCH_ROUTE, {
+      width: 1440,
+      height: 900,
+    });
+
+    try {
+      await previewer.scrollIntoViewIfNeeded();
+      for (const runtime of RUNTIMES) {
+        await selectRuntime(page, previewer, runtime, '[role="switch"]', 3);
+        for (const scheme of COLOR_SCHEMES) {
+          await applyColorScheme(page, scheme);
+          await focusFirstSwitch(page, previewer);
+
+          const shadows = await switchShadows(page);
+          const label = `${runtime}/${scheme}`;
+          expect(shadows.focusVisible, `${label}/focus-visible`).toBe(true);
+
+          // The focused element keeps its ring: the offset layer, the ring
+          // itself, and the Brutalist hard shadow.
+          expect(paintedLayers(shadows.root), `${label}/root-layers`).toHaveLength(3);
+
+          // The Thumb declares one shadow token and no ring, so one painted
+          // layer is all it may have. Anything more is an inherited ring.
+          expect(paintedLayers(shadows.thumb), `${label}/thumb-layers`).toHaveLength(1);
+          expect(paintedLayers(shadows.thumb)[0].value, `${label}/thumb-own-shadow`).toBe(
+            paintedLayers(shadows.root)[2].value
+          );
+        }
+      }
+    } finally {
+      await context.close();
+    }
+  }, 240_000);
+
+  it('scales the pressed Switch once, not again on its thumb', async () => {
+    const { context, page, previewer } = await openRoute(browser, baseUrl, SHADCN_SWITCH_ROUTE, {
+      width: 1440,
+      height: 900,
+    });
+
+    try {
+      await previewer.scrollIntoViewIfNeeded();
+      for (const runtime of RUNTIMES) {
+        await selectRuntime(page, previewer, runtime, '[role="switch"]', 3);
+        await applyColorScheme(page, 'light');
+
+        const resting = await switchScales(page);
+        expect(resting.root, `${runtime}/resting-root`).toBeCloseTo(1, 3);
+        expect(resting.thumb, `${runtime}/resting-thumb`).toBeCloseTo(1, 3);
+
+        const box = await previewer.getByRole('switch').first().boundingBox();
+        if (!box) throw new Error('The Switch Root must be laid out.');
+
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await page.mouse.down();
+
+        try {
+          // The Root transitions into the pressed scale over 200ms. Sampling on
+          // the attribute alone catches both elements still at 1, where the
+          // comparison below would hold for either behaviour, so wait until the
+          // transition has actually moved the Root before settling on it.
+          await page.waitForFunction(
+            () => {
+              const root = document.querySelector<HTMLElement>(
+                '[data-previewer-id] [role="switch"]'
+              );
+              if (!root?.hasAttribute('data-pressed')) return false;
+              return new DOMMatrixReadOnly(getComputedStyle(root).transform).a < 0.999;
+            },
+            undefined,
+            { timeout: 10_000 }
+          );
+
+          const pressed = await settledScales(page);
+          expect(pressed.root, `${runtime}/pressed-root`).toBeCloseTo(PRESSED_SCALE, 3);
+          // The Root transform already scales its subtree, so a Thumb that also
+          // scales lands the same factor twice.
+          expect(pressed.thumb, `${runtime}/pressed-thumb`).toBeCloseTo(1, 3);
+        } finally {
+          await page.mouse.up();
+        }
+      }
+    } finally {
+      await context.close();
+    }
+  }, 240_000);
+});

--- a/packages/cli/src/services/proto-style-css.ts
+++ b/packages/cli/src/services/proto-style-css.ts
@@ -282,6 +282,7 @@ export function renderProtoStyleTokenCss(tokens: string[]): string {
     '}',
     '',
     '@layer proto-ui {',
+    ...composedPropertyReset(),
   ];
 
   if (
@@ -643,6 +644,45 @@ function ringShadow(): string[] {
     '--pui-ring-offset-shadow: 0 0 0 var(--pui-ring-offset-width, 0px) var(--pui-ring-offset-color, var(--pui-background));',
     '--pui-ring-shadow: var(--pui-ring-inset,) 0 0 0 calc(var(--pui-ring-width, 0px) + var(--pui-ring-offset-width, 0px)) var(--pui-ring-color, var(--pui-ring));',
     ...composedShadow(),
+  ];
+}
+
+/**
+ * `composedShadow` and `transformValue` read custom properties through a
+ * `var(name, fallback)` fallback, and the fallback only applies while the
+ * property is unset. Custom properties inherit, so once an ancestor sets one,
+ * every styled descendant that composes the same shorthand paints the
+ * ancestor's value again at its own size: a focus ring repeats on any
+ * descendant carrying a shadow token, and a pressed scale is applied a second
+ * time by a descendant carrying a translate token.
+ *
+ * Resetting each one to `initial` restores the guaranteed-invalid value, so the
+ * fallback declared next to each `var()` fires again and stays the single place
+ * that value is written. The selector is `:where()` so the reset never outranks
+ * a token rule, and it is first in the layer so any equally weighted token rule
+ * still wins on order.
+ */
+function composedPropertyReset(): string[] {
+  const properties = [
+    'ring-offset-shadow',
+    'ring-shadow',
+    'shadow',
+    'ring-inset',
+    'ring-width',
+    'ring-offset-width',
+    'ring-color',
+    'ring-offset-color',
+    'translate-x',
+    'translate-y',
+    'scale-x',
+    'scale-y',
+  ];
+
+  return [
+    `  :where([${PUI_STYLE_ATTR}]) {`,
+    ...properties.map((property) => `    --pui-${property}: initial;`),
+    '  }',
+    '',
   ];
 }
 

--- a/packages/cli/test/proto-style-css.test.ts
+++ b/packages/cli/test/proto-style-css.test.ts
@@ -87,6 +87,34 @@ describe('proto style css renderer', () => {
     expect(css).not.toContain('Unsupported Proto UI style tokens');
   });
 
+  it('resets composed custom properties inside the layer, below every token rule', () => {
+    const css = renderProtoStyleTokenCss(['ring-2', 'shadow-[3px_3px_0_0_#000]', 'translate-x-0']);
+
+    const layerAt = css.indexOf('@layer proto-ui {');
+    const resetAt = css.indexOf(':where([data-pui-style]) {');
+    const firstTokenAt = css.indexOf(':where([data-pui-style~=');
+
+    // Inside the layer, because the unlayered baseline would outrank every
+    // token rule and no ring could paint at all.
+    expect(layerAt).toBeGreaterThanOrEqual(0);
+    expect(resetAt).toBeGreaterThan(layerAt);
+    // First in the layer, because a token rule is `:where()` too and only
+    // source order puts it on top.
+    expect(resetAt).toBeLessThan(firstTokenAt);
+
+    // `initial` restores the guaranteed-invalid value, so the fallback declared
+    // next to each `var()` stays the one place the default is written.
+    for (const property of [
+      '--pui-ring-offset-shadow',
+      '--pui-ring-shadow',
+      '--pui-shadow',
+      '--pui-translate-x',
+      '--pui-scale-x',
+    ]) {
+      expect(css.slice(resetAt, firstTokenAt)).toContain(`${property}: initial;`);
+    }
+  });
+
   it('renders directional separator borders in the theme foreground', () => {
     const css = renderProtoStyleTokenCss(['border-b-2', 'border-t-2', 'border-foreground']);
 

--- a/scripts/test/run-runtime-tests.mjs
+++ b/scripts/test/run-runtime-tests.mjs
@@ -22,6 +22,7 @@ const READY_ROUTES = [
   '/en/ui-libraries/brutalist/components/tabs/',
   '/en/ui-libraries/shadcn/checkbox/',
   '/en/ui-libraries/shadcn/dropdown-menu/',
+  '/en/ui-libraries/shadcn/switch/',
   '/en/ui-libraries/shadcn/textarea/',
 ];
 const READY_TIMEOUT_MS = 180_000;

--- a/scripts/test/run-runtime-tests.test.mjs
+++ b/scripts/test/run-runtime-tests.test.mjs
@@ -24,7 +24,8 @@ describe('runtime test plan', () => {
       },
       {
         needsServer: true,
-        args: BROWSER_SUITES,
+        // Sequential, because every suite drives the same dev server.
+        args: ['--no-file-parallelism', ...BROWSER_SUITES],
       },
     ]);
   });

--- a/scripts/test/runtime-test-plan.mjs
+++ b/scripts/test/runtime-test-plan.mjs
@@ -1,6 +1,7 @@
 export const BROWSER_SUITES = Object.freeze([
   'apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts',
   'apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts',
+  'apps/www/src/content/docs/zh-cn/demo-composed-style-isolation.browser.test.ts',
   'apps/www/src/content/docs/zh-cn/demo-ring-offset-default.browser.test.ts',
   'apps/www/src/content/docs/zh-cn/demo-shadcn-controls.browser.test.ts',
 ]);
@@ -16,7 +17,11 @@ export function createRuntimeTestPlan(rawArgs) {
     },
     {
       needsServer: true,
-      args: BROWSER_SUITES,
+      // One dev server compiles for every suite, so running the files in
+      // parallel makes them queue behind each other and blow their own
+      // readiness timeouts. Measured on five suites: 75s sequential against
+      // 102s parallel, with the parallel run intermittently timing out.
+      args: ['--no-file-parallelism', ...BROWSER_SUITES],
     },
   ];
 }


### PR DESCRIPTION
Closes #455.

## What leaked

`composedShadow` and `transformValue` read custom properties through `var(name, fallback)`, and the fallback only applies while the property is unset. Custom properties inherit, so once an ancestor sets one, every styled descendant that composes the same shorthand paints the ancestor's value again at its own size.

Measured on clean `main`, all three runtimes, keyboard focus on the Brutalist Switch:

```
root : rgb(245,245,245) 0 0 0 2px, rgb(23,23,23) 0 0 0 4px, rgb(0,0,0) 3px 3px 0 0
thumb: rgb(245,245,245) 0 0 0 2px, rgb(23,23,23) 0 0 0 4px, rgb(0,0,0) 3px 3px 0 0
```

After the fix the thumb paints its own hard shadow and nothing else, and the root is untouched:

```
thumb: rgba(0,0,0,0) 0 0 0 0, rgba(0,0,0,0) 0 0 0 0, rgb(0,0,0) 3px 3px 0 0
```

## A second leak, same mechanism, measured

`transformValue` composes `--pui-translate-*` and `--pui-scale-*` the same way. On the Shadcn Switch, pressing the Root applies `scale-[0.98]`, and because the Root transform already scales its subtree, the Thumb applied the same factor a second time:

| | before | after |
| --- | --- | --- |
| root while pressed | `matrix(0.98, 0, 0, 0.98, 0, 0)` | unchanged |
| thumb while pressed | `matrix(0.98, 0, 0, 0.98, 0, 0)` | `matrix(1, 0, 0, 1, 0, 0)` |

The reset covers both families. I included the transform half because it is the same defect through the same helper and is fixed by the same rule — happy to split it if you would rather keep the slice to the ring.

## The fix

One `:where([data-pui-style])` rule, first inside `@layer proto-ui`, setting each composed property to `initial`.

- **Inside the layer**, because the existing box-model baseline is unlayered and unlayered styles outrank layered ones — a reset there would beat every token rule and no ring could paint at all.
- **`:where()`**, because a plain token rule is `:where(...)` too, at specificity 0. A reset with any weight would outrank it.
- **First**, so an equally weighted token rule still wins on source order.
- **`initial`** rather than literal defaults, because it restores the guaranteed-invalid value and lets the fallback already written next to each `var()` fire. Spelling the defaults a second time would be two places to keep in sync, and `--pui-ring-color` / `--pui-ring-offset-color` resolve through theme-derived fallbacks that #463 deliberately put there.

No document-wide `*` reset, per `D-WEB-STYLE-BASELINE-0001-B`.

## Evidence

New `demo-composed-style-isolation.browser.test.ts`, following the shape #463 used for the ring-offset fix. Both cases verified red before and green after:

- `wc/light/thumb-layers: expected [...] to have a length of 1 but got 3`
- `wc/pressed-thumb: expected 0.98 to be close to 1`

It resolves each shadow layer's colour through a canvas and counts painted layers, so it asserts what is drawn rather than a token string. Both cases run in Web Components, React and Vue; the ring case runs in Light and Dark.

Plus a unit test pinning the reset's placement and weight, `vitest run packages` at 1332 passed / 34 todo / 3 skipped, and every governance check green.

## Two things to flag

**Acceptance criterion 2 is wrong and I did not implement it.** I wrote "the root's hard offset shadow remains visible while focused" when filing. It cannot hold without reordering `composedShadow`, and it should not: the ring's 4px spread covers the border box in every direction, the 3px offset shadow sits inside that, and the ring is composed first so it paints on top. That order is Tailwind's, and reversing it would put every element's own shadow above its own focus ring — worse contrast on the indicator, everywhere. I suggest dropping that criterion rather than moving it; say the word if you want it as a separate design question instead.

**Criterion 3's anchors are covered by proxy, not by name.** Brutalist Button, Tabs Trigger, Toggle, Textarea and Switch all project the same `BRUTALIST_FOCUS_TOKENS` constant, so the Switch Root assertion — three painted layers, ring intact, both schemes, three runtimes — exercises the identical token set. #463's suite anchors the Shadcn side. I did not add Button and Tabs Trigger routes of their own; tell me if you want them named explicitly.

## One change outside the fix

The browser phase now runs with `--no-file-parallelism`. Adding a fifth suite made the parallel run intermittently blow `selectRuntime`'s 20s readiness timeout, because every suite drives the one shared dev server from #457 and they queue behind each other. Sequential is also faster: **75s against 102s** on five suites, with the parallel run failing three tests on the first attempt and passing on the second. Easy to drop if you would rather I fold the two cases into the existing suites instead.

Unrelated local note: `demo-brutalist-controls.browser.test.ts` times out its 10s `afterAll` under the shared-server run on my machine, sequential or parallel. It does the same on a clean `origin/main` checkout with four suites, and its `stopServer` is a no-op in that mode, so it is `browser.close()` on this hardware rather than anything from this branch. Left untouched.
