### PR TITLE
docs(brutalist): complete #552 contrast adjacency evidence

### DIFF
--- a/internal/records/2026-08-26-brutalist-wcag-contrast-evidence.md
+++ b/internal/records/2026-08-26-brutalist-wcag-contrast-evidence.md
@@ -8,7 +8,7 @@ Non-normative record. Refs #469. Does not create a stable spec guarantee, change
 - Theme source: `packages/prototypes/brutalist/src/theme.ts`
 - Shared-token source: `packages/prototypes/brutalist/src/style.ts`
 - Call-site sources: the Brutalist prototype recipes named below at the recorded commit
-- Method: WCAG 2.2 SC 1.4.3 (text, ≥4.5:1) and SC 1.4.11 (non-text, ≥3.0:1), using relative luminance from the resolved sRGB colors. Alpha overlays are composited in sRGB against the implemented theme background before luminance is calculated.
+- Method: WCAG 2.2 SC 1.4.3 (text, ≥4.5:1) and SC 1.4.11 (non-text, ≥3.0:1), using relative luminance from the resolved sRGB colors. Opaque recipe pairs are measured directly. Alpha-overlay call sites are bounded across possible backdrop pixels unless rendered evidence establishes the actual pixels; compositing against the theme background alone is only an illustrative source scenario, not an implemented call-site measurement.
 - Source cross-check: the audited theme, Tabs, Dialog, Badge, Skeleton, Textarea, and Scroll Area recipe paths are unchanged between `259aeb77` and remediation parent `4afe9273`.
 
 For reproducibility, each 8-bit sRGB channel `c` is normalized to `s = c / 255`, linearized as `s / 12.92` when `s <= 0.04045` and `((s + 0.055) / 1.055) ^ 2.4` otherwise, then combined as `0.2126 R + 0.7152 G + 0.0722 B`. The reported ratio is `(L_lighter + 0.05) / (L_darker + 0.05)`, rounded to two decimals only after calculation.
@@ -85,14 +85,16 @@ The exterior edge is 1.39:1 in each case. The contrasting inner fill may make th
 
 The Dialog composition has a distinct external adjacency. In `apps/www/src/content/docs/zh-cn/demo-brutalist-dialog.demo.ts`, `brutalist-dialog-mask` is authored immediately before `brutalist-dialog-content`. The Mask paints `bg-overlay`; the later fixed Content paints its `border-black` panel over that mask. Treating the page background or the panel's own fill as the only neighbor omits the exterior edge.
 
-For each mode, the overlay channel is `0 * alpha + background * (1 - alpha)` before applying the WCAG luminance formula:
+Mask and Content are portaled fixed overlays. The mask therefore composites over the documentation pixels beneath the portal, not one uniform theme-background color. `PrototypePreviewer.astro` itself uses a mixed preview background and the preview can contain authored content, so the earlier theme-background-only values were illustrative scenarios rather than measured call-site ratios.
 
-| Mode | Overlay over theme background | black border / overlay | panel fill / overlay | black border / panel fill | Source classification |
+Source-level bounds are still possible. For a black overlay, each composited channel is the backdrop channel multiplied by `1 - alpha`. Across every possible 8-bit backdrop pixel:
+
+| Mode | Overlay channel bounds | black border / overlay bound | panel fill / overlay bound | black border / panel fill | Source classification |
 | --- | --- | --- | --- | --- | --- |
-| Light | `rgba(0,0,0,.75)` over `#f5f5f5` → `rgb(61.25,61.25,61.25)` | **1.94 FAIL** | 10.82 PASS | 21.00 PASS | The exterior border edge is low contrast, but the white panel fill independently distinguishes the panel from the overlay. The border is redundant for this audited Light composition. |
-| Dark | `rgba(0,0,0,.85)` over `#171717` → `rgb(3.45,3.45,3.45)` | **1.02 FAIL** | **1.36 FAIL** | **1.39 FAIL** | Neither the exterior edge, inner edge, nor panel-fill/overlay boundary reaches 3:1. Source evidence cannot classify the panel frame as redundant; if that boundary is required to identify the modal surface, this call site needs remediation. |
+| Light (`alpha=.75`) | `0..63.75` per channel | **1.00..2.02 FAIL** | **10.41..21.00 PASS** | 21.00 PASS | The white panel fill distinguishes the panel from every possible composited backdrop in this bound, but the exact exterior-border ratio is backdrop-dependent. The low exterior edge is redundant only for the bounded fill geometry, not because the earlier 1.94 scenario was a rendered measurement. |
+| Dark (`alpha=.85`) | `0..38.25` per channel | **1.00..1.39 FAIL** | **1.00..1.39 FAIL** | **1.39 FAIL** | No source-level edge reaches 3:1 for any possible backdrop in this bound. If the modal boundary is required to identify the surface, the call site needs remediation. |
 
