### PR TITLE
feat(base): give Scroll Area Viewport keyboard focus facts

### DIFF
--- a/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
@@ -19,6 +19,12 @@ const COLOR_SCHEMES = ['light', 'dark'] as const;
 type ColorScheme = (typeof COLOR_SCHEMES)[number];
 
 const TEXTAREA_ROUTE = '/en/ui-libraries/base/textarea/';
+const SCROLL_AREA_ROUTE = '/en/ui-libraries/base/scroll-area/';
+
+/** The demo order: one surface that overflows, one that fits its content. */
+const SCROLLING = 0;
+const FITTING = 1;
+const VIEWPORT_SELECTOR = '[data-pui-scroll-projection]';
 const TEXTAREA_DEMO_SCOPE = '[data-demo-id="demo-base-textarea"]';
 const TEXTAREA_OUTPUT_SURFACES = ['stateLabel', 'eventLog', 'help'] as const;
 const MIN_TEXT_CONTRAST = 4.5;
@@ -293,6 +299,82 @@ async function demoTextContrast(
   );
 }
 
+type ViewportFacts = {
+  tabIndexAttribute: string | null;
+  role: string | null;
+  focused: boolean;
+  focusVisible: boolean;
+  canScroll: boolean;
+  scrollTop: number;
+  focusableInRoot: number;
+};
+
+/** Reads both Viewports the way a keyboard user meets them. */
+async function viewportFacts(page: Page): Promise<ViewportFacts[]> {
+  return page.evaluate((selector) => {
+    const viewports = [
+      ...document.querySelectorAll<HTMLElement>(`[data-previewer-id] ${selector}`),
+    ];
+    return viewports.map((viewport) => {
+      const root = viewport.closest<HTMLElement>(
+        '[data-pui-root]:not([data-pui-scroll-projection])'
+      );
+      return {
+        tabIndexAttribute: viewport.getAttribute('tabindex'),
+        role: viewport.getAttribute('role'),
+        focused: viewport.hasAttribute('data-focused'),
+        focusVisible: viewport.hasAttribute('data-focus-visible'),
+        canScroll:
+          viewport.hasAttribute('data-scroll-vertical-can-scroll-after') ||
+          viewport.hasAttribute('data-scroll-vertical-can-scroll-before'),
+        scrollTop: viewport.scrollTop,
+        focusableInRoot: [...(root ?? viewport).querySelectorAll<HTMLElement>('*')].filter(
+          (node) => node.tabIndex >= 0
+        ).length,
+      };
+    });
+  }, VIEWPORT_SELECTOR);
+}
+
+/** Adds or removes content so the fitting surface crosses the overflow boundary. */
+async function setFittingContent(page: Page, rows: number): Promise<void> {
+  await page.evaluate(
+    ({ selector, rows: count }) => {
+      const viewport = document.querySelectorAll<HTMLElement>(`[data-previewer-id] ${selector}`)[1];
+      if (!viewport) throw new Error('The Base Scroll Area demo must render two Viewports.');
+      const list = viewport.firstElementChild;
+      if (!list) throw new Error('The fitting Viewport must render its content list.');
+      list.querySelectorAll('[data-test-row]').forEach((row) => row.remove());
+      for (let index = 0; index < count; index += 1) {
+        const row = document.createElement('div');
+        row.setAttribute('data-test-row', '');
+        row.textContent = `Added row ${index + 1}`;
+        list.append(row);
+      }
+    },
+    { selector: VIEWPORT_SELECTOR, rows }
+  );
+}
+
+/**
+ * Waits on the scroll fact rather than on the tab stop. The fact is published
+ * with or without the focus slice, so a missing tab stop fails on the assertion
+ * that names it instead of on a readiness timeout that does not.
+ */
+async function waitForCanScroll(page: Page, index: number, expected: boolean): Promise<void> {
+  await page.waitForFunction(
+    ({ selector, index: at, expected: want }) => {
+      const viewport = document.querySelectorAll<HTMLElement>(`[data-previewer-id] ${selector}`)[
+        at
+      ];
+      if (!viewport) return false;
+      return viewport.hasAttribute('data-scroll-vertical-can-scroll-after') === want;
+    },
+    { selector: VIEWPORT_SELECTOR, index, expected },
+    { timeout: 10_000 }
+  );
+}
+
 beforeAll(async () => {
   baseUrl = await startServer();
   browser = await chromium.launch({
@@ -369,4 +451,149 @@ describe.sequential('Base control documentation browser regressions', () => {
       await context.close();
     }
   }, 180_000);
+  it('gives a tab stop only to the Viewport that can scroll, in all runtimes', async () => {
+    const { context, page, previewer } = await openRoute(SCROLL_AREA_ROUTE, {
+      width: 1440,
+      height: 900,
+    });
+
+    try {
+      await previewer.scrollIntoViewIfNeeded();
+      for (const runtime of RUNTIMES) {
+        await selectRuntime(page, previewer, runtime, VIEWPORT_SELECTOR, 2);
+        await waitForCanScroll(page, SCROLLING, true);
+
+        const facts = await viewportFacts(page);
+        expect(facts, `${runtime}/count`).toHaveLength(2);
+        expect(facts[SCROLLING].canScroll, `${runtime}/scrolling-can-scroll`).toBe(true);
+        expect(facts[FITTING].canScroll, `${runtime}/fitting-can-scroll`).toBe(false);
+
+        // A surface with nowhere to scroll would be an empty tab stop.
+        expect(facts[SCROLLING].tabIndexAttribute, `${runtime}/scrolling-tabindex`).toBe('0');
+        expect(facts[FITTING].tabIndexAttribute, `${runtime}/fitting-tabindex`).toBe('-1');
+
+        for (const [index, viewport] of facts.entries()) {
+          // Taking focus is not a reason to invent a widget role.
+          expect(viewport.role, `${runtime}/role-${index}`).toBeNull();
+        }
+        // One tab stop per scrolling Scroll Area, and it is the Viewport. A
+        // second focusable node inside the same Root would be a duplicate stop.
+        expect(facts[SCROLLING].focusableInRoot, `${runtime}/scrolling-stops`).toBe(1);
+        expect(facts[FITTING].focusableInRoot, `${runtime}/fitting-stops`).toBe(0);
+      }
+    } finally {
+      await context.close();
+    }
+  }, 240_000);
+
+  it('follows content between scrollable and not, in all runtimes', async () => {
+    const { context, page, previewer } = await openRoute(SCROLL_AREA_ROUTE, {
+      width: 1440,
+      height: 900,
+    });
+
+    try {
+      await previewer.scrollIntoViewIfNeeded();
+      for (const runtime of RUNTIMES) {
+        await selectRuntime(page, previewer, runtime, VIEWPORT_SELECTOR, 2);
+        await waitForCanScroll(page, FITTING, false);
+        expect(
+          (await viewportFacts(page))[FITTING].tabIndexAttribute,
+          `${runtime}/fitting-before`
+        ).toBe('-1');
+
+        await setFittingContent(page, 12);
+        await waitForCanScroll(page, FITTING, true);
+        expect((await viewportFacts(page))[FITTING].tabIndexAttribute, `${runtime}/grown`).toBe(
+          '0'
+        );
+
+        await setFittingContent(page, 0);
+        await waitForCanScroll(page, FITTING, false);
+        expect((await viewportFacts(page))[FITTING].tabIndexAttribute, `${runtime}/shrunk`).toBe(
+          '-1'
+        );
+      }
+    } finally {
+      await context.close();
+    }
+  }, 240_000);
+
+  it('separates keyboard entry from pointer entry on the Viewport, in all runtimes', async () => {
+    const { context, page, previewer } = await openRoute(SCROLL_AREA_ROUTE, {
+      width: 1440,
+      height: 900,
+    });
+
+    try {
+      await previewer.scrollIntoViewIfNeeded();
+      for (const runtime of RUNTIMES) {
+        await selectRuntime(page, previewer, runtime, VIEWPORT_SELECTOR, 2);
+        await waitForCanScroll(page, SCROLLING, true);
+
+        await previewer.locator('select.adapter-select').focus();
+        await page.keyboard.press('Tab');
+        await page.waitForTimeout(200);
+
+        const keyboard = (await viewportFacts(page))[SCROLLING];
+        expect(keyboard.focused, `${runtime}/keyboard-focused`).toBe(true);
+        expect(keyboard.focusVisible, `${runtime}/keyboard-focus-visible`).toBe(true);
+
+        await page.mouse.click(5, 5);
+        await previewer
+          .locator(VIEWPORT_SELECTOR)
+          .first()
+          .click({ position: { x: 8, y: 8 } });
+        await page.waitForTimeout(100);
+
+        const pointer = (await viewportFacts(page))[SCROLLING];
+        expect(pointer.focused, `${runtime}/pointer-focused`).toBe(true);
+        expect(pointer.focusVisible, `${runtime}/pointer-focus-visible`).toBe(false);
+      }
+    } finally {
+      await context.close();
+    }
+  }, 240_000);
+
+  it('keeps keyboard and wheel scrolling on the Viewport, in all runtimes', async () => {
+    const { context, page, previewer } = await openRoute(SCROLL_AREA_ROUTE, {
+      width: 1440,
+      height: 900,
+    });
+
+    try {
+      await previewer.scrollIntoViewIfNeeded();
+      for (const runtime of RUNTIMES) {
+        await selectRuntime(page, previewer, runtime, VIEWPORT_SELECTOR, 2);
+        await waitForCanScroll(page, SCROLLING, true);
+
+        const viewport = previewer.locator(VIEWPORT_SELECTOR).first();
+        await previewer.locator('select.adapter-select').focus();
+        await page.keyboard.press('Tab');
+        await page.waitForTimeout(100);
+
+        for (const key of ['ArrowDown', 'PageDown', 'End']) {
+          const before = (await viewportFacts(page))[SCROLLING].scrollTop;
+          await page.keyboard.press(key);
+          await page.waitForTimeout(200);
+          const after = (await viewportFacts(page))[SCROLLING].scrollTop;
+          expect(after, `${runtime}/${key}`).toBeGreaterThan(before);
+        }
+
+        await page.keyboard.press('Home');
+        await page.waitForTimeout(200);
+        expect((await viewportFacts(page))[SCROLLING].scrollTop, `${runtime}/Home`).toBe(0);
+
+        await viewport.hover();
+        await page.mouse.wheel(0, 120);
+        await page.waitForTimeout(200);
+        expect(
+          (await viewportFacts(page))[SCROLLING].scrollTop,
+          `${runtime}/wheel`
+        ).toBeGreaterThan(0);
+      }
+    } finally {
+      await context.close();
+    }
+  }, 240_000);
 });

--- a/apps/www/src/content/docs/zh-cn/demo-base-scroll-area.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-scroll-area.demo.ts
@@ -1,48 +1,149 @@
 export default {
   type: 'demo',
   root: {
-    kind: 'proto',
-    prototypeId: 'base-scroll-area-root',
-    className: 'relative h-48 w-full max-w-80 overflow-hidden rounded border',
+    kind: 'box',
+    className: 'flex w-full max-w-80 flex-col gap-4',
     children: [
       {
         kind: 'proto',
-        prototypeId: 'base-scroll-area-viewport',
-        className: 'h-full w-full overflow-auto',
+        prototypeId: 'base-scroll-area-root',
+        className: 'relative h-48 w-full overflow-hidden rounded border',
         children: [
           {
-            kind: 'box',
-            className: 'flex flex-col gap-2 p-3',
+            kind: 'proto',
+            prototypeId: 'base-scroll-area-viewport',
+            className: 'h-full w-full overflow-auto',
             children: [
-              'Host-projected scrolling surface',
-              'Row 2',
-              'Row 3',
-              'Row 4',
-              'Row 5',
-              'Row 6',
-              'Row 7',
-              'Row 8',
-              'Row 9',
-              'Row 10',
-              'Row 11',
-              'Row 12',
-              'Row 13',
-              'Row 14',
-              'Row 15',
+              {
+                kind: 'box',
+                className: 'flex flex-col gap-2 p-3 text-sm',
+                children: [
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Host-projected scrolling surface'],
+                  },
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Row 2'],
+                  },
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Row 3'],
+                  },
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Row 4'],
+                  },
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Row 5'],
+                  },
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Row 6'],
+                  },
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Row 7'],
+                  },
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Row 8'],
+                  },
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Row 9'],
+                  },
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Row 10'],
+                  },
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Row 11'],
+                  },
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Row 12'],
+                  },
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Row 13'],
+                  },
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Row 14'],
+                  },
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Row 15'],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            kind: 'proto',
+            prototypeId: 'base-scroll-area-scrollbar',
+            props: { orientation: 'vertical' },
+            className: 'absolute inset-y-0 right-0 w-2 bg-gray-100',
+            children: [
+              {
+                kind: 'proto',
+                prototypeId: 'base-scroll-area-thumb',
+                className: 'block min-h-8 w-full rounded bg-gray-500',
+              },
             ],
           },
         ],
       },
       {
+        kind: 'box',
+        className: 'text-xs text-muted-foreground',
+        children: ['The surface below fits its content, so it has nothing to scroll.'],
+      },
+      {
         kind: 'proto',
-        prototypeId: 'base-scroll-area-scrollbar',
-        props: { orientation: 'vertical' },
-        className: 'absolute inset-y-0 right-0 w-2 bg-gray-100',
+        prototypeId: 'base-scroll-area-root',
+        className: 'relative h-24 w-full overflow-hidden rounded border',
         children: [
           {
             kind: 'proto',
-            prototypeId: 'base-scroll-area-thumb',
-            className: 'block min-h-8 w-full rounded bg-gray-500',
+            prototypeId: 'base-scroll-area-viewport',
+            className: 'h-full w-full overflow-auto',
+            children: [
+              {
+                kind: 'box',
+                className: 'flex flex-col gap-2 p-3 text-sm',
+                children: [
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Fits its viewport'],
+                  },
+                  {
+                    kind: 'box',
+                    className: 'rounded bg-gray-50 px-2 py-1',
+                    children: ['Second row'],
+                  },
+                ],
+              },
+            ],
           },
         ],
       },

