### PR TITLE
fix(spec): update 6 stale test implementation file paths (#543)

### DIFF
--- a/spec/tests/T-DELAY-0001.yaml
+++ b/spec/tests/T-DELAY-0001.yaml
@@ -71,7 +71,7 @@ implementations:
   - id: delay-runtime-fixture
     kind: fixture
     status: planned
-    path: packages/spec/fixtures/src/delay/runtime-delay.ts
+    path: packages/runtime/test/contract/delay.v0.contract.test.ts
     required: true
     consumesCases:
       - T-DELAY-0001-CASE-MINIMUM-DELAY

--- a/spec/tests/T-RULE-0001.yaml
+++ b/spec/tests/T-RULE-0001.yaml
@@ -46,7 +46,7 @@ implementations:
   - id: runtime-rule-declaration-contract
     kind: runtime-test
     status: planned
-    path: packages/runtime/test/contract/rule.declaration.v0.contract.test.ts
+    path: packages/runtime/test/contract/rule.meta.v0.contract.test.ts
     required: true
     consumesCases:
       - T-RULE-0001-CASE-SETUP-ONLY
@@ -55,7 +55,7 @@ implementations:
   - id: module-rule-ir-contract
     kind: module-test
     status: planned
-    path: packages/modules/rule/test/contract/rule-ir.v0.contract.test.ts
+    path: packages/runtime/test/contract/rule.matrix.combine.v0.contract.test.ts
     required: true
     consumesCases:
       - T-RULE-0001-CASE-SPEC-RECORDING

--- a/spec/tests/T-RULE-INTENT-0001.yaml
+++ b/spec/tests/T-RULE-INTENT-0001.yaml
@@ -29,7 +29,7 @@ implementations:
   - id: runtime-rule-intent-contract
     kind: runtime-test
     status: planned
-    path: packages/runtime/test/contract/rule.intent.v0.contract.test.ts
+    path: packages/runtime/test/contract/rule.matrix.intent.v0.contract.test.ts
     required: true
     consumesCases:
       - T-RULE-INTENT-0001-CASE-RECORDS-OPS

--- a/spec/tests/T-RULE-INTENT-FEEDBACK-STYLE-0001.yaml
+++ b/spec/tests/T-RULE-INTENT-FEEDBACK-STYLE-0001.yaml
@@ -56,7 +56,7 @@ implementations:
   - id: runtime-rule-feedback-style-contract
     kind: runtime-test
     status: planned
-    path: packages/runtime/test/contract/rule.feedback-style.v0.contract.test.ts
+    path: packages/runtime/test/contract/feedback.style.setup-only.v0.contract.test.ts
     required: true
     consumesCases:
       - T-RULE-INTENT-FEEDBACK-STYLE-0001-CASE-HANDLE-CONSTRAINTS

--- a/spec/tests/T-RULE-WHEN-0001.yaml
+++ b/spec/tests/T-RULE-WHEN-0001.yaml
@@ -34,7 +34,7 @@ implementations:
   - id: runtime-rule-when-expression-contract
     kind: runtime-test
     status: planned
-    path: packages/runtime/test/contract/rule.when.expression.v0.contract.test.ts
+    path: packages/runtime/test/contract/rule.matrix.when.v0.contract.test.ts
     required: true
     consumesCases:
       - T-RULE-WHEN-0001-CASE-PURITY


### PR DESCRIPTION
## Summary

Closes #543. Update 6 stale test implementation file paths in T-* spec entities.

## Changes

- T-DELAY-0001: `packages/spec/fixtures/src/delay/runtime-delay.ts` → `packages/runtime/test/contract/delay.v0.contract.test.ts`
- T-RULE-0001: `rule.declaration.v0` → `rule.meta.v0`, `rule-ir.v0` → `rule.matrix.combine.v0`
- T-RULE-INTENT-0001: `rule.intent.v0` → `rule.matrix.intent.v0`
- T-RULE-INTENT-FEEDBACK-STYLE-0001: `rule.feedback-style.v0` → `feedback.style.setup-only.v0`
- T-RULE-WHEN-0001: `rule.when.expression.v0` → `rule.matrix.when.v0`

## Validation

- `check:prototype-catalog` — OK.
- All 6 referenced paths now exist.
- 0 remaining stale paths.

## Contribution provenance

- Original rights: Path corrections are original work. DCO signer confirms MIT.
- Third-party/upstream: No code copied.
- Material AI assistance: OpenAI Codex/GPT-5.6 via Oh My Pi.
- Employer/client: Not derived from employer/client code.

Closes #543.