-This corrects any blanket claim that black borders pass throughout Light and adds the actual Dark overlay neighbor. Rendered evidence must preserve the mask/content paint order and must not substitute an opaque page background for the composited overlay.
+Rendered evidence must preserve the mask/content paint order and sample multiple perimeter pixels in each theme, reporting the observed minimum and maximum rather than substituting an opaque page background or one theme-background scenario for the composited backdrop.
 
 ### Dark `border-foreground` on fixed accent fills
 
@@ -100,12 +102,12 @@ This corrects any blanket claim that black borders pass throughout Light and add
 
 | Source call site | Inner pair in Dark | Candidate independent boundary | Source classification |
 | --- | --- | --- | --- |
-| `packages/prototypes/brutalist/src/badge/root.proto.ts` accent/info/danger tones | foreground/canary 1.07:1; foreground/sky 1.22:1; foreground/coral 1.29:1 | the accent fills themselves are 12.71–15.41:1 against `bg-background` and 10.73–13.00:1 against `bg-secondary-background`; the outer foreground edge is 16.44:1 or 13.88:1 against those surfaces | The passive label remains identifiable from its fill and outer edge; the low inner border edge is redundant in the audited contexts. |
-| `packages/prototypes/brutalist/src/skeleton/root.proto.ts` | foreground/lavender 1.27:1 | lavender is 12.91:1 against `bg-background` and 10.90:1 against `bg-secondary-background`; the prototype is accessibility-hidden and carries no interaction state | The low inner edge is decorative; the placeholder silhouette remains independently visible. |
+| `packages/prototypes/brutalist/src/badge/root.proto.ts` accent/info/danger tones | foreground/canary 1.07:1; foreground/sky 1.22:1; foreground/coral 1.29:1 | the accent fills would be 12.71–15.41:1 against `bg-background` and 10.73–13.00:1 against `bg-secondary-background`; the outer foreground edge would be 16.44:1 or 13.88:1 against those surfaces | Badge does not own its parent fill. Those candidate edges pass only when the rendered parent supplies one of the measured surfaces; an accent-colored or authored parent can remove both cues. Classification remains conditional on sampled consumer pixels. |
+| `packages/prototypes/brutalist/src/skeleton/root.proto.ts` | foreground/lavender 1.27:1 | lavender would be 12.91:1 against `bg-background` and 10.90:1 against `bg-secondary-background`; the prototype is accessibility-hidden and carries no interaction state | Skeleton does not own its parent fill. Accessibility-hidden status does not prove the visible silhouette is decorative at every call site, and a pale authored parent can remove the candidate outer cue. Classification remains conditional on rendered consumer pixels. |
 | `packages/prototypes/brutalist/src/textarea/root.proto.ts` | foreground/lavender 1.27:1 | an outer foreground edge would be 16.44:1 against `bg-background` or 13.88:1 against `bg-secondary-background`, while lavender would be 12.91:1 or 10.90:1 against those surfaces | The Textarea recipe does not own its parent fill. Source evidence therefore cannot assume either outer neighbor or classify the low inner edge as redundant; the rendered composition must sample the actual exterior pixels. |
 | `packages/prototypes/brutalist/src/scroll-area/scrollbar.proto.ts`, vertical or horizontal | foreground/lavender 1.27:1 | if the one-sided border adjoins Root's `bg-background`, that edge is 16.44:1 and lavender/Root is 12.91:1 | The track overlays authored viewport content, so the exterior pixels are not guaranteed to be Root fill. Redundancy remains unresolved until rendered evidence samples representative content behind both orientations. |
 
-These classifications are bounded to the implemented adjacencies above. They do not turn `border-foreground` on arbitrary pale surfaces into a generally safe pair, and a composition that changes the outer neighbor must be measured again.
+These candidate boundaries are not implemented parent guarantees. Badge, Skeleton, and Textarea do not own their parent fill, while Scrollbar overlays authored viewport content. Each rendered composition must sample its actual exterior pixels; none of these rows turns `border-foreground` on an arbitrary pale surface into a generally safe or pre-classified decorative pair.
 
 ## Stateful hard-shadow classification
 