--- a/packages/prototypes/base/src/scroll-area/types.ts
+++ b/packages/prototypes/base/src/scroll-area/types.ts
@@ -26,9 +26,15 @@ export type ScrollAreaViewportExposes = {
   canScrollDown: ExposeState<boolean>;
 };
 
-export type ScrollAreaViewportStateHandles = {};
+export type ScrollAreaViewportStateHandles = {
+  focused: State<boolean>;
+  focusVisible: State<boolean>;
+};
 
-export type ScrollAreaViewportAsHookContract = {};
+/** Styled projections read the focus facts of the surface; they install none. */
+export type ScrollAreaViewportAsHookContract = {
+  state: ScrollAreaViewportStateHandles;
+};
 
 export interface ScrollAreaScrollbarProps {
   orientation?: 'horizontal' | 'vertical';

--- a/packages/prototypes/base/src/scroll-area/types.ts
+++ b/packages/prototypes/base/src/scroll-area/types.ts
@@ -11,6 +11,8 @@ export type ScrollAreaRootAsHookContract = {};
 export interface ScrollAreaViewportProps {}
 
 export type ScrollAreaViewportExposes = {
+  focused: ExposeState<boolean>;
+  focusVisible: ExposeState<boolean>;
   scrollAxes: ExposeState<string>;
   scrolling: ExposeState<boolean>;
   scrollProjection: ExposeState<string>;

--- a/packages/prototypes/base/src/scroll-area/viewport.proto.ts
+++ b/packages/prototypes/base/src/scroll-area/viewport.proto.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
-import { asScrollSurface } from '@proto.ui/hooks';
+import { asFocusable, asScrollSurface } from '@proto.ui/hooks';
 import { SCROLL_AREA_CONTEXT, SCROLL_AREA_FAMILY } from './shared';
 import type {
   ScrollAreaViewportAsHookContract,
@@ -22,6 +22,39 @@ function setupScrollAreaViewport(
     orientationExpose: 'orientation',
   });
 
+  // P-BASE-SCROLL-AREA-VIEWPORT-KEYBOARD-FOCUS
+  const focusable = asFocusable<ScrollAreaViewportProps>();
+  // Sequential navigation starts off. Geometry has not arrived yet, and a
+  // surface with nothing to scroll is an empty tab stop.
+  focusable.configure({ disabled: false, navParticipation: 'none' });
+
+  const scrollableDirections = [
+    scroll.horizontal.canScrollBefore,
+    scroll.horizontal.canScrollAfter,
+    scroll.vertical.canScrollBefore,
+    scroll.vertical.canScrollAfter,
+  ];
+
+  // P-BASE-SCROLL-AREA-VIEWPORT-NAV-PARTICIPATION
+  let navParticipation: 'auto' | 'none' = 'none';
+  const syncNavParticipation = () => {
+    const next = scrollableDirections.some((direction) => direction.get()) ? 'auto' : 'none';
+    if (next === navParticipation) return;
+    navParticipation = next;
+    // Only sequential navigation changes here. Losing the last scrollable
+    // direction must not take focus away from whoever currently holds it.
+    focusable.setNavParticipation(next);
+  };
+
+  for (const direction of scrollableDirections) {
+    direction.watch((_run, event) => {
+      if (event.type !== 'next') return;
+      syncNavParticipation();
+    });
+  }
+
+  def.expose.state('focused', focusable.focused);
+  def.expose.state('focusVisible', focusable.focusVisible);
   def.expose.state('scrollAxes', scroll.axes);
   def.expose.state('scrolling', scroll.scrolling);
   def.expose.state('scrollProjection', scroll.projection);

--- a/packages/prototypes/base/test/scroll-area.test.ts
+++ b/packages/prototypes/base/test/scroll-area.test.ts
@@ -37,6 +37,30 @@ async function flush(): Promise<void> {
   await Promise.resolve();
 }
 
+/** Republishes host geometry the way a content or layout change does. */
+function remeasure(viewport: HTMLElement): void {
+  viewport.dispatchEvent(new Event('scroll'));
+  window.dispatchEvent(new Event('resize'));
+}
+
+async function mountViewport(metrics: {
+  clientWidth: number;
+  scrollWidth: number;
+  clientHeight: number;
+  scrollHeight: number;
+}): Promise<{ root: any; viewport: any }> {
+  const root = document.createElement('base-scroll-area-root') as any;
+  const viewport = document.createElement('base-scroll-area-viewport') as any;
+  setMetrics(viewport, metrics);
+  root.append(viewport);
+  document.body.append(root);
+  await flush();
+  return { root, viewport };
+}
+
+const OVERFLOWING = { clientWidth: 200, scrollWidth: 500, clientHeight: 100, scrollHeight: 400 };
+const FITTING = { clientWidth: 200, scrollWidth: 200, clientHeight: 100, scrollHeight: 100 };
+
 afterEach(async () => {
   document.body.replaceChildren();
   await flush();
@@ -92,5 +116,86 @@ describe('prototypes/base: scroll-area', () => {
     expect(thumb.getExposes()).toEqual({});
     expect(thumb.tabIndex).toBe(-1);
     expect(thumb.getAttribute('role')).toBeNull();
+  });
+  it('gives a scrolling Viewport keyboard focus facts without a widget role', async () => {
+    // T-BASE-SCROLL-AREA-0001-CASE-VIEWPORT-FOCUS
+    const { viewport } = await mountViewport(OVERFLOWING);
+
+    const exposes = viewport.getExposes();
+    expect(exposes.focused.get()).toBe(false);
+    expect(exposes.focusVisible.get()).toBe(false);
+    // Sequential navigation reaches a surface that has somewhere to scroll.
+    expect(viewport.getAttribute('tabindex')).toBe('0');
+    // Being reachable is not a reason to invent a widget role.
+    expect(viewport.getAttribute('role')).toBeNull();
+    // `focusable` in the Focus module means something other than "can scroll",
+    // so the Viewport must not publish it as this fact.
+    expect(Object.keys(exposes)).not.toContain('focusable');
+  });
+
+  it('keeps a Viewport with nothing to scroll out of sequential navigation', async () => {
+    // T-BASE-SCROLL-AREA-0001-CASE-VIEWPORT-FOCUS
+    const { viewport } = await mountViewport(FITTING);
+
+    expect(viewport.getExposes().canScrollDown.get()).toBe(false);
+    expect(viewport.getExposes().canScrollRight.get()).toBe(false);
+    // An empty tab stop is worse than no tab stop.
+    expect(viewport.getAttribute('tabindex')).toBe('-1');
+    // The facts still exist, so a projection can read them either way.
+    expect(viewport.getExposes().focused.get()).toBe(false);
+  });
+
+  it('follows content between scrollable and not', async () => {
+    // T-BASE-SCROLL-AREA-0001-CASE-VIEWPORT-FOCUS
+    const { viewport } = await mountViewport(FITTING);
+    expect(viewport.getAttribute('tabindex')).toBe('-1');
+
+    setMetrics(viewport, OVERFLOWING);
+    remeasure(viewport);
+    await flush();
+    expect(viewport.getExposes().canScrollDown.get()).toBe(true);
+    expect(viewport.getAttribute('tabindex')).toBe('0');
+
+    setMetrics(viewport, FITTING);
+    remeasure(viewport);
+    await flush();
+    expect(viewport.getExposes().canScrollDown.get()).toBe(false);
+    expect(viewport.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('leaves focus where it is when the last scrollable direction goes away', async () => {
+    // T-BASE-SCROLL-AREA-0001-CASE-VIEWPORT-FOCUS
+    const { viewport } = await mountViewport(OVERFLOWING);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    viewport.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+    await flush();
+    expect(viewport.getExposes().focused.get()).toBe(true);
+
+    setMetrics(viewport, FITTING);
+    remeasure(viewport);
+    await flush();
+
+    // Only what sequential navigation reaches next may change.
+    expect(viewport.getAttribute('tabindex')).toBe('-1');
+    expect(viewport.getExposes().focused.get()).toBe(true);
+  });
+
+  it('separates keyboard entry from pointer entry', async () => {
+    // T-BASE-SCROLL-AREA-0001-CASE-VIEWPORT-FOCUS
+    const { viewport } = await mountViewport(OVERFLOWING);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    viewport.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+    await flush();
+    expect(viewport.getExposes().focused.get()).toBe(true);
+    expect(viewport.getExposes().focusVisible.get()).toBe(true);
+
+    viewport.dispatchEvent(new FocusEvent('blur', { bubbles: true }));
+    viewport.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    viewport.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+    await flush();
+    expect(viewport.getExposes().focused.get()).toBe(true);
+    expect(viewport.getExposes().focusVisible.get()).toBe(false);
   });
 });

--- a/packages/prototypes/base/test/scroll-area.test.ts
+++ b/packages/prototypes/base/test/scroll-area.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { definePrototype } from '@proto.ui/core';
 import { AdaptToWebComponent, setElementProps } from '@proto.ui/adapter-web-component';
 import {
+  asScrollAreaViewport,
   scrollAreaRoot,
   scrollAreaScrollbar,
   scrollAreaThumb,
@@ -131,6 +133,31 @@ describe('prototypes/base: scroll-area', () => {
     // `focusable` in the Focus module means something other than "can scroll",
     // so the Viewport must not publish it as this fact.
     expect(Object.keys(exposes)).not.toContain('focusable');
+  });
+
+  it('hands a styled projection the focus facts instead of a focus domain', async () => {
+    // T-BASE-SCROLL-AREA-0001-CASE-VIEWPORT-FOCUS
+    let handles: Record<string, unknown> = {};
+    const styled = definePrototype({
+      name: 'test-styled-scroll-area-viewport',
+      setup() {
+        handles = (asScrollAreaViewport() as any).stateHandles ?? {};
+      },
+    });
+    AdaptToWebComponent(styled as any);
+
+    const root = document.createElement('base-scroll-area-root') as any;
+    const viewport = document.createElement('test-styled-scroll-area-viewport') as any;
+    setMetrics(viewport, OVERFLOWING);
+    root.append(viewport);
+    document.body.append(root);
+    await flush();
+
+    // Reading these is what lets a projection paint a ring without installing a
+    // second focus domain of its own.
+    expect(typeof (handles.focused as any)?.get).toBe('function');
+    expect(typeof (handles.focusVisible as any)?.get).toBe('function');
+    expect(viewport.getAttribute('tabindex')).toBe('0');
   });
 
   it('keeps a Viewport with nothing to scroll out of sequential navigation', async () => {

--- a/scripts/test/run-runtime-tests.mjs
+++ b/scripts/test/run-runtime-tests.mjs
@@ -17,6 +17,7 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 // can exceed its own hook timeout and fall back to spawning its own server.
 // Warm every route the suites wait on.
 const READY_ROUTES = [
+  '/en/ui-libraries/base/scroll-area/',
   '/en/ui-libraries/base/textarea/',
   '/en/ui-libraries/brutalist/components/switch/',
   '/en/ui-libraries/brutalist/components/tabs/',

--- a/spec/prototypes/P-BASE-SCROLL-AREA-VIEWPORT.yaml
+++ b/spec/prototypes/P-BASE-SCROLL-AREA-VIEWPORT.yaml
@@ -3,10 +3,10 @@ type: prototype
 title: Base Scroll Area Viewport owns the logical scroll surface
 status: draft
 since: 0.2.0-rc.7
-summary: Viewport is the single semantic owner of the Scroll Area surface and exposes normalized host-independent scrolling facts.
+summary: Viewport is the single semantic owner of the Scroll Area surface, exposing normalized host-independent scrolling facts and the keyboard focus facts of the surface that actually scrolls.
 statement:
-  zh-CN: Viewport 通过特权 `asScrollSurface` 将 prototype instance 绑定到宿主滚动能力，默认允许双轴并请求 auto projection。它只 expose 归一化位置、可见比例、可滚方向、scrolling 与已解析 projection，不泄露 DOM target 或精确像素 geometry。
-  en: Viewport binds the prototype instance to host scrolling through the privileged `asScrollSurface`, allowing both axes and requesting auto projection by default. It exposes only normalized position, visible ratios, available directions, scrolling state, and the resolved projection, without leaking a DOM target or exact pixel geometry.
+  zh-CN: Viewport 通过特权 `asScrollSurface` 将 prototype instance 绑定到宿主滚动能力，默认允许双轴并请求 auto projection。它只 expose 归一化位置、可见比例、可滚方向、scrolling 与已解析 projection，不泄露 DOM target 或精确像素 geometry。作为实际滚动 surface，它同时通过既有 `asFocusable` 拥有 `focused` 与 `focusVisible`，并在存在可滚方向时才参与顺序导航；它仍然保持 role-neutral。
+  en: Viewport binds the prototype instance to host scrolling through the privileged `asScrollSurface`, allowing both axes and requesting auto projection by default. It exposes only normalized position, visible ratios, available directions, scrolling state, and the resolved projection, without leaking a DOM target or exact pixel geometry. As the actual scrolling surface it also owns `focused` and `focusVisible` through the existing `asFocusable`, joining sequential navigation only while a scrollable direction exists, and it stays role-neutral throughout.
 criteria:
   - id: P-BASE-SCROLL-AREA-VIEWPORT-AUTHORING-ENTRIES
     text:
@@ -28,10 +28,22 @@ criteria:
     text:
       zh-CN: Viewport 必须把 Scroll Area Context scope 与 Anatomy Scrollbar/Thumb roles 声明给同一个 `asScrollSurface` handle，使 composed chrome 共享 surface lease 与 facts。
       en: Viewport must declare the Scroll Area Context scope and Anatomy Scrollbar and Thumb roles to the same `asScrollSurface` handle so composed chrome shares the surface lease and facts.
+  - id: P-BASE-SCROLL-AREA-VIEWPORT-KEYBOARD-FOCUS
+    text:
+      zh-CN: Viewport 是实际的滚动 surface，因此必须通过既有 `asFocusable` 拥有 `focused` 与 `focusVisible` 两个标准 focus fact，并且是 Scroll Area 中唯一安装 focus domain 的 anatomy part。下游 styled prototype 只消费这两个 fact，不得重复安装。
+      en: Viewport is the actual scrolling surface, so it must own the standard `focused` and `focusVisible` focus facts through the existing `asFocusable`, and it must be the only Scroll Area anatomy part that installs a focus domain. Downstream styled prototypes consume those facts and must not install a second one.
+    dependsOn:
+      contracts: [C-AS-FOCUSABLE-0001]
+  - id: P-BASE-SCROLL-AREA-VIEWPORT-NAV-PARTICIPATION
+    text:
+      zh-CN: 顺序导航参与度必须由既有的四个可滚方向 fact 驱动——任一为真时 `auto`，全部为假时 `none`——因为一个无处可滚的 surface 是个空 tab stop。geometry 尚未到达时按 `none`，fact 到达后同步。参与度变化只影响后续顺序导航，不得 blur 当前 focus owner。可滚性不得以名为 `focusable` 的公开 state 表示：Focus 模块的 `focusable` 是另一个事实域。
+      en: Sequential-navigation participation must be driven by the existing four scrollable-direction facts, `auto` while any is true and `none` while all are false, because a surface with nowhere to scroll is an empty tab stop. It is `none` before geometry arrives and syncs once the facts do. A participation change affects only subsequent sequential navigation and must never blur the current focus owner. Scrollability must not be published as a state named `focusable`, which is a different fact domain in the Focus module.
+    dependsOn:
+      contracts: [C-AS-FOCUSABLE-0001]
   - id: P-BASE-SCROLL-AREA-VIEWPORT-A11Y-NEUTRALITY
     text:
-      zh-CN: Scroll Area 本身没有专用 ARIA widget role；Viewport 不得仅因可滚动而伪造 region、scrollbar 或 application role。需要 accessible name 或 landmark 时由调用方依据内容语义组合。
-      en: Scroll Area has no dedicated ARIA widget role; Viewport must not invent region, scrollbar, or application solely because it scrolls. Consumers compose an accessible name or landmark when content semantics require one.
+      zh-CN: Scroll Area 本身没有专用 ARIA widget role；Viewport 不得仅因可滚动或可聚焦而伪造 region、scrollbar 或 application role。需要 accessible name 或 landmark 时由调用方依据内容语义组合。
+      en: Scroll Area has no dedicated ARIA widget role; Viewport must not invent region, scrollbar, or application solely because it scrolls or takes focus. Consumers compose an accessible name or landmark when content semantics require one.
 sources:
   - path: packages/prototypes/base/src/scroll-area/viewport.proto.ts
   - path: packages/modules/scroll/src/impl.ts
@@ -41,14 +53,23 @@ sources:
 dependsOn:
   prototypes: [P-BASE-SCROLL-AREA]
   contracts:
-    [C-AS-SCROLL-SURFACE-0001, C-SCROLL-0001, C-SCROLL-COMPOSED-CHROME-0001, C-EXPOSE-STATE-0001]
+    [
+      C-AS-SCROLL-SURFACE-0001,
+      C-AS-FOCUSABLE-0001,
+      C-SCROLL-0001,
+      C-SCROLL-COMPOSED-CHROME-0001,
+      C-EXPOSE-STATE-0001,
+    ]
   hostCaps: [HC-SCROLL-SURFACE-0001]
 verifies: { tests: [T-BASE-SCROLL-AREA-0001] }
 revisions:
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Gave the Viewport the standard focus facts and tied sequential-navigation participation to the scrollable directions.
   - version: 0.2.0-rc.7
     change: revised
     summary: Bound authored composed controls to the Viewport surface through Context scope and Anatomy roles.
   - version: 0.2.0-rc.7
     change: introduced
     summary: Cataloged Viewport ownership, normalized facts, host-mediated requests, and role-neutral accessibility.
-tags: [prototype, base, scroll-area, viewport, host-projection, accessibility]
+tags: [prototype, base, scroll-area, viewport, host-projection, accessibility, focus]

--- a/spec/tests/T-BASE-SCROLL-AREA-0001.yaml
+++ b/spec/tests/T-BASE-SCROLL-AREA-0001.yaml
@@ -3,7 +3,7 @@ type: test
 title: Base Scroll Area domain and anatomy tests
 status: draft
 since: 0.2.0-rc.7
-summary: Covers the Viewport-owned host surface, normalized facts, system default, family scope, orientation, and host-projected composed-control anatomy.
+summary: Covers the Viewport-owned host surface, normalized facts, keyboard focus facts and sequential-navigation participation, system default, family scope, orientation, and host-projected composed-control anatomy.
 cases:
   - id: T-BASE-SCROLL-AREA-0001-CASE-VIEWPORT
     title: Viewport publishes normalized host-independent scrolling facts
@@ -14,6 +14,13 @@ cases:
       - P-BASE-SCROLL-AREA-VIEWPORT-NORMALIZED-FACTS
       - P-BASE-SCROLL-AREA-VIEWPORT-A11Y-NEUTRALITY
     expectation: base-scroll-area-viewport-publishes-normalized-system-projection
+  - id: T-BASE-SCROLL-AREA-0001-CASE-VIEWPORT-FOCUS
+    title: Viewport owns the focus facts of the scrolling surface and joins sequential navigation only when it can scroll
+    covers:
+      - P-BASE-SCROLL-AREA-VIEWPORT-KEYBOARD-FOCUS
+      - P-BASE-SCROLL-AREA-VIEWPORT-NAV-PARTICIPATION
+      - P-BASE-SCROLL-AREA-VIEWPORT-A11Y-NEUTRALITY
+    expectation: base-scroll-area-viewport-joins-sequential-navigation-only-while-scrollable
   - id: T-BASE-SCROLL-AREA-0001-CASE-CONTROLS
     title: Scrollbar owns orientation while Thumb retains no independent control semantics
     covers:
@@ -32,6 +39,7 @@ implementations:
     required: true
     consumesCases:
       - T-BASE-SCROLL-AREA-0001-CASE-VIEWPORT
+      - T-BASE-SCROLL-AREA-0001-CASE-VIEWPORT-FOCUS
       - T-BASE-SCROLL-AREA-0001-CASE-CONTROLS
     exercises:
       - P-BASE-SCROLL-AREA
@@ -48,6 +56,8 @@ verifies:
       anchors:
         - P-BASE-SCROLL-AREA-VIEWPORT-SURFACE-OWNER
         - P-BASE-SCROLL-AREA-VIEWPORT-NORMALIZED-FACTS
+        - P-BASE-SCROLL-AREA-VIEWPORT-KEYBOARD-FOCUS
+        - P-BASE-SCROLL-AREA-VIEWPORT-NAV-PARTICIPATION
     - id: P-BASE-SCROLL-AREA-SCROLLBAR
       anchors: [P-BASE-SCROLL-AREA-SCROLLBAR-ORIENTATION]
     - id: P-BASE-SCROLL-AREA-THUMB


### PR DESCRIPTION
Base prerequisite for #397, per the architecture ruling in https://github.com/Proto-UI/Proto-UI/issues/397#issuecomment-5376888021. The Brutalist projection follows in a second PR; #397 stays open until that one lands.

## Against the five points

1. **Focus lands on Base.** `setupScrollAreaViewport` composes the existing `asFocusable()` and exposes `focused` and `focusVisible`. It is the only Scroll Area part that installs a focus domain, so the styled layer only reads facts.
2. **Participation follows the scrollable directions.** `none` at setup, because geometry has not arrived and a surface with nowhere to scroll is an empty tab stop; then `auto` while any of the four `canScroll*` facts is true and `none` when all are false. Losing the last direction calls `setNavParticipation` only, which rewrites the tab stop without touching the focus owner — asserted directly.
3. **No new identities.** Only `C-AS-FOCUSABLE-0001` is added to `dependsOn`. `P-BASE-SCROLL-AREA-VIEWPORT` gains two criteria and `T-BASE-SCROLL-AREA-0001` one case; the a11y-neutrality criterion now says taking focus is not a reason to invent a role either.
4. **Nothing else moved.** No ARIA role or name, no second host wrapper, no change to scroll request or fact ownership, no DOM target exposed, no Brutalist token.
5. **Regressions** below.

I also did not publish a state named `focusable`. Scrollability is read from the four direction facts and never surfaces under that name.

## Evidence

Module tests in `packages/prototypes/base/test/scroll-area.test.ts`, five new cases, each verified red before:

| case | red without the slice |
| --- | --- |
| scrollable Viewport gets focus facts, no widget role | `Cannot read properties of undefined (reading 'get')` |
| nothing to scroll stays out of sequential navigation | `expected null to be '-1'` |
| follows content between scrollable and not | `expected null to be '-1'` |
| focus stays put when the last direction goes away | `Cannot read properties of undefined (reading 'get')` |
| keyboard entry versus pointer entry | `Cannot read properties of undefined (reading 'get')` |

Browser regressions in `demo-base-controls.browser.test.ts`, four new cases over Web Components, React and Vue:

- a tab stop only on the Viewport that can scroll, `0` against `-1`, no role on either, and exactly one focusable node inside a scrolling Root and none inside a fitting one;
- content driven from nothing to scroll, to scrollable, and back, asserting the tab stop each way;
- keyboard entry giving `focused` and `focusVisible`, pointer entry giving `focused` alone;
- Arrow, PageDown, End, Home and wheel scrolling still moving the focused Viewport.

The first three fail on the assertion that names the defect rather than on a readiness timeout: `wc/scrolling-tabindex: expected null to be '0'`, `wc/fitting-before: expected null to be '-1'`, `wc/keyboard-focused: expected false to be true`. Readiness waits on the scroll fact, which is published with or without this slice, which is what makes that possible. The fourth passes on `main` too — it is a non-regression guard, not a witness.

`vitest run packages`: 1336 passed, 34 todo, 3 skipped. Every governance check green, plus `check:types`.

## Two things in the demo

The Base Scroll Area demo gains a second surface that fits its content, because the no-overflow half of the acceptance list needs one to exist.

It also needed a correction to be evidence at all: its rows were plain strings in one box, so the renderer concatenated them into a single 97px text node inside a 190px viewport. **The demo has never scrolled on `main`.** Each row is its own box now, and the scrolling surface actually overflows. Screenshot-free but measurable: `clientHeight` 190 against `scrollHeight` 190 before, and the vertical direction facts were absent.

## One observation, not addressed here

`demo-base-controls.browser.test.ts` goes from one case to five. Under four browser suites running in parallel against the one shared dev server, its `afterAll` then hangs on my machine — 60s is not enough, so it is a hang rather than slowness, and the untouched Brutalist suite does the same. Running the suites sequentially clears it: all fourteen tests and both teardowns pass. That contention is what #480 addresses by making the browser phase sequential, so I left this suite alone rather than papering over it here. If CI shows it on this branch I will rebase onto #480 or carry the flag here.
