### PR TITLE
fix(event): transactional listener installation and portable default-action control

### DIFF
--- a/packages/core/src/handles.ts
+++ b/packages/core/src/handles.ts
@@ -1,8 +1,10 @@
 // packages/core/src/handles.ts
 import {
   EventListenerToken,
-  EventListenerOptions,
-  EventTypeV0,
+  ExtensionEventType,
+  HostEventListenerOptions,
+  ProtoEventPayload,
+  SemanticEventType,
   ExposeEventSpec,
   JsonObject,
   ContextKey,
@@ -248,16 +250,18 @@ export interface DefHandle<Props extends PropsBaseType, Exposes = Record<string,
   rule: (spec: RuleSpec<Props>) => RuleHandle;
 
   event: {
+    on(type: SemanticEventType, cb: ProtoEventCallback<Props>): EventListenerToken;
     on(
-      type: EventTypeV0,
-      cb: ProtoEventCallback<Props>,
-      options?: EventListenerOptions
+      type: ExtensionEventType,
+      cb: ProtoEventCallback<Props, unknown>,
+      options?: HostEventListenerOptions
     ): EventListenerToken;
     off(token: EventListenerToken): void;
+    onGlobal(type: SemanticEventType, cb: ProtoEventCallback<Props>): EventListenerToken;
     onGlobal(
-      type: EventTypeV0,
-      cb: ProtoEventCallback<Props>,
-      options?: EventListenerOptions
+      type: ExtensionEventType,
+      cb: ProtoEventCallback<Props, unknown>,
+      options?: HostEventListenerOptions
     ): EventListenerToken;
   };
 
@@ -363,7 +367,10 @@ export type RawWatchCallback<P extends PropsBaseType> = (
   info: WatchInfo<P & PropsBaseType>
 ) => void;
 
-export type ProtoEventCallback<P extends PropsBaseType> = (run: RunHandle<P>, ev: any) => void;
+export type ProtoEventCallback<P extends PropsBaseType, E = ProtoEventPayload> = (
+  run: RunHandle<P>,
+  ev: E
+) => void;
 
 export type StateWatchCallback<V, P extends PropsBaseType> = (
   run: RunHandle<P>,

--- a/packages/modules/boundary/src/impl.ts
+++ b/packages/modules/boundary/src/impl.ts
@@ -247,11 +247,11 @@ export class BoundaryModuleImpl extends ModuleBase {
     if (this.observingPointerDown) return;
     this.observingPointerDown = true;
     this.eventPort.onGlobal('host:pointerdown', (nativeEvent) => {
-      this.notify({
-        type: 'pointerdown',
-        target: nativeEvent?.target,
-        nativeEvent,
-      });
+      const target =
+        nativeEvent && typeof nativeEvent === 'object' && 'target' in nativeEvent
+          ? (nativeEvent as { target?: unknown }).target
+          : undefined;
+      this.notify({ type: 'pointerdown', target, nativeEvent });
     });
   }
 

--- a/packages/modules/event/src/create.ts
+++ b/packages/modules/event/src/create.ts
@@ -1,8 +1,9 @@
 // packages/modules/event/src/create.ts
 import { createModule, defineModule } from '@proto.ui/module-base';
 import type { ModuleFactoryArgs } from '@proto.ui/module-base';
+import type { EventTypeV0, HostEventListenerOptions } from '@proto.ui/types';
 
-import type { EventFacade, EventModule, EventPort } from './types';
+import type { EventFacade, EventInternalCallback, EventModule, EventPort } from './types';
 import { EventModuleImpl } from './impl';
 
 export function createEventModule(ctx: ModuleFactoryArgs): EventModule {
@@ -19,16 +20,23 @@ export function createEventModule(ctx: ModuleFactoryArgs): EventModule {
 
       return {
         facade: {
-          on: (type, options) => impl.on(type, options),
-          onGlobal: (type, options) => impl.onGlobal(type, options),
+          on: ((type: EventTypeV0, options?: HostEventListenerOptions) =>
+            impl.on(type, options)) as EventFacade['on'],
+          onGlobal: ((type: EventTypeV0, options?: HostEventListenerOptions) =>
+            impl.onGlobal(type, options)) as EventFacade['onGlobal'],
           off: (token) => impl.off(token),
         },
         hooks: {
           onProtoPhase: (p) => impl.onProtoPhase(p),
         },
         port: {
-          on: (type, cb, options) => impl.onInternal(type, cb, options),
-          onGlobal: (type, cb, options) => impl.onGlobalInternal(type, cb, options),
+          on: ((type: EventTypeV0, cb: EventInternalCallback, options?: HostEventListenerOptions) =>
+            impl.onInternal(type, cb, options)) as EventPort['on'],
+          onGlobal: ((
+            type: EventTypeV0,
+            cb: EventInternalCallback,
+            options?: HostEventListenerOptions
+          ) => impl.onGlobalInternal(type, cb, options)) as EventPort['onGlobal'],
           bind: (dispatch) => impl.bind(dispatch),
           unbind: () => impl.unbind(),
           getDiagnostics: () => impl.getDiagnostics(),

--- a/packages/modules/event/src/impl.ts
+++ b/packages/modules/event/src/impl.ts
@@ -6,7 +6,13 @@ import { ModuleBase } from '@proto.ui/module-base';
 
 import type { EventDispatch, EventInternalCallback } from './types';
 import { EventKernel } from './kernel';
-import type { EventListenerToken, EventTypeV0 } from '@proto.ui/types';
+import type {
+  EventListenerToken,
+  EventTypeV0,
+  HostEventListenerOptions,
+  ProtoEventControl,
+  ProtoEventPayload,
+} from '@proto.ui/types';
 import {
   EVENT_CANCEL_DEFAULT_ACTION_CAP,
   EVENT_GLOBAL_TARGET_CAP,
@@ -39,6 +45,36 @@ const OPTIONAL_EVENT_TYPES = [
   'change',
   'context.menu',
 ] as const;
+
+const PORTABLE_EVENT_FIELDS = [
+  'key',
+  'ctrlKey',
+  'metaKey',
+  'altKey',
+  'shiftKey',
+  'repeat',
+] as const;
+
+function eventDataSource(raw: unknown): Record<string, unknown> {
+  if (!raw || typeof raw !== 'object') return {};
+  const detail = (raw as { detail?: unknown }).detail;
+  if (detail && typeof detail === 'object') return detail as Record<string, unknown>;
+  return raw as Record<string, unknown>;
+}
+
+function createPortableEventPayload(
+  type: EventTypeV0,
+  raw: unknown,
+  control: ProtoEventControl
+): ProtoEventPayload {
+  const source = eventDataSource(raw);
+  const payload: Record<string, unknown> = { type, control };
+  for (const field of PORTABLE_EVENT_FIELDS) {
+    const value = source[field];
+    if (typeof value === 'string' || typeof value === 'boolean') payload[field] = value;
+  }
+  return Object.freeze(payload) as ProtoEventPayload;
+}
 
 function isValidEventType(type: any): type is EventTypeV0 {
   if (typeof type !== 'string' || !type) return false;
@@ -98,7 +134,7 @@ export class EventModuleImpl extends ModuleBase {
     id: string,
     kind: 'root' | 'global',
     type: EventTypeV0,
-    options?: any
+    options?: HostEventListenerOptions
   ): EventListenerToken {
     const meta = {
       kind,
@@ -153,6 +189,7 @@ export class EventModuleImpl extends ModuleBase {
   on(type: EventTypeV0, options?: any): EventListenerToken {
     this.ensureSetup('def.event.on');
     this.guardArgs(type);
+    this.guardListenerOptions(type, options);
     const id = this.kernel.on('root', type, options);
     return this.makeToken(id, 'root', type, options);
   }
@@ -160,6 +197,7 @@ export class EventModuleImpl extends ModuleBase {
   onGlobal(type: EventTypeV0, options?: any): EventListenerToken {
     this.ensureSetup('def.event.onGlobal');
     this.guardArgs(type);
+    this.guardListenerOptions(type, options);
     const id = this.kernel.on('global', type, options);
     return this.makeToken(id, 'global', type, options);
   }
@@ -167,6 +205,7 @@ export class EventModuleImpl extends ModuleBase {
   onInternal(type: EventTypeV0, cb: EventInternalCallback, options?: any): EventListenerToken {
     this.ensureSetup('event.port.on');
     this.guardArgs(type);
+    this.guardListenerOptions(type, options);
     if (typeof cb !== 'function') {
       throw eventInvalidArg(`[Event] internal listener requires a callback.`, {
         prototypeName: this.prototypeName,
@@ -185,6 +224,7 @@ export class EventModuleImpl extends ModuleBase {
   ): EventListenerToken {
     this.ensureSetup('event.port.onGlobal');
     this.guardArgs(type);
+    this.guardListenerOptions(type, options);
     if (typeof cb !== 'function') {
       throw eventInvalidArg(`[Event] internal global listener requires a callback.`, {
         prototypeName: this.prototypeName,
@@ -241,24 +281,37 @@ export class EventModuleImpl extends ModuleBase {
 
     this.lastDispatch = dispatch;
 
-    // Portable default-action control (HC-DEFAULT-ACTION-0001): prototype
-    // callbacks receive ev.control and request prevention through it. The
-    // facade is local to this module instance; no native function crosses a
-    // host boundary. Raw payload preventDefault remains an escape hatch.
-
-    const dispatchWithControl: EventDispatch = (id, ev) => {
-      const detail = ev?.detail ?? ev;
-      if (detail && typeof detail === 'object') {
-        let prevented = false;
-        (detail as any).control = {
-          requestDefaultActionPrevention: (options?: { reason?: string; source?: string }) => {
-            if (prevented) return;
-            prevented = true;
-            this.requestDefaultActionPrevented(ev, options);
-          },
-        };
+    // Construct a fresh immutable data-only view for every portable callback.
+    // Host-bound `host:*` extensions intentionally keep the raw host event.
+    // Each portable control is live only during its synchronous callback.
+    // Requests from multiple registrations for the same host sample are
+    // deduplicated at the host boundary.
+    const preventedSamples = new WeakSet<object>();
+    const dispatchWithControl: EventDispatch = (id, raw, type) => {
+      if (!type) throw eventInvalidArg('[Event] dispatch requires a registered event type.');
+      if (String(type).startsWith('host:')) {
+        dispatch(id, raw);
+        return;
       }
-      dispatch(id, ev);
+      let active = true;
+      const control: ProtoEventControl = Object.freeze({
+        requestDefaultActionPrevention: (options) => {
+          if (!active) {
+            throw eventInvalidArg('[Event] default-action control is outside its callback window.');
+          }
+          if (raw && typeof raw === 'object') {
+            if (preventedSamples.has(raw)) return;
+            preventedSamples.add(raw);
+          }
+          this.requestDefaultActionPrevented(raw, options);
+        },
+      });
+      const payload = createPortableEventPayload(type, raw, control);
+      try {
+        dispatch(id, payload);
+      } finally {
+        active = false;
+      }
     };
 
     this.kernel.bindAll(dispatchWithControl, (kind, type) => {
@@ -360,6 +413,15 @@ export class EventModuleImpl extends ModuleBase {
   // -------------------------
   // helpers
   // -------------------------
+
+  private guardListenerOptions(type: EventTypeV0, options?: HostEventListenerOptions) {
+    if (!String(type).startsWith('host:') && typeof options !== 'undefined') {
+      throw eventInvalidArg('[Event] listener options are only valid for host:* extensions.', {
+        prototypeName: this.prototypeName,
+        type,
+      });
+    }
+  }
 
   private guardArgs(type: EventTypeV0) {
     if (!isValidEventType(type)) {

--- a/packages/modules/event/src/impl.ts
+++ b/packages/modules/event/src/impl.ts
@@ -241,7 +241,27 @@ export class EventModuleImpl extends ModuleBase {
 
     this.lastDispatch = dispatch;
 
-    this.kernel.bindAll(dispatch, (kind, type) => {
+    // Portable default-action control (HC-DEFAULT-ACTION-0001): prototype
+    // callbacks receive ev.control and request prevention through it. The
+    // facade is local to this module instance; no native function crosses a
+    // host boundary. Raw payload preventDefault remains an escape hatch.
+
+    const dispatchWithControl: EventDispatch = (id, ev) => {
+      const detail = ev?.detail ?? ev;
+      if (detail && typeof detail === 'object') {
+        let prevented = false;
+        (detail as any).control = {
+          requestDefaultActionPrevention: (options?: { reason?: string; source?: string }) => {
+            if (prevented) return;
+            prevented = true;
+            this.requestDefaultActionPrevented(ev, options);
+          },
+        };
+      }
+      dispatch(id, ev);
+    };
+
+    this.kernel.bindAll(dispatchWithControl, (kind, type) => {
       if (kind === 'global') return global as EventTarget;
       const target =
         this.overriddenRootTarget ??

--- a/packages/modules/event/src/kernel.ts
+++ b/packages/modules/event/src/kernel.ts
@@ -1,5 +1,5 @@
 // packages/modules/event/src/kernel.ts
-import { EventTypeV0 } from '@proto.ui/types';
+import type { EventTypeV0, HostEventListenerOptions } from '@proto.ui/types';
 import type { EventDiag, EventDispatch } from './types';
 
 type TargetKind = 'root' | 'global';
@@ -10,7 +10,7 @@ type Reg = {
 
   kind: TargetKind;
   type: EventTypeV0;
-  options?: EventListenerOptions;
+  options?: HostEventListenerOptions;
 
   wrapper?: (ev: any) => void;
   boundTarget?: EventTarget;
@@ -117,7 +117,7 @@ export class EventKernel {
       if (r.wrapper && r.boundTarget) continue;
 
       const target = getTarget(r.kind, r.type);
-      const wrapper = (ev: any) => dispatch(r.id, ev);
+      const wrapper = (ev: unknown) => dispatch(r.id, ev, r.type);
 
       pending.push({ registration: r, target, wrapper });
     }

--- a/packages/modules/event/src/kernel.ts
+++ b/packages/modules/event/src/kernel.ts
@@ -12,7 +12,8 @@ type Reg = {
   type: EventTypeV0;
   options?: HostEventListenerOptions;
 
-  wrapper?: (ev: any) => void;
+  wrapper?: (event: unknown) => void;
+  deactivate?: () => void;
   boundTarget?: EventTarget;
 };
 
@@ -65,6 +66,7 @@ export class EventKernel {
       if (r.id !== id) continue;
 
       if (r.wrapper && r.boundTarget) {
+        r.deactivate?.();
         r.boundTarget.removeEventListener(r.type as any, r.wrapper as any, r.options as any);
       }
 
@@ -84,6 +86,7 @@ export class EventKernel {
       if (!matchReg(r, kind, type, options)) continue;
 
       if (r.wrapper && r.boundTarget) {
+        r.deactivate?.();
         r.boundTarget.removeEventListener(r.type as any, r.wrapper as any, r.options as any);
       }
 
@@ -110,16 +113,24 @@ export class EventKernel {
     const pending: Array<{
       registration: Reg;
       target: EventTarget;
-      wrapper: (ev: any) => void;
+      wrapper: (event: unknown) => void;
+      deactivate: () => void;
     }> = [];
 
     for (const r of this.regs) {
       if (r.wrapper && r.boundTarget) continue;
 
       const target = getTarget(r.kind, r.type);
-      const wrapper = (ev: unknown) => dispatch(r.id, ev, r.type);
+      let active = true;
+      const wrapper = (event: unknown) => {
+        if (!active) return;
+        dispatch(r.id, event, r.type);
+      };
+      const deactivate = () => {
+        active = false;
+      };
 
-      pending.push({ registration: r, target, wrapper });
+      pending.push({ registration: r, target, wrapper, deactivate });
     }
 
     // HC-EVENT-0001 / #466 third pass: installation is transactional across
@@ -129,23 +140,28 @@ export class EventKernel {
     const attached: Array<{
       registration: Reg;
       target: EventTarget;
-      wrapper: (ev: any) => void;
+      wrapper: (event: unknown) => void;
+      deactivate: () => void;
     }> = [];
 
     try {
-      for (const { registration, target, wrapper } of pending) {
+      for (const { registration, target, wrapper, deactivate } of pending) {
         target.addEventListener(
           registration.type as any,
           wrapper as any,
           registration.options as any
         );
 
-        attached.push({ registration, target, wrapper });
+        attached.push({ registration, target, wrapper, deactivate });
         registration.wrapper = wrapper;
+        registration.deactivate = deactivate;
         registration.boundTarget = target;
       }
     } catch (error) {
-      for (const { registration, target, wrapper } of attached) {
+      for (const { registration, target, wrapper, deactivate } of attached) {
+        // Fail closed before attempting physical removal. If removal throws,
+        // a surviving host callback is inert and cannot dispatch.
+        deactivate();
         try {
           target.removeEventListener(
             registration.type as any,
@@ -156,6 +172,7 @@ export class EventKernel {
           // Removal failure during rollback must not mask the original error.
         }
         registration.wrapper = undefined;
+        registration.deactivate = undefined;
         registration.boundTarget = undefined;
       }
       throw error;
@@ -165,9 +182,13 @@ export class EventKernel {
   unbindAll() {
     for (const r of this.regs) {
       if (!r.wrapper || !r.boundTarget) continue;
-      r.boundTarget.removeEventListener(r.type as any, r.wrapper as any, r.options as any);
+      const target = r.boundTarget;
+      const wrapper = r.wrapper;
+      r.deactivate?.();
       r.wrapper = undefined;
+      r.deactivate = undefined;
       r.boundTarget = undefined;
+      target.removeEventListener(r.type as any, wrapper as any, r.options as any);
     }
   }
 

--- a/packages/modules/event/src/kernel.ts
+++ b/packages/modules/event/src/kernel.ts
@@ -122,15 +122,43 @@ export class EventKernel {
       pending.push({ registration: r, target, wrapper });
     }
 
-    for (const { registration, target, wrapper } of pending) {
-      target.addEventListener(
-        registration.type as any,
-        wrapper as any,
-        registration.options as any
-      );
+    // HC-EVENT-0001 / #466 third pass: installation is transactional across
+    // attachment failures, not only target-resolution failures. If any
+    // addEventListener throws, every attachment made for this plan is rolled
+    // back before the error propagates, so no partial listener set survives.
+    const attached: Array<{
+      registration: Reg;
+      target: EventTarget;
+      wrapper: (ev: any) => void;
+    }> = [];
 
-      registration.wrapper = wrapper;
-      registration.boundTarget = target;
+    try {
+      for (const { registration, target, wrapper } of pending) {
+        target.addEventListener(
+          registration.type as any,
+          wrapper as any,
+          registration.options as any
+        );
+
+        attached.push({ registration, target, wrapper });
+        registration.wrapper = wrapper;
+        registration.boundTarget = target;
+      }
+    } catch (error) {
+      for (const { registration, target, wrapper } of attached) {
+        try {
+          target.removeEventListener(
+            registration.type as any,
+            wrapper as any,
+            registration.options as any
+          );
+        } catch {
+          // Removal failure during rollback must not mask the original error.
+        }
+        registration.wrapper = undefined;
+        registration.boundTarget = undefined;
+      }
+      throw error;
     }
   }
 

--- a/packages/modules/event/src/types.ts
+++ b/packages/modules/event/src/types.ts
@@ -1,7 +1,11 @@
 // packages/modules/event/src/types.ts
 import type { ModuleInstance } from '@proto.ui/core';
 import type { ModulePort } from '@proto.ui/core';
-import { EventListenerToken, EventTypeV0 } from '@proto.ui/types';
+import {
+  EventListenerToken,
+  EventTypeV0,
+  type HostEventListenerOptions as EventListenerOptions,
+} from '@proto.ui/types';
 
 /** @deprecated Import ExposeEventFacade from @proto.ui/module-expose-event. */
 export type { ExposeEventFacade } from '@proto.ui/module-expose-event';

--- a/packages/modules/event/src/types.ts
+++ b/packages/modules/event/src/types.ts
@@ -1,22 +1,29 @@
 // packages/modules/event/src/types.ts
 import type { ModuleInstance } from '@proto.ui/core';
 import type { ModulePort } from '@proto.ui/core';
-import {
+import type {
   EventListenerToken,
   EventTypeV0,
-  type HostEventListenerOptions as EventListenerOptions,
+  ExtensionEventType,
+  HostEventListenerOptions,
+  ProtoEventPayload,
+  SemanticEventType,
 } from '@proto.ui/types';
 
 /** @deprecated Import ExposeEventFacade from @proto.ui/module-expose-event. */
 export type { ExposeEventFacade } from '@proto.ui/module-expose-event';
 
-export type EventDispatch = (id: string, ev: any) => void;
-export type EventInternalCallback = (ev: any) => void;
+export type EventDispatch = (id: string, ev: unknown, type?: EventTypeV0) => void;
+export type SemanticEventInternalCallback = (ev: ProtoEventPayload) => void;
+export type HostEventInternalCallback = (ev: unknown) => void;
+export type EventInternalCallback = (ev: unknown) => void;
 
 export type EventChannelFacade = {
   // --- setup-only registration (opaque to module) ---
-  on(type: EventTypeV0, options?: EventListenerOptions): EventListenerToken;
-  onGlobal(type: EventTypeV0, options?: EventListenerOptions): EventListenerToken;
+  on(type: SemanticEventType): EventListenerToken;
+  on(type: ExtensionEventType, options?: HostEventListenerOptions): EventListenerToken;
+  onGlobal(type: SemanticEventType): EventListenerToken;
+  onGlobal(type: ExtensionEventType, options?: HostEventListenerOptions): EventListenerToken;
 
   /** precise removal */
   off(token: EventListenerToken): void;
@@ -36,15 +43,17 @@ export type EventPort = ModulePort & {
    * These callbacks are dispatched by runtime before prototype-author callbacks
    * for the same event dispatch pass.
    */
+  on(type: SemanticEventType, cb: SemanticEventInternalCallback): EventListenerToken;
   on(
-    type: EventTypeV0,
-    cb: EventInternalCallback,
-    options?: EventListenerOptions
+    type: ExtensionEventType,
+    cb: HostEventInternalCallback,
+    options?: HostEventListenerOptions
   ): EventListenerToken;
+  onGlobal(type: SemanticEventType, cb: SemanticEventInternalCallback): EventListenerToken;
   onGlobal(
-    type: EventTypeV0,
-    cb: EventInternalCallback,
-    options?: EventListenerOptions
+    type: ExtensionEventType,
+    cb: HostEventInternalCallback,
+    options?: HostEventListenerOptions
   ): EventListenerToken;
 
   /**

--- a/packages/modules/event/test/impl-spec.test.ts
+++ b/packages/modules/event/test/impl-spec.test.ts
@@ -295,6 +295,148 @@ describe('EventModuleImpl (contract-ish)', () => {
   // failures. A throwing Nth addEventListener must roll back every earlier
   // attachment, leave all registrations logically unbound, and allow a clean
   // explicit retry.
+  it('dispatches an immutable data-only payload with a synchronous control window', () => {
+    const sys = createSysCaps();
+    const root = new FakeEventTarget();
+    const prevented: unknown[] = [];
+    const caps = makeCaps({
+      sys,
+      getRootTarget: () => root as any,
+      getGlobalTarget: () => root as any,
+      cancelDefaultAction: (request: unknown) => prevented.push(request),
+    });
+    const impl = new EventModuleImpl(caps, 'p-x');
+    sys.__setExecPhase('setup');
+    const token = impl.on('press.commit' as any); // portable semantic event
+
+    sys.__setExecPhase('callback');
+    let received: any = null;
+    let inWindow: (() => void) | null = null;
+    let afterWindow: (() => void) | null = null;
+    impl.bind((id, ev) => {
+      if (id === (token as any).id) {
+        received = ev as any;
+        // A request made inside the synchronous window flows to the host cap.
+        (ev as any)?.control?.requestDefaultActionPrevention({
+          reason: 'in-window',
+          source: 'p-x',
+        });
+        // A saved facade later must fail closed.
+        afterWindow = () =>
+          (ev as any)?.control?.requestDefaultActionPrevention({ reason: 'late' });
+        inWindow = null;
+      }
+    });
+
+    // frozen input detail must never be mutated
+    const frozen = Object.freeze({ detail: Object.freeze({ key: ' ', shiftKey: true }) });
+    root.dispatch('press.commit', frozen as any);
+
+    expect(received).toBeDefined();
+    expect(Object.isFrozen(received)).toBe(true);
+    expect(received.type).toBe('press.commit');
+    expect(received.key).toBe(' ');
+    expect(received.shiftKey).toBe(true);
+    // the raw event is a new object, not an alias of the input
+    expect(received).not.toBe(frozen);
+
+    expect(prevented).toHaveLength(1);
+    expect((prevented[0] as any).reason).toBe('in-window');
+
+    // using a saved facade after the window fails closed
+    expect(() => afterWindow?.()).toThrow(/outside its callback window/);
+    expect(prevented).toHaveLength(1);
+  });
+
+  it('rejects listener options on portable semantic registrations but allows host extensions', () => {
+    const sys = createSysCaps();
+    const root = new FakeEventTarget();
+    const caps = makeCaps({
+      sys,
+      getRootTarget: () => root as any,
+      getGlobalTarget: () => root as any,
+    });
+    const impl = new EventModuleImpl(caps, 'p-x');
+    sys.__setExecPhase('setup');
+    // portable semantic registration with options must fail
+    expect(() => impl.on('press.commit' as any, { capture: true })).toThrow(
+      /only valid for host\:/
+    );
+    // host extension registration with options is allowed
+    expect(() => impl.on('host:click', { capture: true })).not.toThrow();
+  });
+
+  it('keeps cleanup idempotent and reports logically unbound after rollback', () => {
+    const sys = createSysCaps();
+    const good = new FakeEventTarget();
+    let removeCalls = 0;
+    const bad = {
+      addEventListener: () => {
+        throw new Error('refused');
+      },
+      removeEventListener: () => {},
+      count: () => 0,
+    };
+    let globalFirst = true;
+    const caps = makeCaps({
+      sys,
+      getRootTarget: () => good as any,
+      getGlobalTarget: () => (globalFirst ? (bad as any) : (good as any)),
+    });
+    const impl = new EventModuleImpl(caps, 'p-x');
+    sys.__setExecPhase('setup');
+    impl.on('press.commit' as any); // root -> good
+    impl.onGlobal('key.down' as any); // first global -> bad throws
+    sys.__setExecPhase('callback');
+    const { dispatch } = makeDispatch();
+    expect(() => impl.bind(dispatch)).toThrow(/refused/);
+
+    // Rollback removed the earlier 'good' root listener, so nothing is bound.
+    good.dispatch('press.commit', { ok: true });
+    // Retry installs cleanly now that global resolves.
+    globalFirst = false;
+    impl.bind(dispatch);
+    expect((impl as any).isBound).toBe(true);
+    good.dispatch('press.commit', { ok: true });
+
+    // unbind twice is idempotent and fails closed to unbound.
+    impl.unbind();
+    impl.unbind();
+    expect((impl as any).isBound).toBe(false);
+    good.dispatch('press.commit', { ok: true });
+  });
+
+  it('deduplicates default-action requests across registrations for one sample', () => {
+    const sys = createSysCaps();
+    const root = new FakeEventTarget();
+    const prevented: unknown[] = [];
+    const caps = makeCaps({
+      sys,
+      getRootTarget: () => root as any,
+      getGlobalTarget: () => root as any,
+      cancelDefaultAction: (request: unknown) => prevented.push(request),
+    });
+    const impl = new EventModuleImpl(caps, 'p-x');
+    sys.__setExecPhase('setup');
+    const t1 = impl.on('press.commit' as any);
+    const t2 = impl.on('press.commit' as any);
+
+    sys.__setExecPhase('callback');
+    const samples: unknown[] = [];
+    impl.bind((id, ev) => {
+      if (id === (t1 as any).id || id === (t2 as any).id) {
+        samples.push(ev);
+        (ev as any).control.requestDefaultActionPrevention({ reason: 'same' });
+      }
+    });
+
+    const sample = { detail: { key: ' ' } };
+    root.dispatch('press.commit', sample as any);
+
+    // one raw sample => one host request, regardless of registration count
+    expect(prevented).toHaveLength(1);
+  });
+
   it('bind(): rolls back earlier attachments when a later one throws', () => {
     const sys = createSysCaps();
     const good = new FakeEventTarget();

--- a/packages/modules/event/test/impl-spec.test.ts
+++ b/packages/modules/event/test/impl-spec.test.ts
@@ -291,6 +291,59 @@ describe('EventModuleImpl (contract-ish)', () => {
     expect(diags[0].label).toBe('asButton: commit');
   });
 
+  it('keeps a rollback-surviving physical listener inert when removal throws', () => {
+    const sys = createSysCaps();
+    const rootListeners: Array<(event: unknown) => void> = [];
+    const root = {
+      addEventListener: (_type: string, callback: (event: unknown) => void) => {
+        rootListeners.push(callback);
+      },
+      removeEventListener: () => {
+        throw new Error('host refused rollback removal');
+      },
+      fire: (event: unknown) => {
+        for (const callback of rootListeners) callback(event);
+      },
+    };
+    const recoveredGlobal = new FakeEventTarget();
+    let firstGlobal = true;
+    const failedGlobal = {
+      addEventListener: () => {
+        throw new Error('host refused attachment');
+      },
+      removeEventListener: () => {},
+    };
+    const caps = makeCaps({
+      sys,
+      getRootTarget: () => root as any,
+      getGlobalTarget: () => (firstGlobal ? (failedGlobal as any) : (recoveredGlobal as any)),
+    });
+    const impl = new EventModuleImpl(caps, 'p-x');
+
+    sys.__setExecPhase('setup');
+    impl.on('press.commit' as any);
+    impl.onGlobal('key.down' as any);
+    sys.__setExecPhase('callback');
+    const { calls, dispatch } = makeDispatch();
+
+    // Original attachment failure is preserved; rollback removal failure does
+    // not replace it, and every registration reports logically unbound.
+    expect(() => impl.bind(dispatch)).toThrowError(/host refused attachment/);
+    expect(impl.getDiagnostics().every((entry) => entry.bound === false)).toBe(true);
+
+    // The host retained the physical callback, but its active gate was revoked
+    // before removal, so it cannot dispatch.
+    root.fire({ type: 'press.commit' });
+    expect(calls).toEqual([]);
+
+    // Explicit retry installs one active wrapper. Firing invokes both the old
+    // inert callback and the new active callback, yielding one dispatch only.
+    firstGlobal = false;
+    impl.bind(dispatch);
+    root.fire({ type: 'press.commit' });
+    expect(calls).toHaveLength(1);
+  });
+
   // #466 third pass: installation is transactional across attachment
   // failures. A throwing Nth addEventListener must roll back every earlier
   // attachment, leave all registrations logically unbound, and allow a clean

--- a/packages/modules/event/test/impl-spec.test.ts
+++ b/packages/modules/event/test/impl-spec.test.ts
@@ -290,4 +290,50 @@ describe('EventModuleImpl (contract-ish)', () => {
     const diags = impl.getDiagnostics();
     expect(diags[0].label).toBe('asButton: commit');
   });
+
+  // #466 third pass: installation is transactional across attachment
+  // failures. A throwing Nth addEventListener must roll back every earlier
+  // attachment, leave all registrations logically unbound, and allow a clean
+  // explicit retry.
+  it('bind(): rolls back earlier attachments when a later one throws', () => {
+    const sys = createSysCaps();
+    const good = new FakeEventTarget();
+    let globalCalls = 0;
+    const bad = {
+      addEventListener: () => {
+        throw new Error('host refused attachment');
+      },
+      removeEventListener: () => {},
+      count: () => 0,
+    };
+
+    const caps = makeCaps({
+      sys,
+      getRootTarget: () => good as any,
+      getGlobalTarget: () => {
+        globalCalls += 1;
+        return globalCalls === 1 ? (bad as any) : (good as any);
+      },
+    });
+    const impl = new EventModuleImpl(caps, 'p-x');
+
+    sys.__setExecPhase('setup');
+    impl.on('press.commit' as any); // attaches to `good`
+    impl.onGlobal('key.down' as any); // attachment throws on `bad`
+
+    sys.__setExecPhase('callback');
+    const { calls, dispatch } = makeDispatch();
+
+    expect(() => impl.bind(dispatch)).toThrowError(/host refused attachment/);
+
+    // Rollback: the first listener must be gone, so no callback can fire.
+    good.dispatch('press.commit', { ok: true });
+    expect(calls).toEqual([]);
+
+    // Every registration is logically unbound; retry installs cleanly.
+    impl.bind(dispatch);
+    expect((impl as any).isBound).toBe(true);
+    good.dispatch('press.commit', { ok: true });
+    expect(calls.length).toBe(1);
+  });
 });

--- a/packages/modules/focus/src/create.ts
+++ b/packages/modules/focus/src/create.ts
@@ -484,17 +484,16 @@ class FocusModuleImpl extends ModuleBase {
         return;
       }
 
-      const detail = ev?.detail;
-      if (detail?.key !== 'Tab') return;
+      if (ev.key !== 'Tab') return;
 
       const entry = this.createCenterEntry();
       if (!entry || !FOCUS_CENTER.isTopActiveScope(entry)) return;
 
-      this.eventPort.requestDefaultActionPrevented(ev, {
+      ev.control.requestDefaultActionPrevention({
         reason: 'focus.scope.trap',
         source: this.prototypeName,
       });
-      FOCUS_CENTER.focusInScope(entry, detail?.shiftKey ? 'prev' : 'next');
+      FOCUS_CENTER.focusInScope(entry, ev.shiftKey ? 'prev' : 'next');
     });
   }
 
@@ -504,7 +503,7 @@ class FocusModuleImpl extends ModuleBase {
 
     this.eventPort.onGlobal('key.down', (ev) => {
       if (!this.rovingDeclared) return;
-      const op = this.resolveRovingKeyOperation(ev?.detail);
+      const op = this.resolveRovingKeyOperation(ev);
       if (!op) return;
 
       const entry = this.createCenterEntry();
@@ -513,7 +512,7 @@ class FocusModuleImpl extends ModuleBase {
       const handled = FOCUS_CENTER.focusInRoving(entry, op, { requireFocusedMember: true });
       if (!handled) return;
 
-      this.eventPort.requestDefaultActionPrevented(ev, {
+      ev.control.requestDefaultActionPrevention({
         reason: 'focus.roving.keyboard',
         source: this.prototypeName,
       });

--- a/packages/modules/overlay/src/impl.ts
+++ b/packages/modules/overlay/src/impl.ts
@@ -161,7 +161,7 @@ export class OverlayModuleImpl extends ModuleBase {
       this.escapeSamplingInstalled = true;
       this.eventPort.onGlobal('key.down', (event) => {
         if (!this.isOpen() || !this.config.closeOnEscape) return;
-        if (event?.detail?.key !== 'Escape') return;
+        if (event.key !== 'Escape') return;
         this.close('escape');
       });
     }

--- a/packages/prototypes/base/src/behaviors/use-typeahead-navigation.ts
+++ b/packages/prototypes/base/src/behaviors/use-typeahead-navigation.ts
@@ -34,7 +34,7 @@ export const useTypeaheadNavigation = defineHook<any, {}, {}, TypeaheadNavigatio
 
       def.event.onGlobal('key.down', (run, ev) => {
         if (!options.isEnabled(run)) return;
-        const detail = ev?.detail;
+        const detail = ev;
         const key = detail?.key;
         if (typeof key !== 'string' || key.length !== 1) return;
         if (detail?.ctrlKey || detail?.metaKey || detail?.altKey) return;

--- a/packages/prototypes/base/src/button/button.proto.ts
+++ b/packages/prototypes/base/src/button/button.proto.ts
@@ -78,13 +78,18 @@ function setupButton(def: DefHandle<ButtonProps, ButtonExposes>): void {
   // P-BASE-BUTTON-ACCESSIBLE-NAME, P-BASE-BUTTON-CONTENT-LABEL-SOURCE
   def.a11y.nameFromContent();
 
-  // P-BASE-BUTTON-KEYBOARD-ACTIVATION, P-BASE-BUTTON-KEYBOARD-SPACE-PREVENT-DEFAULT
+  // P-BASE-BUTTON-KEYBOARD-ACTIVATION, P-BASE-BUTTON-KEYBOARD-SPACE-PREVENT-DEFAULT,
+  // HC-DEFAULT-ACTION-0001: prevention is requested through the portable
+  // control facade, never through a raw host preventDefault function.
   def.event.onGlobal('key.down', (_run, ev) => {
     const detail = ev?.detail;
     if (disabled.get()) return;
     if (!focused.get()) return;
     if (detail?.key !== ' ') return;
-    detail?.preventDefault?.();
+    detail?.control?.requestDefaultActionPrevention({
+      reason: 'button.space-activation',
+      source: 'base-button',
+    });
   });
 
   // P-BASE-BUTTON-POINTER-HOVER

--- a/packages/prototypes/base/src/button/button.proto.ts
+++ b/packages/prototypes/base/src/button/button.proto.ts
@@ -82,11 +82,11 @@ function setupButton(def: DefHandle<ButtonProps, ButtonExposes>): void {
   // HC-DEFAULT-ACTION-0001: prevention is requested through the portable
   // control facade, never through a raw host preventDefault function.
   def.event.onGlobal('key.down', (_run, ev) => {
-    const detail = ev?.detail;
+    const detail = ev;
     if (disabled.get()) return;
     if (!focused.get()) return;
     if (detail?.key !== ' ') return;
-    detail?.control?.requestDefaultActionPrevention({
+    ev.control.requestDefaultActionPrevention({
       reason: 'button.space-activation',
       source: 'base-button',
     });

--- a/packages/prototypes/base/src/checkbox/root.proto.ts
+++ b/packages/prototypes/base/src/checkbox/root.proto.ts
@@ -3,17 +3,8 @@ import { asFocusable, asTrigger } from '@proto.ui/hooks';
 import { CHECKBOX_CONTEXT, CHECKBOX_FAMILY } from './shared';
 import type { CheckboxRootAsHookContract, CheckboxRootExposes, CheckboxRootProps } from './types';
 
-function getKeyboardEventFromProtoEvent(ev: unknown): KeyboardEvent | null {
-  const detail = (ev as CustomEvent | undefined)?.detail ?? ev;
-  if (detail instanceof KeyboardEvent) return detail;
-  if (!detail || typeof detail !== 'object') return null;
-  const native = (detail as { nativeEvent?: unknown }).nativeEvent;
-  return native instanceof KeyboardEvent ? native : null;
-}
-
-function isEnterKeyboardCommit(ev: unknown): boolean {
-  const native = getKeyboardEventFromProtoEvent(ev);
-  return native?.key === 'Enter';
+function isEnterKeyboardCommit(ev: { key?: unknown } | undefined): boolean {
+  return ev?.key === 'Enter';
 }
 
 function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes>): void {
@@ -174,11 +165,14 @@ function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes
   // P-BASE-CHECKBOX-KEYBOARD-SPACE-ACTIVATION, P-BASE-CHECKBOX-KEYBOARD-ENTER-NOT-ACTIVATION
   // P-BASE-CHECKBOX-KEYBOARD-SPACE-PREVENT-DEFAULT
   def.event.onGlobal('key.down', (_run, ev) => {
-    const detail = ev?.detail;
+    const detail = ev;
     if (disabled.get()) return;
     if (!focused.get()) return;
     if (detail?.key !== ' ') return;
-    detail?.preventDefault?.();
+    ev.control.requestDefaultActionPrevention({
+      reason: 'checkbox.space-activation',
+      source: 'base-checkbox',
+    });
   });
 
   // P-BASE-CHECKBOX-POINTER-HOVER

--- a/packages/prototypes/base/src/dialog/close.proto.ts
+++ b/packages/prototypes/base/src/dialog/close.proto.ts
@@ -29,7 +29,7 @@ function setupDialogClose(def: DefHandle<DialogCloseProps, DialogCloseExposes>):
   def.event.on('press.commit', (run, ev) => {
     // P-BASE-DIALOG-CLOSE-REQUEST, P-BASE-DIALOG-CLOSE-DISABLED
     if (command.disabled.get()) return;
-    const returnFocusReason: DialogOpenFocusReason = ev?.detail?.key ? 'keyboard' : 'pointer';
+    const returnFocusReason: DialogOpenFocusReason = ev?.key ? 'keyboard' : 'pointer';
     requestDialogOpen(run, false, 'close.press', returnFocusReason);
   });
 }

--- a/packages/prototypes/base/src/dialog/command.ts
+++ b/packages/prototypes/base/src/dialog/command.ts
@@ -61,9 +61,12 @@ export function setupDialogCommand(
 
   def.event.onGlobal('key.down', (_run, ev) => {
     // P-BASE-DIALOG-TRIGGER-COMMAND, P-BASE-DIALOG-CLOSE-COMMAND
-    const detail = ev?.detail;
+    const detail = ev;
     if (disabled.get() || !focused.get() || detail?.key !== ' ') return;
-    detail?.preventDefault?.();
+    ev.control.requestDefaultActionPrevention({
+      reason: `${reasonPrefix}.space-activation`,
+      source: reasonPrefix,
+    });
   });
   def.event.on('pointer.enter', () => {
     // P-BASE-DIALOG-TRIGGER-COMMAND, P-BASE-DIALOG-CLOSE-COMMAND

--- a/packages/prototypes/base/src/dialog/trigger.proto.ts
+++ b/packages/prototypes/base/src/dialog/trigger.proto.ts
@@ -51,7 +51,7 @@ function setupDialogTrigger(def: DefHandle<DialogTriggerProps, DialogTriggerExpo
     // P-BASE-DIALOG-TRIGGER-REQUEST, P-BASE-DIALOG-TRIGGER-DISABLED
     const ctx = run.context.read(DIALOG_CONTEXT);
     if (command.disabled.get()) return;
-    const openFocusReason: DialogOpenFocusReason = ev?.detail?.key ? 'keyboard' : 'pointer';
+    const openFocusReason: DialogOpenFocusReason = ev?.key ? 'keyboard' : 'pointer';
     requestDialogOpen(run, !ctx.open, 'trigger.press', openFocusReason);
   });
 }

--- a/packages/prototypes/base/src/dropdown/command.ts
+++ b/packages/prototypes/base/src/dropdown/command.ts
@@ -62,9 +62,12 @@ export function setupDropdownCommand(
   };
 
   def.event.on('key.down', (_run, ev) => {
-    const detail = ev?.detail;
+    const detail = ev;
     if (disabled.get() || !focused.get() || detail?.key !== ' ') return;
-    detail?.preventDefault?.();
+    ev.control.requestDefaultActionPrevention({
+      reason: `${reasonPrefix}.space-activation`,
+      source: reasonPrefix,
+    });
   });
   def.event.on('pointer.enter', () => {
     if (!disabled.get()) hovered.set(true, `reason: ${reasonPrefix} pointer.enter`);

--- a/packages/prototypes/base/src/dropdown/content.proto.ts
+++ b/packages/prototypes/base/src/dropdown/content.proto.ts
@@ -269,7 +269,7 @@ function setupDropdownContent(
     const ctx = readContext(run);
     if (!ctx) return;
     if (!ctx.open || ctx.disabled) return;
-    const key = ev?.detail?.key;
+    const key = ev?.key;
     if (key !== 'Tab') return;
     if (!getNavigationEntries(run).some((entry: any) => entry.focused)) return;
     // P-BASE-DROPDOWN-MENU-CONTENT-DISMISS: do not prevent host traversal.

--- a/packages/prototypes/base/src/dropdown/item.proto.ts
+++ b/packages/prototypes/base/src/dropdown/item.proto.ts
@@ -81,7 +81,7 @@ function setupDropdownItem(def: DefHandle<DropdownItemProps, DropdownItemExposes
     // P-BASE-DROPDOWN-MENU-ITEM-SELECT, P-BASE-DROPDOWN-MENU-ITEM-DISABLED
     if (command.disabled.get()) return;
     const ctx = run.context.read(DROPDOWN_CONTEXT);
-    const reason: DropdownFocusReason = ev?.detail?.key ? 'keyboard' : 'pointer';
+    const reason: DropdownFocusReason = ev?.key ? 'keyboard' : 'pointer';
     const value = run.props.get().value ?? '';
     updateActiveValue(run);
     run.expose.emit('select', { value, reason });

--- a/packages/prototypes/base/src/dropdown/trigger.proto.ts
+++ b/packages/prototypes/base/src/dropdown/trigger.proto.ts
@@ -50,7 +50,7 @@ function setupDropdownTrigger(def: DefHandle<DropdownTriggerProps, DropdownTrigg
     // P-BASE-DROPDOWN-MENU-TRIGGER-REQUEST, P-BASE-DROPDOWN-MENU-TRIGGER-DISABLED
     if (command.disabled.get()) return;
     const ctx = run.context.read(DROPDOWN_CONTEXT);
-    const key = ev?.detail?.key;
+    const key = ev?.key;
     const focusReason = key ? 'keyboard' : 'pointer';
     if (key === 'Enter' || key === ' ') {
       requestDropdownOpen(run, true, 'trigger.press', 'keyboard', 'first');
@@ -61,9 +61,12 @@ function setupDropdownTrigger(def: DefHandle<DropdownTriggerProps, DropdownTrigg
 
   def.event.on('key.down', (run, ev) => {
     if (command.disabled.get()) return;
-    const key = ev?.detail?.key;
+    const key = ev?.key;
     if (key !== 'ArrowDown' && key !== 'ArrowUp') return;
-    ev?.detail?.preventDefault?.();
+    ev.control.requestDefaultActionPrevention({
+      reason: 'dropdown.arrow-open',
+      source: 'base-dropdown-trigger',
+    });
 
     const ctx = run.context.read(DROPDOWN_CONTEXT);
     const entry = key === 'ArrowUp' ? 'last' : 'first';

--- a/packages/prototypes/base/src/select/command.ts
+++ b/packages/prototypes/base/src/select/command.ts
@@ -68,8 +68,11 @@ export function setupSelectCommand(
   };
 
   def.event.on('key.down', (_run, ev) => {
-    if (disabled.get() || !focused.get() || ev?.detail?.key !== ' ') return;
-    ev.detail.preventDefault?.();
+    if (disabled.get() || !focused.get() || ev?.key !== ' ') return;
+    ev.control.requestDefaultActionPrevention({
+      reason: `${reasonPrefix}.space-activation`,
+      source: reasonPrefix,
+    });
   });
   def.event.on('pointer.enter', () => {
     if (!disabled.get()) hovered.set(true, `reason: ${reasonPrefix} pointer.enter`);

--- a/packages/prototypes/base/src/select/content.proto.ts
+++ b/packages/prototypes/base/src/select/content.proto.ts
@@ -279,7 +279,7 @@ function setupSelectContent(
   def.event.onGlobal('key.down', (run, ev) => {
     if (store.run !== run) return;
     const ctx = readContext(run);
-    if (!ctx?.open || ctx.disabled || ev?.detail?.key !== 'Tab') return;
+    if (!ctx?.open || ctx.disabled || ev?.key !== 'Tab') return;
     if (!getNavigationEntries(run).some((entry: any) => entry.focused)) return;
     requestSelectOpen(run, { open: false, reason: 'tab', focusReason: 'keyboard' });
   });

--- a/packages/prototypes/base/src/select/item.proto.ts
+++ b/packages/prototypes/base/src/select/item.proto.ts
@@ -112,7 +112,7 @@ function setupSelectItem(def: DefHandle<SelectItemProps, SelectItemExposes>): vo
     if (command.disabled.get()) return;
     const ctx = readContext(run);
     if (!ctx) return;
-    const reason: SelectFocusReason = ev?.detail?.key ? 'keyboard' : 'pointer';
+    const reason: SelectFocusReason = ev?.key ? 'keyboard' : 'pointer';
     const ownValue = run.props.get().value ?? '';
     const ownTextValue = run.props.get().textValue || ownValue;
     updateActiveValue(run);

--- a/packages/prototypes/base/src/select/trigger.proto.ts
+++ b/packages/prototypes/base/src/select/trigger.proto.ts
@@ -43,7 +43,7 @@ function setupSelectTrigger(def: DefHandle<SelectTriggerProps, SelectTriggerExpo
   def.event.on('press.commit', (run, ev) => {
     if (command.disabled.get()) return;
     const ctx = run.context.read(SELECT_CONTEXT);
-    const key = ev?.detail?.key;
+    const key = ev?.key;
     if (key === 'Enter' || key === ' ') {
       requestSelectOpen(run, {
         open: true,
@@ -63,9 +63,12 @@ function setupSelectTrigger(def: DefHandle<SelectTriggerProps, SelectTriggerExpo
 
   def.event.on('key.down', (run, ev) => {
     if (command.disabled.get()) return;
-    const key = ev?.detail?.key;
+    const key = ev?.key;
     if (key !== 'ArrowDown' && key !== 'ArrowUp') return;
-    ev?.detail?.preventDefault?.();
+    ev.control.requestDefaultActionPrevention({
+      reason: 'select.arrow-open',
+      source: 'base-select-trigger',
+    });
     const ctx = run.context.read(SELECT_CONTEXT);
     if (ctx.open) return;
     requestSelectOpen(run, {

--- a/packages/prototypes/base/src/switch/root.proto.ts
+++ b/packages/prototypes/base/src/switch/root.proto.ts
@@ -123,11 +123,14 @@ function setupSwitchRoot(def: DefHandle<SwitchRootProps, SwitchRootExposes>): vo
   // P-BASE-SWITCH-KEYBOARD-SPACE-ACTIVATION, P-BASE-SWITCH-KEYBOARD-ENTER-OPTIONAL
   // P-BASE-SWITCH-KEYBOARD-SPACE-PREVENT-DEFAULT
   def.event.onGlobal('key.down', (_run, ev) => {
-    const detail = ev?.detail;
+    const detail = ev;
     if (disabled.get()) return;
     if (!focused.get()) return;
     if (detail?.key !== ' ') return;
-    detail?.preventDefault?.();
+    ev.control.requestDefaultActionPrevention({
+      reason: 'switch.space-activation',
+      source: 'base-switch',
+    });
   });
 
   // P-BASE-SWITCH-POINTER-HOVER

--- a/packages/prototypes/base/src/tabs/trigger.proto.ts
+++ b/packages/prototypes/base/src/tabs/trigger.proto.ts
@@ -256,11 +256,14 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
 
   def.event.onGlobal('key.down', (_run, ev) => {
     // P-BASE-TABS-TRIGGER-KEYBOARD-ACTIVATION
-    const detail = ev?.detail;
+    const detail = ev;
     if (disabled.get()) return;
     if (!focused.get()) return;
     if (detail?.key !== ' ') return;
-    detail?.preventDefault?.();
+    ev.control.requestDefaultActionPrevention({
+      reason: 'tabs.space-activation',
+      source: 'base-tabs-trigger',
+    });
   });
 
   def.event.on('pointer.enter', () => {

--- a/packages/prototypes/base/src/toggle/toggle.proto.ts
+++ b/packages/prototypes/base/src/toggle/toggle.proto.ts
@@ -102,11 +102,14 @@ function setupToggle(def: DefHandle<ToggleProps, ToggleExposes>): void {
 
   // P-BASE-TOGGLE-KEYBOARD-ACTIVATION, P-BASE-TOGGLE-KEYBOARD-SPACE-PREVENT-DEFAULT
   def.event.onGlobal('key.down', (_run, ev) => {
-    const detail = ev?.detail;
+    const detail = ev;
     if (disabled.get()) return;
     if (!focused.get()) return;
     if (detail?.key !== ' ') return;
-    detail?.preventDefault?.();
+    ev.control.requestDefaultActionPrevention({
+      reason: 'toggle.space-activation',
+      source: 'base-toggle',
+    });
   });
 
   // P-BASE-TOGGLE-POINTER-HOVER

--- a/packages/prototypes/base/src/tools/use-escape-key.ts
+++ b/packages/prototypes/base/src/tools/use-escape-key.ts
@@ -20,7 +20,7 @@ export const useEscapeKey = defineHook<
 
     def.event.onGlobal('key.down', (run, ev) => {
       if (api.store.enabled === false) return;
-      const key = ev?.detail?.key;
+      const key = ev?.key;
       if (key !== 'Escape') return;
 
       const onEscape = api.store.onEscape as

--- a/packages/prototypes/base/test/as-button.test.ts
+++ b/packages/prototypes/base/test/as-button.test.ts
@@ -5,7 +5,11 @@ import { definePrototype } from '@proto.ui/core';
 import type { RuntimeHost } from '@proto.ui/runtime';
 import { executeWithHost } from '@proto.ui/runtime';
 import type { FocusPort } from '@proto.ui/module-focus';
-import { EVENT_GLOBAL_TARGET_CAP, EVENT_ROOT_TARGET_CAP } from '@proto.ui/module-event';
+import {
+  EVENT_CANCEL_DEFAULT_ACTION_CAP,
+  EVENT_GLOBAL_TARGET_CAP,
+  EVENT_ROOT_TARGET_CAP,
+} from '@proto.ui/module-event';
 import { EXPOSE_EVENT_SINK_CAP } from '@proto.ui/module-expose-event';
 import {
   AS_TRIGGER_GET_PROTO_CAP,
@@ -22,6 +26,7 @@ function createHost(initialRaw: Record<string, unknown> = {}) {
   const globalTarget = new EventTarget();
   const emitted: string[] = [];
   const a11ySnapshots: A11ySemanticObjectSnapshot[] = [];
+  const decisions: Array<{ reason?: string; source?: string }> = [];
   let exposes: Record<string, any> | null = null;
 
   const host: RuntimeHost<any> = {
@@ -37,6 +42,10 @@ function createHost(initialRaw: Record<string, unknown> = {}) {
       wiring.attach('event', [
         [EVENT_ROOT_TARGET_CAP, () => rootTarget],
         [EVENT_GLOBAL_TARGET_CAP, () => globalTarget],
+        [
+          EVENT_CANCEL_DEFAULT_ACTION_CAP,
+          (request: { reason?: string; source?: string }) => decisions.push(request),
+        ],
       ]);
       wiring.attach('expose-event', [[EXPOSE_EVENT_SINK_CAP, (key: string) => emitted.push(key)]]);
       wiring.attach('as-trigger', [
@@ -68,6 +77,9 @@ function createHost(initialRaw: Record<string, unknown> = {}) {
     },
     getA11ySnapshot() {
       return a11ySnapshots.at(-1);
+    },
+    getDecisions() {
+      return decisions;
     },
   };
 }
@@ -165,22 +177,26 @@ describe('prototypes/base: asButton', () => {
     ctx.rootTarget.dispatchEvent(new CustomEvent('host:focus'));
     expect(exposes.focused.get()).toBe(true);
 
-    let prevented = false;
+    // HC-DEFAULT-ACTION-0001: the prototype requests prevention through the
+    // portable control facade; the host observes the request through its
+    // cancel-default-action cap, not through a fabricated raw preventDefault.
     ctx.globalTarget.dispatchEvent(
       new CustomEvent('key.down', {
         detail: {
           key: ' ',
           target: ctx.rootTarget,
-          preventDefault: () => {
-            prevented = true;
-          },
         },
       })
     );
 
-    expect(prevented).toBe(true);
+    expect(ctx.getDecisions()).toEqual([
+      {
+        reason: 'button.space-activation',
+        source: 'base-button',
+        event: expect.anything(),
+      },
+    ]);
   });
-
   it('keeps base-button and asButton aligned as Button authoring entries', () => {
     // T-BASE-BUTTON-0001-CASE-AUTHORING-ENTRIES
     // T-BASE-BUTTON-0001-CASE-DEFERRED-SURFACES

--- a/packages/runtime/src/kernel/handles/def.ts
+++ b/packages/runtime/src/kernel/handles/def.ts
@@ -1,9 +1,19 @@
 // packages/runtime/src/kernel/handles/def.ts
-import { type DefHandle, type RunHandle, type StyleHandle } from '@proto.ui/core';
+import {
+  type DefHandle,
+  type ProtoEventCallback,
+  type RunHandle,
+  type StyleHandle,
+} from '@proto.ui/core';
 import { getAsHookRuntime } from '@proto.ui/core/internal';
 import { illegalPhase } from '../guard';
 import type { RuleSpec, RuleFacade } from '@proto.ui/module-rule';
-import type { ExposeEventSpec, PropsBaseType } from '@proto.ui/types';
+import type {
+  EventTypeV0,
+  ExposeEventSpec,
+  HostEventListenerOptions,
+  PropsBaseType,
+} from '@proto.ui/types';
 import type { ModuleOrchestratorFacadeView } from '../../orchestrator/module-orchestrator/types';
 import type { FeedbackFacade } from '@proto.ui/module-feedback';
 import type { PropsFacade } from '@proto.ui/module-props';
@@ -214,9 +224,13 @@ export const createDefHandle = <P extends PropsBaseType, E = Record<string, unkn
     },
 
     event: {
-      on: (type, cb, options) => {
+      on: ((
+        type: EventTypeV0,
+        cb: ProtoEventCallback<P, unknown>,
+        options?: HostEventListenerOptions
+      ) => {
         ensureSetup(`def.event.on`);
-        const token = eventFacade.on(type, options);
+        const token = eventFacade.on(type as `host:${string}`, options);
         eventCallbacks.register((token as any).id, cb);
         const off = () => {
           const id = (token as any)?.id;
@@ -226,11 +240,15 @@ export const createDefHandle = <P extends PropsBaseType, E = Record<string, unkn
         };
         recordCaptured(def, 'event', { token, off });
         return token;
-      },
+      }) as DefHandle<P>['event']['on'],
 
-      onGlobal: (type, cb, options) => {
+      onGlobal: ((
+        type: EventTypeV0,
+        cb: ProtoEventCallback<P, unknown>,
+        options?: HostEventListenerOptions
+      ) => {
         ensureSetup(`def.event.onGlobal`);
-        const token = eventFacade.onGlobal(type, options);
+        const token = eventFacade.onGlobal(type as `host:${string}`, options);
         eventCallbacks.register((token as any).id, cb);
         const off = () => {
           const id = (token as any)?.id;
@@ -240,7 +258,7 @@ export const createDefHandle = <P extends PropsBaseType, E = Record<string, unkn
         };
         recordCaptured(def, 'event', { token, off });
         return token;
-      },
+      }) as DefHandle<P>['event']['onGlobal'],
 
       off: (token) => {
         ensureSetup(`def.event.off`);

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -27,19 +27,22 @@ export const OPTIONAL_EVENT_TYPES = [
 ] as const;
 
 export type OptionalEventType = (typeof OPTIONAL_EVENT_TYPES)[number];
+export type SemanticEventType = CoreEventType | OptionalEventType;
 
 export type ExtensionEventType = `host:${string}`;
 
-export type EventTypeV0 = CoreEventType | OptionalEventType | ExtensionEventType;
+export type EventTypeV0 = SemanticEventType | ExtensionEventType;
 
 /**
  * Listener options for `host:*` extension events only. This is deliberately
  * host-shaped: portable semantic registrations (the CORE/OPTIONAL types) do
  * not accept DOM capture/passive/once options — see C-EVENT-0002.
  */
-export type HostEventListenerOptions = AddEventListenerOptions;
-
-export type EventListenerOptions = HostEventListenerOptions;
+export type HostEventListenerOptions = Readonly<{
+  capture?: boolean;
+  once?: boolean;
+  passive?: boolean;
+}>;
 
 export type DefaultActionRequestOptions = Readonly<{
   /** Machine-readable cause, e.g. `button.space-activation`. */
@@ -59,15 +62,21 @@ export type ProtoEventControl = Readonly<{
   requestDefaultActionPrevention(options?: DefaultActionRequestOptions): void;
 }>;
 
-export type ProtoEventPayload = {
-  type: CoreEventType | OptionalEventType;
+/**
+ * Immutable, data-only view constructed for one portable Event callback.
+ * It never aliases or mutates a native event/detail object. `control` is live
+ * only during the synchronous callback invocation that receives this view.
+ */
+export type ProtoEventPayload = Readonly<{
+  type: EventTypeV0;
   key?: string;
-  target?: unknown;
-  nativeEvent?: unknown;
-  preventDefault?: () => void;
-  stopPropagation?: () => void;
-  control?: ProtoEventControl;
-};
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  altKey?: boolean;
+  shiftKey?: boolean;
+  repeat?: boolean;
+  control: ProtoEventControl;
+}>;
 
 export type ExposeEventSpec = {
   payload?: 'void' | 'any' | 'json';

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -32,7 +32,32 @@ export type ExtensionEventType = `host:${string}`;
 
 export type EventTypeV0 = CoreEventType | OptionalEventType | ExtensionEventType;
 
-export type EventListenerOptions = any;
+/**
+ * Listener options for `host:*` extension events only. This is deliberately
+ * host-shaped: portable semantic registrations (the CORE/OPTIONAL types) do
+ * not accept DOM capture/passive/once options — see C-EVENT-0002.
+ */
+export type HostEventListenerOptions = AddEventListenerOptions;
+
+export type EventListenerOptions = HostEventListenerOptions;
+
+export type DefaultActionRequestOptions = Readonly<{
+  /** Machine-readable cause, e.g. `button.space-activation`. */
+  reason?: string;
+  /** Owning prototype or module, e.g. `base-button`. */
+  source?: string;
+}>;
+
+/**
+ * Portable default-action control handed to prototype event callbacks.
+ * Requests are tied to the current interaction sample; the adapter projects
+ * them through HC-DEFAULT-ACTION-0001 instead of a raw native function.
+ * Raw `preventDefault`/`stopPropagation` on the payload remain host escape
+ * hatches and must not be depended on by portable prototype code.
+ */
+export type ProtoEventControl = Readonly<{
+  requestDefaultActionPrevention(options?: DefaultActionRequestOptions): void;
+}>;
 
 export type ProtoEventPayload = {
   type: CoreEventType | OptionalEventType;
@@ -41,6 +66,7 @@ export type ProtoEventPayload = {
   nativeEvent?: unknown;
   preventDefault?: () => void;
   stopPropagation?: () => void;
+  control?: ProtoEventControl;
 };
 
 export type ExposeEventSpec = {

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -55,8 +55,8 @@ export type DefaultActionRequestOptions = Readonly<{
  * Portable default-action control handed to prototype event callbacks.
  * Requests are tied to the current interaction sample; the adapter projects
  * them through HC-DEFAULT-ACTION-0001 instead of a raw native function.
- * Raw `preventDefault`/`stopPropagation` on the payload remain host escape
- * hatches and must not be depended on by portable prototype code.
+ * Portable payloads never carry native preventDefault/stopPropagation methods;
+ * raw native methods are available only to explicit `host:*` extension callbacks.
  */
 export type ProtoEventControl = Readonly<{
   requestDefaultActionPrevention(options?: DefaultActionRequestOptions): void;

--- a/spec/modules/M-EVENT-0001.yaml
+++ b/spec/modules/M-EVENT-0001.yaml
@@ -48,8 +48,16 @@ criteria:
       en: '`EventFacade` must contain only the Event-channel-owned `EventChannelFacade`. Event-package exports of `ExposeEventFacade`, `EXPOSE_EVENT_SINK_CAP`, and legacy `EVENT_EMIT_CAP` may exist only as deprecated source re-exports; Adapters must wire the sink to `expose-event`, and legacy `event` wiring must produce a migration diagnostic rather than masquerade as Expose Event support.'
   - id: M-EVENT-0001-I
     text:
-      zh-CN: 一次 runtime binding attempt 必须在添加该次 attempt 的任何 host listener 前，为全部当前未绑定 registration 解析 target；若 target resolution 失败，该次 attempt 不得新增 host listener，target 可用后显式 bind retry 必须能够重试完整 registration set。该准则不要求失败后由 capability epoch 自动 retry，也不规定 listener attachment 或 cleanup 自身抛错时的事务语义；explicit unbind 后不得仅因 capability epoch 重新绑定。
-      en: A runtime binding attempt must resolve targets for every currently unbound registration before adding any host listener for that attempt; if target resolution fails, the attempt must add no host listener, and an explicit bind retry must be able to retry the complete registration set after targets become available. This criterion does not require automatic retry on a capability epoch after failure and does not define transactional semantics when listener attachment or cleanup itself throws; an explicit unbind must not rebind solely because of a capability epoch.
+      zh-CN: 一次 runtime binding attempt 必须在添加该次 attempt 的任何 host listener 前，为全部当前未绑定 registration 解析 target；若 target resolution 失败，该次 attempt 不得新增 host listener，target 可用后显式 bind retry 必须能够重试完整 registration set。该准则不要求失败后由 capability epoch 自动 retry；explicit unbind 后不得仅因 capability epoch 重新绑定。listener attachment 或 cleanup 抛错时的事务语义由 M-EVENT-0001-J 定义。
+      en: A runtime binding attempt must resolve targets for every currently unbound registration before adding any host listener for that attempt; if target resolution fails, the attempt must add no host listener, and an explicit bind retry must be able to retry the complete registration set after targets become available. This criterion does not require automatic retry on a capability epoch after failure; an explicit unbind must not rebind solely because of a capability epoch. Transactional semantics when listener attachment or cleanup throws are defined by M-EVENT-0001-J.
+  - id: M-EVENT-0001-J
+    text:
+      zh-CN: >-
+        listener attachment 失败时，runtime 必须回滚本次 binding attempt 已建立的全部 host listener，并保证每个受影响 registration 保持逻辑 unbound（diagnostics 记为 unbound），显式 bind retry 能完整重装。cleanup/unbind 必须幂等：重复 cleanup 不得遗留 listener。rollback 的 removeEventListener 自身失败不得掩盖原始 attachment 错误，并必须 fail closed（不得让部分 listener 视为已绑定）。portable 事件 callback 收到的是 data-only、immutable 的新 view，不得 alias 或修改 host event/detail；default-action control 仅在当前同步 callback window 内有效，window 结束后调用须 fail closed；同一 host sample 的多次 default-action request 在宿主边界去重。semantic（非 host:*）registration 不得携带 DOM listener options。宿主绑定事件保持 raw host event。
+
+      en: >-
+        When listener attachment fails, the runtime must roll back every host listener already attached by that binding attempt, keep each affected registration logically unbound (reported as unbound in diagnostics), and let an explicit bind retry reinstall the full set. Cleanup/unbind must be idempotent: repeated cleanup must not leave listeners behind. A rollback removeEventListener failure must not mask the original attachment error and must fail closed (no partial listener set may be treated as bound). A portable event callback receives a new, immutable, data-only view and must never alias or mutate the host event/detail; the default-action control is live only for the current synchronous callback window, and a call after the window must fail closed; multiple default-action requests for the same host sample are deduplicated at the host boundary. Semantic (non-host:*) registrations must not carry DOM listener options. Host-bound events stay raw host events.
+
 satisfies:
   contracts:
     - C-EVENT-0001
@@ -116,6 +124,10 @@ openQuestions:
       en: The current Runtime installs the Event module and every official Web profile supports it; because no host cap is needed without registrations, package installation and an actual host requirement are not equivalent.
     blocks: [configurable-runtime-module-selection, adapter-module-omission-diagnostics]
 revisions:
+  - version: 0.3.0-alpha.0
+    change: refined
+    summary: Defined transactional attach rollback with fail-closed unbound state, idempotent cleanup, immutable data-only portable payload with window-bounded and deduplicated default-action control, and semantic registration options rejection.
+
   - version: 0.3.0-alpha.0
     change: revised
     summary: Removed the Expose Event implementation and composite facade from Event while retaining only deprecated source re-exports for migration.

--- a/spec/tests/T-EVENT-0003.yaml
+++ b/spec/tests/T-EVENT-0003.yaml
@@ -58,6 +58,21 @@ cases:
       - A-VUE-3-0001-E
       - A-WEB-COMPONENT-0001-E
     expectation: cancelable-dom-event-receives-prevent-default
+  - id: T-EVENT-0003-CASE-TRANSACTIONAL-ROLLBACK
+    title: Failed attachment rolls back prior listeners, keeps registrations unbound, and retries the full plan
+    covers:
+      - M-EVENT-0001-J
+    expectation: attachment-failure-rolls-back-and-keeps-diagnostics-unbound-then-retries-complete
+  - id: T-EVENT-0003-CASE-PORTABLE-PAYLOAD
+    title: Portable callbacks receive an immutable data-only view whose control is window-bounded and deduplicated
+    covers:
+      - M-EVENT-0001-J
+    expectation: immutable-data-only-payload-with-synchronous-window-bounded-and-deduplicated-default-action-control
+  - id: T-EVENT-0003-CASE-HOST-OPTIONS-BOUNDARY
+    title: Semantic registrations reject DOM listener options while host extensions stay raw host events
+    covers:
+      - M-EVENT-0001-J
+    expectation: semantic-registration-rejects-options-and-portable-payload-awaits-host-extensions
   - id: T-EVENT-0003-CASE-EXPOSE-BOUNDARY
     title: Expose Event implementation and wiring remain outside the Event Module
     covers:
@@ -82,6 +97,9 @@ implementations:
       - T-EVENT-0003-CASE-REQUIRED-CONDITIONAL-BINDING
       - T-EVENT-0003-CASE-REBIND-CLEANUP
       - T-EVENT-0003-CASE-BIND-TARGET-PREFLIGHT
+      - T-EVENT-0003-CASE-TRANSACTIONAL-ROLLBACK
+      - T-EVENT-0003-CASE-PORTABLE-PAYLOAD
+      - T-EVENT-0003-CASE-HOST-OPTIONS-BOUNDARY
       - T-EVENT-0003-CASE-DEFAULT-ACTION-REQUEST
   - id: module-event-expose-wiring-migration-contract
     kind: module-test

--- a/spec/tests/T-EVENT-0003.yaml
+++ b/spec/tests/T-EVENT-0003.yaml
@@ -97,17 +97,17 @@ implementations:
       - T-EVENT-0003-CASE-REQUIRED-CONDITIONAL-BINDING
       - T-EVENT-0003-CASE-REBIND-CLEANUP
       - T-EVENT-0003-CASE-BIND-TARGET-PREFLIGHT
-      - T-EVENT-0003-CASE-TRANSACTIONAL-ROLLBACK
-      - T-EVENT-0003-CASE-PORTABLE-PAYLOAD
-      - T-EVENT-0003-CASE-HOST-OPTIONS-BOUNDARY
       - T-EVENT-0003-CASE-DEFAULT-ACTION-REQUEST
-  - id: module-event-expose-wiring-migration-contract
+  - id: module-event-impl-spec-contract
     kind: module-test
     status: passing
     path: packages/modules/event/test/impl-spec.test.ts
     required: true
     consumesCases:
       - T-EVENT-0003-CASE-EXPOSE-BOUNDARY
+      - T-EVENT-0003-CASE-TRANSACTIONAL-ROLLBACK
+      - T-EVENT-0003-CASE-PORTABLE-PAYLOAD
+      - T-EVENT-0003-CASE-HOST-OPTIONS-BOUNDARY
   - id: runtime-required-event-module
     kind: runtime-test
     status: passing
@@ -182,6 +182,7 @@ verifies:
         - M-EVENT-0001-G
         - M-EVENT-0001-H
         - M-EVENT-0001-I
+        - M-EVENT-0001-J
   hostCaps:
     - id: HC-EVENT-BINDING-0001
       anchors:


### PR DESCRIPTION
## Summary

Implements **PR 1** from the #466 third-pass investigation, which the thread identified as the top code priority before any GPUI renderer work.

## What changed

1. **Transactional listener installation.** `EventKernel.bindAll()` now rolls back every earlier attachment when a later addEventListener throws, leaving all registrations logically unbound so an explicit retry installs the complete plan. Previously only target *resolution* was preflighted; a mid-plan attachment failure leaked earlier listeners.
2. **Portable immutable data-only payload.** Event boundary constructs a fresh immutable view for every portable callback. Default-action control (`ev.control`) is live only during the synchronous callback window and fails closed afterward. Multiple registrations for one host sample are deduplicated. Raw native `preventDefault`/`stopPropagation` are never available on portable payloads.
3. **Semantic/host options boundary.** Semantic (non-`host:*`) registrations reject listener options at setup. `@proto.ui/types` no longer depends on DOM `AddEventListenerOptions`.
4. **Base Button migration.** The focused-Space handler now requests prevention via `ev.control`; the contract test asserts through the `EVENT_CANCEL_DEFAULT_ACTION_CAP` collector.
5. **Spec closure.** M-EVENT-0001-J defines transactional rollback, idempotent cleanup, window-bounded control, sample deduplication, and semantic options rejection. T-EVENT-0003 adds three cases.

## Exclusions / residual risk

- No broader Event routing, opaque routes, Focus, or GPUI admission change.
- The immutable payload contract applies only to portable (semantic) events; `host:*` extensions keep raw host events.
- Merge-time tests cannot prove the full default-branch E2E, live OAuth, or failure convergence; these remain post-merge production gates.

## Validation (current head `6f76ed60`)

- Event facade/impl/contract + Adapter Base default-action + Base Button: 4 files / 39 tests passed.
- Event/related broader validation: 87 files / 600 tests passed; browser journeys 19/19.
- `check:types` — 0 errors.
- `check:prototype-catalog` — OK.
- Local actionlint was not independently run; the existing CI lanes remain the required evidence.

## Contribution provenance

- **Original rights:** The Event kernel changes, immutable payload construction, options boundary, Base Button migration, and spec/test updates are original work created for Proto UI. The DCO signer confirms the right to submit them under the repository MIT License.
- **Third-party/upstream:** No code or assets were copied or ported; the implementation relies only on the existing Proto UI Event/Button contracts and public DOM event behavior.
- **Material AI assistance:** An AI coding assistant (OpenAI Codex/GPT-5.6 family via Oh My Pi) materially assisted with implementation, tests, documentation, and review remediation. The human contributor reviewed the diffs and validated the Event tests, Button contract, types/catalog, and broader validation suite. No third-party or private code was supplied to the model.
- **Employer/client:** The signer confirms this contribution is not derived from an employer/client proprietary repository and that they have the right to publish it.