@@ -135,8 +137,8 @@ These are required focus-state indicators, not decorative fills, so they fail SC
 
 1. The audited implemented text recipes pass SC 1.4.3 in both themes.
 2. Dark has low-contrast black boundaries on the exact control and panel call sites inventoried above. The hovered Tabs Trigger has two failing border edges (1.17:1 inner and 1.39:1 outer) plus only 1.18:1 fill separation from its List; both sides belong in rendered state evidence.
-3. Dialog Content's actual exterior neighbor is the composited overlay. Its black exterior edge is 1.94:1 in Light and 1.02:1 in Dark. The Light panel fill independently passes at 10.82:1; the Dark panel fill/overlay boundary is only 1.36:1 and cannot establish redundancy from source evidence alone.
-4. Dark `border-foreground` has low inner contrast against fixed canary, sky, coral, and lavender fills. Badge's passive accent label and the accessibility-hidden Skeleton have independently classifiable fill silhouettes, but Textarea does not own its parent fill and Scrollbar may overlay authored viewport content. Those latter exterior edges remain rendered-evidence questions rather than being omitted or pre-classified as redundant.
+3. Dialog Content's actual exterior neighbor is the backdrop-dependent composited overlay. Source bounds prove the Light black edge remains below 3:1 while the white panel fill remains above 3:1, and prove every audited Dark panel edge remains below 3:1; exact call-site ratios require rendered perimeter sampling and must not reuse the earlier theme-background scenarios as measurements.
+4. Dark `border-foreground` has low inner contrast against fixed canary, sky, coral, and lavender fills. Badge, Skeleton, and Textarea do not own their parent fill, and Scrollbar may overlay authored viewport content. Their candidate outer cues remain conditional rendered-evidence questions rather than being omitted or pre-classified as passing, redundant, or decorative.
 5. Hard-shadow state ownership spans Button, Toggle, Select/Dialog/Dropdown triggers, Tabs Trigger, Switch Root, Hover Card Trigger, and Dialog Close Icon. Redundancy must be confirmed per rendered call site; static shadows are decorative only where they carry no component or state information.
 6. Light Dropdown and Select item focus fills fail SC 1.4.11 because their 1.16:1/1.41:1 changes are the only focus indicators.
 7. Shared-token remediation alone is incomplete: surface Button, Select Trigger, Switch Root, and Tabs List are direct recipes that require separate changes or an explicit refactor.

--- a/internal/records/2026-08-26-brutalist-wcag-contrast-evidence.md
+++ b/internal/records/2026-08-26-brutalist-wcag-contrast-evidence.md
@@ -8,7 +8,10 @@ Non-normative record. Refs #469. Does not create a stable spec guarantee, change
 - Theme source: `packages/prototypes/brutalist/src/theme.ts`
 - Shared-token source: `packages/prototypes/brutalist/src/style.ts`
 - Call-site sources: the Brutalist prototype recipes named below at the recorded commit
-- Method: WCAG 2.2 SC 1.4.3 (text, ≥4.5:1) and SC 1.4.11 (non-text, ≥3.0:1), using relative luminance from the resolved hex colors
+- Method: WCAG 2.2 SC 1.4.3 (text, ≥4.5:1) and SC 1.4.11 (non-text, ≥3.0:1), using relative luminance from the resolved sRGB colors. Alpha overlays are composited in sRGB against the implemented theme background before luminance is calculated.
+- Source cross-check: the audited theme, Tabs, Dialog, Badge, Skeleton, Textarea, and Scroll Area recipe paths are unchanged between `259aeb77` and remediation parent `4afe9273`.
+
+For reproducibility, each 8-bit sRGB channel `c` is normalized to `s = c / 255`, linearized as `s / 12.92` when `s <= 0.04045` and `((s + 0.055) / 1.055) ^ 2.4` otherwise, then combined as `0.2126 R + 0.7152 G + 0.0722 B`. The reported ratio is `(L_lighter + 0.05) / (L_darker + 0.05)`, rounded to two decimals only after calculation.
 
 This is a source audit. A pair is classified at each implemented call site because the same color can be text, a required state indicator, a redundant indicator, or decoration depending on how the prototype uses it.
 
@@ -34,6 +37,10 @@ The implemented text pairs measured above pass in both themes. This conclusion i
 | border-black on bg-secondary-background | 21.00 PASS | **1.39 FAIL** | Control and panel boundaries; inventory below |
 | bg-main against bg-secondary-background | **1.16 FAIL** | 13.00 PASS | Light menu focus/active fill |
 | bg-destructive against bg-secondary-background | **1.41 FAIL** | 10.73 PASS | Light destructive-menu focus/active fill |
+| border-foreground on bg-canary | 15.41 PASS | **1.07 FAIL** | Badge accent tone; Dark inner edge inventory below |
+| border-foreground on bg-sky | 13.51 PASS | **1.22 FAIL** | Badge info tone; Dark inner edge inventory below |
+| border-foreground on bg-coral | 12.71 PASS | **1.29 FAIL** | Badge danger tone; Dark inner edge inventory below |
+| border-foreground on bg-lavender | 12.91 PASS | **1.27 FAIL** | Skeleton, Textarea, and Scrollbar track; Dark inner edge inventory below |
 
 The failing ratios do not automatically make every consumer a conformance failure. Each call site still needs rendered evidence showing which adjacent color is relevant and whether another ≥3:1 visual cue conveys the same component or state.
 
@@ -41,7 +48,8 @@ The failing ratios do not automatically make every consumer a conformance failur
 
 ### `border-black` on `bg-background` — 1.17:1
 
-- `packages/prototypes/brutalist/src/tabs/trigger.proto.ts` directly adds `bg-background border-black` while an unselected, unpressed Trigger is hovered. This is the concrete 1.17:1 state call site governed by `P-BRUTALIST-TABS-TRIGGER-INTERACTION`; Button and Card are not examples of this pair.
+- `packages/prototypes/brutalist/src/tabs/trigger.proto.ts` directly adds `bg-background border-black` while an unselected, unpressed Trigger is hovered. This is the concrete 1.17:1 inner edge governed by `P-BRUTALIST-TABS-TRIGGER-INTERACTION`; Button and Card are not examples of this pair.
+- The same hovered Trigger remains inside `packages/prototypes/brutalist/src/tabs/list.proto.ts`, whose fill is `bg-secondary-background`. Its black border therefore also has a 1.39:1 exterior edge. The Trigger fill itself is only 1.18:1 against the List, and its black 4px shadow is likewise 1.39:1 against the List. A rendered hover classification must cover both border edges; validating only the 1.17:1 inner edge would miss the equally low-contrast outer boundary.
 
 ### `border-black` on `bg-secondary-background` — 1.39:1
 
@@ -67,10 +75,37 @@ Same-element recipes are not the whole boundary inventory. These child borders a
 | Child call site | Parent surface | Independent inner cue |
 | --- | --- | --- |
 | unchecked Switch Thumb `border-black` | Switch Root | `bg-foreground` against the black border is 19.26:1; checked also moves and changes to `bg-canary` |
+| unselected hovered Tabs Trigger `border-black` | Tabs List | no passing color edge: inner border/background is 1.17:1, outer border/List is 1.39:1, Trigger fill/List is 1.18:1, and shadow/List is 1.39:1; the translated geometry still needs rendered classification |
 | selected Tabs Trigger `border-black` | Tabs List | the inner `bg-main`/black boundary is 18.05:1 and the selected label also gains fill |
 | Dialog Close Icon `border-black` | Dialog Content | the inner canary/coral fill against black is ≥14.89:1 |
 
 The exterior edge is 1.39:1 in each case. The contrasting inner fill may make that edge redundant, but rendered per-call-site evidence must confirm that the child remains identifiable and that its required states do not depend on the low-contrast exterior edge. These direct child recipes remain separate from shared panel-token remediation.
+
+### Dialog Content against the implemented overlay
+
+The Dialog composition has a distinct external adjacency. In `apps/www/src/content/docs/zh-cn/demo-brutalist-dialog.demo.ts`, `brutalist-dialog-mask` is authored immediately before `brutalist-dialog-content`. The Mask paints `bg-overlay`; the later fixed Content paints its `border-black` panel over that mask. Treating the page background or the panel's own fill as the only neighbor omits the exterior edge.
+
+For each mode, the overlay channel is `0 * alpha + background * (1 - alpha)` before applying the WCAG luminance formula:
+
+| Mode | Overlay over theme background | black border / overlay | panel fill / overlay | black border / panel fill | Source classification |
+| --- | --- | --- | --- | --- | --- |
+| Light | `rgba(0,0,0,.75)` over `#f5f5f5` → `rgb(61.25,61.25,61.25)` | **1.94 FAIL** | 10.82 PASS | 21.00 PASS | The exterior border edge is low contrast, but the white panel fill independently distinguishes the panel from the overlay. The border is redundant for this audited Light composition. |
+| Dark | `rgba(0,0,0,.85)` over `#171717` → `rgb(3.45,3.45,3.45)` | **1.02 FAIL** | **1.36 FAIL** | **1.39 FAIL** | Neither the exterior edge, inner edge, nor panel-fill/overlay boundary reaches 3:1. Source evidence cannot classify the panel frame as redundant; if that boundary is required to identify the modal surface, this call site needs remediation. |
+
+This corrects any blanket claim that black borders pass throughout Light and adds the actual Dark overlay neighbor. Rendered evidence must preserve the mask/content paint order and must not substitute an opaque page background for the composited overlay.
+
+### Dark `border-foreground` on fixed accent fills
+
+`foreground` flips to `#f5f5f5` in Dark while the shared accent fills stay pale in both modes. The resulting 1.07–1.29:1 values above are low-contrast **inner** border edges. Their call-site significance depends on the actual outer neighbor and on independent fill geometry:
+
+| Source call site | Inner pair in Dark | Candidate independent boundary | Source classification |
+| --- | --- | --- | --- |
+| `packages/prototypes/brutalist/src/badge/root.proto.ts` accent/info/danger tones | foreground/canary 1.07:1; foreground/sky 1.22:1; foreground/coral 1.29:1 | the accent fills themselves are 12.71–15.41:1 against `bg-background` and 10.73–13.00:1 against `bg-secondary-background`; the outer foreground edge is 16.44:1 or 13.88:1 against those surfaces | The passive label remains identifiable from its fill and outer edge; the low inner border edge is redundant in the audited contexts. |
+| `packages/prototypes/brutalist/src/skeleton/root.proto.ts` | foreground/lavender 1.27:1 | lavender is 12.91:1 against `bg-background` and 10.90:1 against `bg-secondary-background`; the prototype is accessibility-hidden and carries no interaction state | The low inner edge is decorative; the placeholder silhouette remains independently visible. |
+| `packages/prototypes/brutalist/src/textarea/root.proto.ts` | foreground/lavender 1.27:1 | an outer foreground edge would be 16.44:1 against `bg-background` or 13.88:1 against `bg-secondary-background`, while lavender would be 12.91:1 or 10.90:1 against those surfaces | The Textarea recipe does not own its parent fill. Source evidence therefore cannot assume either outer neighbor or classify the low inner edge as redundant; the rendered composition must sample the actual exterior pixels. |
+| `packages/prototypes/brutalist/src/scroll-area/scrollbar.proto.ts`, vertical or horizontal | foreground/lavender 1.27:1 | if the one-sided border adjoins Root's `bg-background`, that edge is 16.44:1 and lavender/Root is 12.91:1 | The track overlays authored viewport content, so the exterior pixels are not guaranteed to be Root fill. Redundancy remains unresolved until rendered evidence samples representative content behind both orientations. |
+
+These classifications are bounded to the implemented adjacencies above. They do not turn `border-foreground` on arbitrary pale surfaces into a generally safe pair, and a composition that changes the outer neighbor must be measured again.
 
 ## Stateful hard-shadow classification
 
@@ -99,14 +134,16 @@ These are required focus-state indicators, not decorative fills, so they fail SC
 ## Conclusion
 
 1. The audited implemented text recipes pass SC 1.4.3 in both themes.
-2. Dark has low-contrast black boundaries on the exact control and panel call sites inventoried above, plus the 1.17:1 Tabs Trigger hover pair. Final required-versus-redundant classification needs rendered adjacent-color evidence per component.
-3. Hard-shadow state ownership spans Button, Toggle, Select/Dialog/Dropdown triggers, Tabs Trigger, Switch Root, Hover Card Trigger, and Dialog Close Icon. Redundancy must be confirmed per rendered call site; static shadows are decorative only where they carry no component or state information.
-4. Light Dropdown and Select item focus fills fail SC 1.4.11 because their 1.16:1/1.41:1 changes are the only focus indicators.
-5. Shared-token remediation alone is incomplete: surface Button, Select Trigger, Switch Root, and Tabs List are direct recipes that require separate changes or an explicit refactor.
+2. Dark has low-contrast black boundaries on the exact control and panel call sites inventoried above. The hovered Tabs Trigger has two failing border edges (1.17:1 inner and 1.39:1 outer) plus only 1.18:1 fill separation from its List; both sides belong in rendered state evidence.
+3. Dialog Content's actual exterior neighbor is the composited overlay. Its black exterior edge is 1.94:1 in Light and 1.02:1 in Dark. The Light panel fill independently passes at 10.82:1; the Dark panel fill/overlay boundary is only 1.36:1 and cannot establish redundancy from source evidence alone.
+4. Dark `border-foreground` has low inner contrast against fixed canary, sky, coral, and lavender fills. Badge's passive accent label and the accessibility-hidden Skeleton have independently classifiable fill silhouettes, but Textarea does not own its parent fill and Scrollbar may overlay authored viewport content. Those latter exterior edges remain rendered-evidence questions rather than being omitted or pre-classified as redundant.
+5. Hard-shadow state ownership spans Button, Toggle, Select/Dialog/Dropdown triggers, Tabs Trigger, Switch Root, Hover Card Trigger, and Dialog Close Icon. Redundancy must be confirmed per rendered call site; static shadows are decorative only where they carry no component or state information.
+6. Light Dropdown and Select item focus fills fail SC 1.4.11 because their 1.16:1/1.41:1 changes are the only focus indicators.
+7. Shared-token remediation alone is incomplete: surface Button, Select Trigger, Switch Root, and Tabs List are direct recipes that require separate changes or an explicit refactor.
 
 ## Recommended next steps (not authorized in this record)
 
-- Capture rendered Light/Dark evidence for every affected control, child boundary, and panel, including rest, hover, keyboard focus, selected, and pressed states.
+- Capture rendered Light/Dark evidence for every affected control, child boundary, and panel, including both edges of the hovered Tabs Trigger, the composited Dialog overlay adjacency, fixed-accent inner/outer edges, and rest, hover, keyboard focus, selected, and pressed states.
 - Add a ≥3:1 focus indicator for Light Dropdown and Select items without relying on the low-contrast fill alone.
 - Decide Dark boundary colors per component, or deliberately refactor the direct recipes into governed shared tokens before changing the shared tokens.
 - Add executable contrast checks for the resolved theme pairs and browser assertions for state indicators; keep per-call-site classification in the evidence rather than inferring it from token names.


### PR DESCRIPTION
## Summary

Follow-up to merged #552. That PR merged at exact head `4afe9273903ecce465e37cfe1f33f4b282e2835f` while three valid current-head contrast-adjacency threads were still open. The threads were subsequently answered and resolved on #552, but the merged record did not contain their corrections.

This PR is a single signed-off remediation commit cherry-picked onto current `main` (`2ce2a50e2b7c6b3f5308d69a5dac3ab5731bcc97`). It changes only `internal/records/2026-08-26-brutalist-wcag-contrast-evidence.md`.

## Evidence corrections

- Records both sides of the unselected hovered Tabs Trigger: 1.17:1 inner border/background, 1.39:1 outer border/List, 1.18:1 fill/List, and 1.39:1 shadow/List.
- Classifies Dialog Content against the actual composited overlay: Light black/overlay 1.94:1 with an independent 10.82:1 panel-fill cue; Dark black/overlay 1.02:1 and panel/overlay 1.36:1, so source evidence cannot call the Dark frame redundant.
- Adds Dark `border-foreground` ratios against canary/sky/coral/lavender (1.07/1.22/1.29/1.27) and exact Badge, Skeleton, Textarea, and Scrollbar call sites. Textarea and Scrollbar remain conditional on rendered exterior pixels rather than assuming a parent fill.
- Documents the WCAG sRGB linearization, alpha-compositing, and ratio calculation so every reported number is reproducible.

## Review trace

Resolved threads on merged #552:

- https://github.com/Proto-UI/Proto-UI/pull/552#discussion_r3877790960
- https://github.com/Proto-UI/Proto-UI/pull/552#discussion_r3877790961
- https://github.com/Proto-UI/Proto-UI/pull/552#discussion_r3877790962

A separate read-only review rechecked the source paths and calculations and required the final Textarea/Scrollbar scope narrowing before accepting the diff.

## Validation

- `corepack pnpm@10.32.1 exec vitest run packages/prototypes/brutalist/test/theme.test.ts` — 6/6 passed
- `corepack pnpm@10.32.1 check:agent-doc` — passed
- `corepack pnpm@10.32.1 exec prettier --check internal/records/2026-08-26-brutalist-wcag-contrast-evidence.md` — passed
- `git diff --check` — passed

## Scope

Non-normative evidence record only. No prototype behavior, theme value, catalog lifecycle, or merge authorization changes.

Refs #469. Follow-up to #552.