### PR TITLE
feat(www): dogfood Proto UI Shadcn controls

### DIFF
--- a/apps/www/src/components/CodeExample.astro
+++ b/apps/www/src/components/CodeExample.astro
@@ -51,10 +51,7 @@ const instanceId = `code-example-${Math.random().toString(36).slice(2)}`;
         hosts.map((host, hostIndex) => {
           const selected = host === activeHost;
           return (
-            <wc-shadcn-button
-              data-site-shadcn-button
-              data-variant="ghost"
-              data-size="sm"
+            <button
               id={`${instanceId}-host-tab-${hostIndex}`}
               type="button"
               role="tab"
@@ -65,7 +62,7 @@ const instanceId = `code-example-${Math.random().toString(36).slice(2)}`;
               tabindex={selected ? 0 : -1}
             >
               {host === 'wc' ? 'Web Components' : host === 'react' ? 'React' : 'Vue'}
-            </wc-shadcn-button>
+            </button>
           );
         })
       }
@@ -94,10 +91,7 @@ const instanceId = `code-example-${Math.random().toString(36).slice(2)}`;
               data-code-file-tabs
             >
               {hostFiles.map((file, fileIndex) => (
-                <wc-shadcn-button
-                  data-site-shadcn-button
-                  data-variant="ghost"
-                  data-size="sm"
+                <button
                   id={`${instanceId}-${hostIndex}-file-tab-${fileIndex}`}
                   type="button"
                   role="tab"
@@ -108,7 +102,7 @@ const instanceId = `code-example-${Math.random().toString(36).slice(2)}`;
                   tabindex={fileIndex === 0 ? 0 : -1}
                 >
                   {file.name}
-                </wc-shadcn-button>
+                </button>
               ))}
             </div>
           </div>
@@ -129,13 +123,10 @@ const instanceId = `code-example-${Math.random().toString(36).slice(2)}`;
 </section>
 
 <script>
-  import { initSiteShadcnControls } from './site-shadcn-controls';
   import { initCodeExamples } from './code-example-client';
 
-  initSiteShadcnControls(document);
   initCodeExamples(document);
   document.addEventListener('astro:page-load', () => {
-    initSiteShadcnControls(document);
     initCodeExamples(document);
   });
 </script>
@@ -179,7 +170,7 @@ const instanceId = `code-example-${Math.random().toString(36).slice(2)}`;
     padding: 0.375rem;
   }
 
-  .code-example__tabs wc-shadcn-button {
+  .code-example__tabs button {
     flex: none;
     border: 0;
     border-radius: 0.375rem;
@@ -193,13 +184,13 @@ const instanceId = `code-example-${Math.random().toString(36).slice(2)}`;
     cursor: pointer;
   }
 
-  .code-example__tabs wc-shadcn-button[aria-selected='true'] {
+  .code-example__tabs button[aria-selected='true'] {
     background: var(--color-background);
     color: var(--color-foreground);
     box-shadow: 0 1px 2px color-mix(in srgb, var(--color-foreground) 12%, transparent);
   }
 
-  .code-example__tabs wc-shadcn-button:focus-visible {
+  .code-example__tabs button:focus-visible {
     outline: 2px solid var(--color-accent);
     outline-offset: 1px;
   }

--- a/apps/www/src/components/CodeExample.astro
+++ b/apps/www/src/components/CodeExample.astro
@@ -51,7 +51,10 @@ const instanceId = `code-example-${Math.random().toString(36).slice(2)}`;
         hosts.map((host, hostIndex) => {
           const selected = host === activeHost;
           return (
-            <button
+            <wc-shadcn-button
+              data-site-shadcn-button
+              data-variant="ghost"
+              data-size="sm"
               id={`${instanceId}-host-tab-${hostIndex}`}
               type="button"
               role="tab"
@@ -62,7 +65,7 @@ const instanceId = `code-example-${Math.random().toString(36).slice(2)}`;
               tabindex={selected ? 0 : -1}
             >
               {host === 'wc' ? 'Web Components' : host === 'react' ? 'React' : 'Vue'}
-            </button>
+            </wc-shadcn-button>
           );
         })
       }
@@ -91,7 +94,10 @@ const instanceId = `code-example-${Math.random().toString(36).slice(2)}`;
               data-code-file-tabs
             >
               {hostFiles.map((file, fileIndex) => (
-                <button
+                <wc-shadcn-button
+                  data-site-shadcn-button
+                  data-variant="ghost"
+                  data-size="sm"
                   id={`${instanceId}-${hostIndex}-file-tab-${fileIndex}`}
                   type="button"
                   role="tab"
@@ -102,7 +108,7 @@ const instanceId = `code-example-${Math.random().toString(36).slice(2)}`;
                   tabindex={fileIndex === 0 ? 0 : -1}
                 >
                   {file.name}
-                </button>
+                </wc-shadcn-button>
               ))}
             </div>
           </div>
@@ -123,10 +129,15 @@ const instanceId = `code-example-${Math.random().toString(36).slice(2)}`;
 </section>
 
 <script>
+  import { initSiteShadcnControls } from './site-shadcn-controls';
   import { initCodeExamples } from './code-example-client';
 
+  initSiteShadcnControls(document);
   initCodeExamples(document);
-  document.addEventListener('astro:page-load', () => initCodeExamples(document));
+  document.addEventListener('astro:page-load', () => {
+    initSiteShadcnControls(document);
+    initCodeExamples(document);
+  });
 </script>
 
 <style>
@@ -168,7 +179,7 @@ const instanceId = `code-example-${Math.random().toString(36).slice(2)}`;
     padding: 0.375rem;
   }
 
-  .code-example__tabs button {
+  .code-example__tabs wc-shadcn-button {
     flex: none;
     border: 0;
     border-radius: 0.375rem;
@@ -182,13 +193,13 @@ const instanceId = `code-example-${Math.random().toString(36).slice(2)}`;
     cursor: pointer;
   }
 
-  .code-example__tabs button[aria-selected='true'] {
+  .code-example__tabs wc-shadcn-button[aria-selected='true'] {
     background: var(--color-background);
     color: var(--color-foreground);
     box-shadow: 0 1px 2px color-mix(in srgb, var(--color-foreground) 12%, transparent);
   }
 
-  .code-example__tabs button:focus-visible {
+  .code-example__tabs wc-shadcn-button:focus-visible {
     outline: 2px solid var(--color-accent);
     outline-offset: 1px;
   }

--- a/apps/www/src/components/InstallCommandCard.astro
+++ b/apps/www/src/components/InstallCommandCard.astro
@@ -120,6 +120,7 @@ const activeManager =
           <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
         </svg>
       </span>
+      <span class="sr-only">Copy command</span>
     </wc-shadcn-button>
   </div>
 
@@ -190,14 +191,16 @@ const activeManager =
       }
 
       tabs.forEach((tab) => {
-        tab.addEventListener('click', () => {
+        tab.addEventListener('click', (event) => {
+          if (!(event instanceof CustomEvent)) return;
           const nextManager = tab.dataset.managerTab;
           if (!nextManager) return;
           setActiveManager(nextManager);
         });
       });
 
-      copyButton.addEventListener('click', async () => {
+      copyButton.addEventListener('click', async (event) => {
+        if (!(event instanceof CustomEvent)) return;
         try {
           await navigator.clipboard.writeText(getCommandNode()?.textContent ?? '');
           copyIcon.innerHTML = successIcon;

--- a/apps/www/src/components/InstallCommandCard.astro
+++ b/apps/www/src/components/InstallCommandCard.astro
@@ -76,7 +76,10 @@ const activeManager =
     <div class="install-command-card__managers" aria-label="Package manager">
       {
         normalizedEntries.map((entry) => (
-          <button
+          <wc-shadcn-button
+            data-site-shadcn-button
+            data-variant="ghost"
+            data-size="sm"
             type="button"
             class:list={[
               'install-command-card__manager',
@@ -86,12 +89,15 @@ const activeManager =
             aria-pressed={entry.manager === activeManager ? 'true' : 'false'}
           >
             {entry.manager}
-          </button>
+          </wc-shadcn-button>
         ))
       }
     </div>
 
-    <button
+    <wc-shadcn-button
+      data-site-shadcn-button
+      data-variant="ghost"
+      data-size="icon"
       type="button"
       class="install-command-card__copy"
       title="Copy command"
@@ -114,7 +120,7 @@ const activeManager =
           <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
         </svg>
       </span>
-    </button>
+    </wc-shadcn-button>
   </div>
 
   {
@@ -139,9 +145,9 @@ const activeManager =
       if (card.dataset.installCommandInit === '1') return;
       card.dataset.installCommandInit = '1';
 
-      const copyButton = card.querySelector<HTMLButtonElement>('[data-copy-button]');
+      const copyButton = card.querySelector<HTMLElement>('[data-copy-button]');
       const copyIcon = card.querySelector<HTMLElement>('[data-copy-icon]');
-      const tabs = Array.from(card.querySelectorAll<HTMLButtonElement>('[data-manager-tab]'));
+      const tabs = Array.from(card.querySelectorAll<HTMLElement>('[data-manager-tab]'));
       const panels = Array.from(card.querySelectorAll<HTMLElement>('[data-command-panel]'));
       if (!copyButton || !copyIcon || tabs.length === 0 || panels.length === 0) return;
 
@@ -204,6 +210,13 @@ const activeManager =
       });
     });
   })();
+</script>
+
+<script>
+  import { initSiteShadcnControls } from './site-shadcn-controls';
+
+  initSiteShadcnControls(document);
+  document.addEventListener('astro:page-load', () => initSiteShadcnControls(document));
 </script>
 
 <style>

--- a/apps/www/src/components/InstallCommandCard.astro
+++ b/apps/www/src/components/InstallCommandCard.astro
@@ -192,7 +192,7 @@ const activeManager =
 
       tabs.forEach((tab) => {
         tab.addEventListener('click', (event) => {
-          if (!(event instanceof CustomEvent)) return;
+          if (tab.matches('wc-shadcn-button') && !(event instanceof CustomEvent)) return;
           const nextManager = tab.dataset.managerTab;
           if (!nextManager) return;
           setActiveManager(nextManager);
@@ -200,7 +200,7 @@ const activeManager =
       });
 
       copyButton.addEventListener('click', async (event) => {
-        if (!(event instanceof CustomEvent)) return;
+        if (copyButton.matches('wc-shadcn-button') && !(event instanceof CustomEvent)) return;
         try {
           await navigator.clipboard.writeText(getCommandNode()?.textContent ?? '');
           copyIcon.innerHTML = successIcon;

--- a/apps/www/src/components/PrototypePreviewer/CodePanel.astro
+++ b/apps/www/src/components/PrototypePreviewer/CodePanel.astro
@@ -64,6 +64,7 @@ const highlighted = await highlightCode(code, lang);
           ></path>
         </svg>
       </span>
+      <span class="sr-only">Copy code</span>
     </wc-shadcn-button>
 
     <div

--- a/apps/www/src/components/PrototypePreviewer/CodePanel.astro
+++ b/apps/www/src/components/PrototypePreviewer/CodePanel.astro
@@ -30,7 +30,10 @@ const highlighted = await highlightCode(code, lang);
     class="group relative min-w-0 max-w-full max-h-24 min-h-12 overflow-hidden p-2 border-t border-border bg-muted data-[code-expanded=true]:max-h-none data-[code-expanded=true]:overflow-visible"
     data-code-inner
   >
-    <button
+    <wc-shadcn-button
+      data-site-shadcn-button
+      data-variant="outline"
+      data-size="icon"
       type="button"
       class="absolute top-2 right-2 size-8 items-center justify-center text-xs font-medium border border-border rounded-md bg-background/90 text-foreground cursor-pointer opacity-80 transition-colors duration-150 hover:opacity-100 hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 hidden group-data-[code-expanded=true]:inline-flex"
       title="Copy code"
@@ -61,7 +64,7 @@ const highlighted = await highlightCode(code, lang);
           ></path>
         </svg>
       </span>
-    </button>
+    </wc-shadcn-button>
 
     <div
       class="[&_.shiki]:!bg-muted dark:[&_.shiki_span]:![color:var(--shiki-dark)] min-w-0 max-w-full overflow-x-auto max-h-36 group-data-[code-expanded=false]:select-none group-data-[code-expanded=true]:overflow-y-auto"
@@ -76,7 +79,10 @@ const highlighted = await highlightCode(code, lang);
     >
     </div>
 
-    <button
+    <wc-shadcn-button
+      data-site-shadcn-button
+      data-variant="outline"
+      data-size="sm"
       type="button"
       class="absolute left-1/2 bottom-1/2 -translate-x-1/2 translate-y-1/2 z-10 py-1.5 px-4 text-[0.8125rem] font-medium rounded-lg border border-border bg-background text-foreground cursor-pointer inline-flex items-center gap-1.5 shadow-sm transition-colors duration-150 hover:bg-muted group-data-[code-expanded=true]:hidden"
       data-code-toggle
@@ -84,13 +90,18 @@ const highlighted = await highlightCode(code, lang);
       aria-label="展开代码"
     >
       View code
-    </button>
+    </wc-shadcn-button>
   </div>
 </figure>
 
 <script>
+  import { initSiteShadcnControls } from '../site-shadcn-controls';
   import { initCodePanels } from './code-panel-client';
 
+  initSiteShadcnControls(document);
   initCodePanels(document);
-  document.addEventListener('astro:page-load', () => initCodePanels(document));
+  document.addEventListener('astro:page-load', () => {
+    initSiteShadcnControls(document);
+    initCodePanels(document);
+  });
 </script>

--- a/apps/www/src/components/PrototypePreviewer/CodePanel.astro
+++ b/apps/www/src/components/PrototypePreviewer/CodePanel.astro
@@ -35,7 +35,8 @@ const highlighted = await highlightCode(code, lang);
       data-variant="outline"
       data-size="icon"
       type="button"
-      class="absolute top-2 right-2 size-8 items-center justify-center text-xs font-medium border border-border rounded-md bg-background/90 text-foreground cursor-pointer opacity-80 transition-colors duration-150 hover:opacity-100 hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 hidden group-data-[code-expanded=true]:inline-flex"
+      class="absolute top-2 right-2 size-8 items-center justify-center text-xs font-medium border border-border rounded-md bg-background/90 text-foreground cursor-pointer opacity-80 transition-colors duration-150 hover:opacity-100 hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 inline-flex"
+      hidden
       title="Copy code"
       aria-label="Copy code"
       data-copy
@@ -84,8 +85,7 @@ const highlighted = await highlightCode(code, lang);
       data-site-shadcn-button
       data-variant="outline"
       data-size="sm"
-      type="button"
-      class="absolute left-1/2 bottom-1/2 -translate-x-1/2 translate-y-1/2 z-10 py-1.5 px-4 text-[0.8125rem] font-medium rounded-lg border border-border bg-background text-foreground cursor-pointer inline-flex items-center gap-1.5 shadow-sm transition-colors duration-150 hover:bg-muted group-data-[code-expanded=true]:hidden"
+      class="absolute left-1/2 bottom-1/2 -translate-x-1/2 translate-y-1/2 z-10 py-1.5 px-4 text-[0.8125rem] font-medium rounded-lg border border-border bg-background text-foreground cursor-pointer inline-flex items-center gap-1.5 shadow-sm transition-colors duration-150 hover:bg-muted"
       data-code-toggle
       aria-expanded="false"
       aria-label="展开代码"
@@ -94,6 +94,12 @@ const highlighted = await highlightCode(code, lang);
     </wc-shadcn-button>
   </div>
 </figure>
+
+<style is:global>
+  [data-code-shell] wc-shadcn-button[hidden] {
+    display: none !important;
+  }
+</style>
 
 <script>
   import { initSiteShadcnControls } from '../site-shadcn-controls';

--- a/apps/www/src/components/PrototypePreviewer/DemoMatrix.astro
+++ b/apps/www/src/components/PrototypePreviewer/DemoMatrix.astro
@@ -204,7 +204,7 @@ function getPreviewerClass(demoId: string) {
 
   .demo-matrix__adapters {
     display: grid;
-    grid-template-columns: repeat(3, minmax(15rem, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
     gap: 0.75rem;
   }
 

--- a/apps/www/src/components/PrototypePreviewer/HomeDemoPreviewer.astro
+++ b/apps/www/src/components/PrototypePreviewer/HomeDemoPreviewer.astro
@@ -57,6 +57,9 @@ if (!Array.isArray(demos) || demos.length === 0) {
 }
 
 const initialDemo = demos.find((demo) => demo.id === initialDemoId) ?? demos[0];
+const instanceToken = Math.random().toString(36).slice(2);
+const pickerLabelId = `${id}-picker-label-${instanceToken}`;
+const runtimeLabelId = `${id}-runtime-label-${instanceToken}`;
 ---
 
 <section
@@ -77,7 +80,7 @@ const initialDemo = demos.find((demo) => demo.id === initialDemoId) ?? demos[0];
 
       <div class="home-demo-previewer__toolbar">
         <div class="home-demo-previewer__control">
-          <label class="home-demo-previewer__label">{pickerLabel}</label>
+          <label id={pickerLabelId} class="home-demo-previewer__label">{pickerLabel}</label>
           <div class="home-demo-previewer__select-wrap">
             <wc-shadcn-select-root
               data-site-select-root
@@ -85,7 +88,10 @@ const initialDemo = demos.find((demo) => demo.id === initialDemoId) ?? demos[0];
               data-home-demo-select="demo"
               data-site-initial-value={initialDemo.id}
             >
-              <wc-shadcn-select-trigger class="home-demo-previewer__select">
+              <wc-shadcn-select-trigger
+                class="home-demo-previewer__select"
+                aria-labelledby={pickerLabelId}
+              >
                 <wc-shadcn-select-value data-placeholder={pickerLabel}></wc-shadcn-select-value>
               </wc-shadcn-select-trigger>
               <wc-shadcn-select-content data-position="popper" data-align="start"
@@ -95,7 +101,7 @@ const initialDemo = demos.find((demo) => demo.id === initialDemoId) ?? demos[0];
         </div>
 
         <div class="home-demo-previewer__control">
-          <label class="home-demo-previewer__label">{runtimeLabel}</label>
+          <label id={runtimeLabelId} class="home-demo-previewer__label">{runtimeLabel}</label>
           <div class="home-demo-previewer__select-wrap">
             <wc-shadcn-select-root
               data-site-select-root
@@ -103,7 +109,10 @@ const initialDemo = demos.find((demo) => demo.id === initialDemoId) ?? demos[0];
               data-home-demo-select="runtime"
               data-site-initial-value={initialRuntime}
             >
-              <wc-shadcn-select-trigger class="home-demo-previewer__select">
+              <wc-shadcn-select-trigger
+                class="home-demo-previewer__select"
+                aria-labelledby={runtimeLabelId}
+              >
                 <wc-shadcn-select-value data-placeholder={runtimeLabel}></wc-shadcn-select-value>
               </wc-shadcn-select-trigger>
               <wc-shadcn-select-content data-position="popper" data-align="start"

--- a/apps/www/src/components/PrototypePreviewer/HomeDemoPreviewer.astro
+++ b/apps/www/src/components/PrototypePreviewer/HomeDemoPreviewer.astro
@@ -77,54 +77,38 @@ const initialDemo = demos.find((demo) => demo.id === initialDemoId) ?? demos[0];
 
       <div class="home-demo-previewer__toolbar">
         <div class="home-demo-previewer__control">
-          <label class="home-demo-previewer__label" for="home-demo-picker">{pickerLabel}</label>
+          <label class="home-demo-previewer__label">{pickerLabel}</label>
           <div class="home-demo-previewer__select-wrap">
-            <select id="home-demo-picker" data-home-demo-picker class="home-demo-previewer__select">
-            </select>
-            <span class="home-demo-previewer__chevron" aria-hidden="true">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                class="lucide lucide-chevron-down-icon lucide-chevron-down"
-              >
-                <path d="m6 9 6 6 6-6"></path>
-              </svg>
-            </span>
+            <wc-shadcn-select-root
+              data-site-select-root
+              data-home-demo-picker
+              data-home-demo-select="demo"
+              data-site-initial-value={initialDemo.id}
+            >
+              <wc-shadcn-select-trigger class="home-demo-previewer__select">
+                <wc-shadcn-select-value data-placeholder={pickerLabel}></wc-shadcn-select-value>
+              </wc-shadcn-select-trigger>
+              <wc-shadcn-select-content data-position="popper" data-align="start"
+              ></wc-shadcn-select-content>
+            </wc-shadcn-select-root>
           </div>
         </div>
 
         <div class="home-demo-previewer__control">
-          <label class="home-demo-previewer__label" for="home-demo-runtime">{runtimeLabel}</label>
+          <label class="home-demo-previewer__label">{runtimeLabel}</label>
           <div class="home-demo-previewer__select-wrap">
-            <select
-              id="home-demo-runtime"
+            <wc-shadcn-select-root
+              data-site-select-root
               data-home-demo-runtime
-              class="home-demo-previewer__select"
+              data-home-demo-select="runtime"
+              data-site-initial-value={initialRuntime}
             >
-            </select>
-            <span class="home-demo-previewer__chevron" aria-hidden="true">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                class="lucide lucide-chevron-down-icon lucide-chevron-down"
-              >
-                <path d="m6 9 6 6 6-6"></path>
-              </svg>
-            </span>
+              <wc-shadcn-select-trigger class="home-demo-previewer__select">
+                <wc-shadcn-select-value data-placeholder={runtimeLabel}></wc-shadcn-select-value>
+              </wc-shadcn-select-trigger>
+              <wc-shadcn-select-content data-position="popper" data-align="start"
+              ></wc-shadcn-select-content>
+            </wc-shadcn-select-root>
           </div>
         </div>
       </div>
@@ -136,8 +120,10 @@ const initialDemo = demos.find((demo) => demo.id === initialDemoId) ?? demos[0];
   </div>
 
   <script>
+    import { initSiteShadcnControls } from '../site-shadcn-controls';
     import { initHomeDemoPreviewer } from './home-demo-client';
 
+    initSiteShadcnControls(document);
     function init() {
       document
         .querySelectorAll<HTMLElement>(
@@ -151,6 +137,10 @@ const initialDemo = demos.find((demo) => demo.id === initialDemoId) ?? demos[0];
     } else {
       init();
     }
+    document.addEventListener('astro:page-load', () => {
+      initSiteShadcnControls(document);
+      init();
+    });
   </script>
 </section>
 
@@ -234,15 +224,20 @@ const initialDemo = demos.find((demo) => demo.id === initialDemoId) ?? demos[0];
     position: relative;
   }
 
+  .home-demo-previewer__select-wrap wc-shadcn-select-root {
+    display: block;
+    width: 100%;
+  }
+
   .home-demo-previewer__select {
     width: 100%;
-    appearance: none;
+    min-height: 2.65rem;
     border: 1px solid var(--color-border);
     border-radius: 0.8rem;
     background: color-mix(in oklch, var(--color-background) 94%, var(--color-muted) 6%);
     color: var(--color-foreground);
     font-size: 0.88rem;
-    padding: 0.7rem 2rem 0.7rem 0.85rem;
+    padding: 0.7rem 0.85rem;
     outline: none;
     transition:
       border-color 160ms ease,
@@ -257,23 +252,6 @@ const initialDemo = demos.find((demo) => demo.id === initialDemoId) ?? demos[0];
   .home-demo-previewer__select:focus-visible {
     border-color: var(--color-ring);
     box-shadow: 0 0 0 3px color-mix(in oklch, var(--color-ring) 18%, transparent);
-  }
-
-  .home-demo-previewer__chevron {
-    position: absolute;
-    right: 0.9rem;
-    top: 50%;
-    transform: translateY(-50%);
-    color: var(--color-muted-foreground);
-    pointer-events: none;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .home-demo-previewer__chevron svg {
-    width: 1rem;
-    height: 1rem;
   }
 
   .home-demo-previewer__description {

--- a/apps/www/src/components/PrototypePreviewer/HomeDemoPreviewer.astro
+++ b/apps/www/src/components/PrototypePreviewer/HomeDemoPreviewer.astro
@@ -45,6 +45,7 @@ const {
     { id: 'wc', label: 'Web Components' },
     { id: 'react', label: 'React' },
     { id: 'vue', label: 'Vue' },
+    { id: 'vue2', label: 'Vue 2' },
   ],
   id = 'home-demo-previewer',
   class: className = '',
@@ -203,10 +204,8 @@ const runtimeLabelId = `${id}-runtime-label-${instanceToken}`;
     line-height: 1.3;
     font-weight: 600;
     color: var(--color-foreground);
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 1;
-    overflow: hidden;
+    display: block;
+    overflow: visible;
   }
 
   .home-demo-previewer__toolbar {

--- a/apps/www/src/components/PrototypePreviewer/PrototypePreviewer.astro
+++ b/apps/www/src/components/PrototypePreviewer/PrototypePreviewer.astro
@@ -210,7 +210,7 @@ const rid = `pp-${Math.random().toString(36).slice(2)}`;
       color: var(--color-muted-foreground);
     }
 
-    .proto-previewer__toolbar select {
+    .proto-previewer__toolbar wc-shadcn-select-trigger {
       padding: 0.375rem 0.625rem;
       font-size: 0.8125rem;
       border: 1px solid var(--color-border);

--- a/apps/www/src/components/PrototypePreviewer/code-panel-client.test.ts
+++ b/apps/www/src/components/PrototypePreviewer/code-panel-client.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { initCodePanels, refreshCodePanel } from './code-panel-client';
 
-function panelMarkup(id: string, raw = 'const exact = "<&";'): string {
+function panelMarkup(id: string, raw = 'const exact = "<&";', projected = false): string {
   const escaped = raw.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+  const buttonTag = projected ? 'wc-shadcn-button' : 'button';
   return `<figure data-code-shell id="${id}">
     <div data-code-inner>
-      <button type="button" data-copy aria-label="Copy code"><span data-copy-text>copy</span></button>
+      <${buttonTag} type="button" data-copy aria-label="Copy code"><span data-copy-text>copy</span></${buttonTag}>
       <div data-code-content><pre class="proto-previewer__code"><code data-raw-code="${escaped}">${raw}</code></pre></div>
-      <button type="button" data-code-toggle aria-expanded="false">View code</button>
+      <${buttonTag} type="button" data-code-toggle aria-expanded="false">View code</${buttonTag}>
     </div>
   </figure>`;
 }
@@ -63,6 +64,20 @@ describe('CodePanel client', () => {
     shell.querySelector<HTMLButtonElement>('[data-copy]')!.click();
     await Promise.resolve();
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('const exact = "<&";');
+  });
+
+  it('handles only the projected Button outward click signal', () => {
+    document.body.innerHTML = panelMarkup('projected', 'line\n'.repeat(80), true);
+    const shell = document.querySelector<HTMLElement>('[data-code-shell]')!;
+    const toggle = shell.querySelector<HTMLElement>('[data-code-toggle]')!;
+    setMeasurements(shell, { fullHeight: 400 });
+    initCodePanels(document);
+    refreshCodePanel(shell, { reset: true });
+
+    toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(shell.dataset.codeExpanded).toBe('false');
+    toggle.dispatchEvent(new CustomEvent('click', { bubbles: true }));
+    expect(shell.dataset.codeExpanded).toBe('true');
   });
 
   it('auto-expands short content and keeps long content collapsed', () => {

--- a/apps/www/src/components/PrototypePreviewer/code-panel-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/code-panel-client.ts
@@ -11,9 +11,11 @@ function setExpanded(shell: HTMLElement, expanded: boolean): void {
   shell.dataset.codeExpanded = String(expanded);
   const panel = shell.querySelector<HTMLElement>('[data-code-inner]');
   if (panel) panel.dataset.codeExpanded = String(expanded);
-  shell
-    .querySelector<HTMLElement>('[data-code-toggle]')
-    ?.setAttribute('aria-expanded', String(expanded));
+  const toggle = shell.querySelector<HTMLElement>('[data-code-toggle]');
+  toggle?.setAttribute('aria-expanded', String(expanded));
+  if (toggle) toggle.hidden = expanded;
+  const copyButton = shell.querySelector<HTMLElement>('[data-copy]');
+  if (copyButton) copyButton.hidden = !expanded;
 }
 
 export function refreshCodePanel(shell: HTMLElement, options: RefreshCodePanelOptions = {}): void {

--- a/apps/www/src/components/PrototypePreviewer/code-panel-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/code-panel-client.ts
@@ -10,7 +10,7 @@ function setExpanded(shell: HTMLElement, expanded: boolean): void {
   const panel = shell.querySelector<HTMLElement>('[data-code-inner]');
   if (panel) panel.dataset.codeExpanded = String(expanded);
   shell
-    .querySelector<HTMLButtonElement>('[data-code-toggle]')
+    .querySelector<HTMLElement>('[data-code-toggle]')
     ?.setAttribute('aria-expanded', String(expanded));
 }
 
@@ -38,8 +38,8 @@ function initCodePanel(shell: HTMLElement): void {
   setExpanded(shell, false);
 
   const panel = shell.querySelector<HTMLElement>('[data-code-inner]');
-  const toggle = shell.querySelector<HTMLButtonElement>('[data-code-toggle]');
-  const copyButton = shell.querySelector<HTMLButtonElement>('[data-copy]');
+  const toggle = shell.querySelector<HTMLElement>('[data-code-toggle]');
+  const copyButton = shell.querySelector<HTMLElement>('[data-copy]');
   const copyText = shell.querySelector<HTMLElement>('[data-copy-text]');
 
   toggle?.addEventListener('click', () => {

--- a/apps/www/src/components/PrototypePreviewer/code-panel-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/code-panel-client.ts
@@ -1,3 +1,5 @@
+import { isSiteButtonActivation } from '../site-shadcn-controls';
+
 export interface RefreshCodePanelOptions {
   readonly reset?: boolean;
 }
@@ -42,14 +44,16 @@ function initCodePanel(shell: HTMLElement): void {
   const copyButton = shell.querySelector<HTMLElement>('[data-copy]');
   const copyText = shell.querySelector<HTMLElement>('[data-copy-text]');
 
-  toggle?.addEventListener('click', () => {
+  toggle?.addEventListener('click', (event) => {
+    if (!isSiteButtonActivation(event)) return;
     setExpanded(shell, shell.dataset.codeExpanded !== 'true');
   });
 
   if (copyButton && copyText) {
     const copyIconHtml = copyText.innerHTML;
     const checkIconHtml = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-4.5"><path d="M20 6 9 17l-5-5"/></svg>`;
-    copyButton.addEventListener('click', async () => {
+    copyButton.addEventListener('click', async (event) => {
+      if (!isSiteButtonActivation(event)) return;
       const code = shell.querySelector<HTMLElement>('.proto-previewer__code code');
       const text = code?.dataset.rawCode ?? code?.textContent ?? '';
       try {

--- a/apps/www/src/components/PrototypePreviewer/home-demo-client.test.ts
+++ b/apps/www/src/components/PrototypePreviewer/home-demo-client.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const demoLoader = vi.hoisted(() => ({
+  loadDemo: vi.fn(),
+  collectPrototypeIds: vi.fn(),
+  loadPrototypes: vi.fn(),
+  renderDemo: vi.fn(),
+}));
+
+vi.mock('./demo-modules', () => ({
+  loadDemo: demoLoader.loadDemo,
+}));
+vi.mock('./demo-types', () => ({
+  collectPrototypeIds: demoLoader.collectPrototypeIds,
+}));
+vi.mock('./prototype-modules', () => ({
+  loadPrototypes: demoLoader.loadPrototypes,
+}));
+vi.mock('./demo-renderer', () => ({
+  renderDemo: demoLoader.renderDemo,
+}));
+vi.mock('../adapter-preference', () => ({
+  PREFERRED_ADAPTER_EVENT: 'proto-adapter:change',
+  PREFERRED_ADAPTER_KEY: 'preferred-prototypes-adapter',
+}));
+vi.mock('../site-shadcn-controls', () => ({
+  initSiteShadcnControls: () => {},
+  selectValue: (root: HTMLElement) => root.dataset.value ?? '',
+  setSelectValue: (root: HTMLElement, value: string) => {
+    root.dataset.value = value;
+  },
+  setSiteSelectDisabled: (root: HTMLElement, disabled: boolean) => {
+    root.dataset.disabled = String(disabled);
+  },
+}));
+
+import { initHomeDemoPreviewer } from './home-demo-client';
+
+function createHomeRoot(): HTMLElement {
+  const root = document.createElement('section');
+  root.dataset.homeDemoOptions = JSON.stringify([
+    { id: 'demo-one', label: 'One' },
+    { id: 'demo-two', label: 'Two' },
+  ]);
+  root.dataset.runtimeOptions = JSON.stringify([
+    { id: 'wc', label: 'Web Components' },
+    { id: 'react', label: 'React' },
+  ]);
+  root.dataset.initialDemoId = 'demo-one';
+  root.dataset.initialRuntime = 'wc';
+  root.innerHTML = `
+    <div data-home-demo-picker>
+      <wc-shadcn-select-trigger></wc-shadcn-select-trigger>
+      <wc-shadcn-select-content></wc-shadcn-select-content>
+    </div>
+    <div data-home-demo-runtime>
+      <wc-shadcn-select-trigger></wc-shadcn-select-trigger>
+      <wc-shadcn-select-content></wc-shadcn-select-content>
+    </div>
+    <div data-home-demo-host></div>
+  `;
+  document.body.append(root);
+  return root;
+}
+
+describe('Home demo runtime selector', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+    demoLoader.loadDemo.mockReset().mockResolvedValue({ root: {} });
+    demoLoader.collectPrototypeIds.mockReset();
+    demoLoader.loadPrototypes.mockReset().mockResolvedValue(undefined);
+    demoLoader.renderDemo.mockReset().mockImplementation(async () => ({ destroy: vi.fn() }));
+  });
+
+  it('rerenders locally when no global AdapterSelect is present', async () => {
+    const root = createHomeRoot();
+    initHomeDemoPreviewer(root);
+
+    await vi.waitFor(() =>
+      expect(demoLoader.renderDemo).toHaveBeenCalledWith(
+        expect.objectContaining({ runtime: 'wc', demo: expect.anything() })
+      )
+    );
+
+    const runtimeSelect = root.querySelector<HTMLElement>('[data-home-demo-runtime]')!;
+    runtimeSelect.dataset.value = 'react';
+    runtimeSelect.dispatchEvent(
+      new CustomEvent('valueChange', { detail: { value: 'react' }, bubbles: true })
+    );
+
+    await vi.waitFor(() =>
+      expect(demoLoader.renderDemo).toHaveBeenCalledWith(
+        expect.objectContaining({ runtime: 'react', demo: expect.anything() })
+      )
+    );
+    expect(demoLoader.renderDemo).toHaveBeenCalledTimes(2);
+    expect(runtimeSelect.dataset.disabled).toBe('false');
+  });
+});

--- a/apps/www/src/components/PrototypePreviewer/home-demo-client.test.ts
+++ b/apps/www/src/components/PrototypePreviewer/home-demo-client.test.ts
@@ -97,4 +97,22 @@ describe('Home demo runtime selector', () => {
     expect(demoLoader.renderDemo).toHaveBeenCalledTimes(2);
     expect(runtimeSelect.dataset.disabled).toBe('false');
   });
+
+  it('does not remount when the active demo or runtime is reselected', async () => {
+    const root = createHomeRoot();
+    initHomeDemoPreviewer(root);
+    await vi.waitFor(() => expect(demoLoader.renderDemo).toHaveBeenCalledTimes(1));
+
+    const runtimeSelect = root.querySelector<HTMLElement>('[data-home-demo-runtime]')!;
+    runtimeSelect.dispatchEvent(
+      new CustomEvent('valueChange', { detail: { value: 'wc' }, bubbles: true })
+    );
+    const demoSelect = root.querySelector<HTMLElement>('[data-home-demo-picker]')!;
+    demoSelect.dispatchEvent(
+      new CustomEvent('valueChange', { detail: { value: 'demo-one' }, bubbles: true })
+    );
+
+    await Promise.resolve();
+    expect(demoLoader.renderDemo).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
@@ -29,6 +29,12 @@ type ActiveRender = {
   destroy: () => Promise<void> | void;
 };
 
+type AdapterPreferenceDetail = {
+  adapter?: unknown;
+  source?: EventTarget | null;
+  focusTarget?: HTMLElement | null;
+};
+
 const DEFAULT_RUNTIME_OPTIONS: RuntimeOption[] = [
   { id: 'wc', label: 'Web Components' },
   { id: 'react', label: 'React' },
@@ -159,17 +165,41 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
           focusTarget?.isConnected &&
           (document.activeElement === document.body || document.activeElement == null)
         ) {
-          focusTarget.focus();
+          // The Select adapter applies the unlocked props on its next
+          // controller turn. Focusing in this same stack is ignored by the
+          // browser while the trigger is still disabled, leaving the local
+          // Runtime control on BODY after a remount. Restore after the
+          // unlock has committed, and re-check the render generation so a
+          // newer selection cannot steal focus.
+          await new Promise<void>((resolve) => {
+            const view = focusTarget.ownerDocument.defaultView;
+            if (view?.requestAnimationFrame) {
+              view.requestAnimationFrame(() => resolve());
+            } else {
+              queueMicrotask(resolve);
+            }
+          });
+          if (
+            !destroyed &&
+            currentVersion === version &&
+            focusTarget.isConnected &&
+            (document.activeElement === document.body || document.activeElement == null)
+          ) {
+            focusTarget.focus();
+          }
         }
       }
     }
   }
 
-  const renderFromInputs = (event: Event, changed: SiteSelectRoot) => {
+  const renderFromInputs = (
+    event: Event,
+    changed: SiteSelectRoot,
+    focusTarget = changed.querySelector<HTMLElement>('wc-shadcn-select-trigger')
+  ) => {
     const detail = (event as CustomEvent<{ value?: unknown }>).detail;
     const value = typeof detail?.value === 'string' ? detail.value : selectValue(changed);
     setSelectValue(changed, value);
-    const focusTarget = changed.querySelector<HTMLElement>('wc-shadcn-select-trigger');
     renderCurrent(
       (changed === runtimeSelectEl ? value : selectValue(runtimeSelectEl)) as RuntimeId,
       changed === demoSelectEl ? value : selectValue(demoSelectEl),
@@ -182,6 +212,7 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
     const detail = (event as CustomEvent<{ value?: unknown }>).detail;
     const value = typeof detail?.value === 'string' ? detail.value : selectValue(runtimeSelectEl);
     if (!runtimeOptions.some((option) => option.id === value)) return;
+    const focusTarget = runtimeSelectEl.querySelector<HTMLElement>('wc-shadcn-select-trigger');
     try {
       localStorage.setItem(PREFERRED_ADAPTER_KEY, value);
     } catch {
@@ -189,20 +220,24 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
     }
     runtimeSelectEl.ownerDocument.dispatchEvent(
       new CustomEvent(PREFERRED_ADAPTER_EVENT, {
-        detail: { adapter: value, source: runtimeSelectEl },
+        detail: { adapter: value, source: runtimeSelectEl, focusTarget },
       })
     );
-    renderFromInputs(event, runtimeSelectEl);
+    renderFromInputs(event, runtimeSelectEl, focusTarget);
   };
   const onAdapterChange = (event: Event) => {
-    const detail = (event as CustomEvent<{ adapter?: unknown; source?: EventTarget }>).detail;
+    const detail = (event as CustomEvent<AdapterPreferenceDetail>).detail;
     const adapter = detail?.adapter;
     if (typeof adapter !== 'string' || !runtimeOptions.some((option) => option.id === adapter))
       return;
     if (detail?.source === runtimeSelectEl) return;
     if (selectValue(runtimeSelectEl) === adapter) return;
     setSelectValue(runtimeSelectEl, adapter);
-    void renderCurrent(adapter as RuntimeId, selectValue(demoSelectEl));
+    void renderCurrent(
+      adapter as RuntimeId,
+      selectValue(demoSelectEl),
+      detail?.focusTarget ?? null
+    );
   };
   demoSelectEl.addEventListener('valueChange', onDemoChange);
   runtimeSelectEl.addEventListener('valueChange', onRuntimeChange);

--- a/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
@@ -181,6 +181,7 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
   const onRuntimeChange = (event: Event) => {
     const detail = (event as CustomEvent<{ value?: unknown }>).detail;
     const value = typeof detail?.value === 'string' ? detail.value : selectValue(runtimeSelectEl);
+    if (!runtimeOptions.some((option) => option.id === value)) return;
     try {
       localStorage.setItem(PREFERRED_ADAPTER_KEY, value);
     } catch {
@@ -189,7 +190,6 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
     runtimeSelectEl.ownerDocument.dispatchEvent(
       new CustomEvent(PREFERRED_ADAPTER_EVENT, { detail: { adapter: value } })
     );
-    renderFromInputs(event, runtimeSelectEl);
   };
   const onAdapterChange = (event: Event) => {
     const adapter = (event as CustomEvent<{ adapter?: unknown }>).detail?.adapter;

--- a/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
@@ -6,6 +6,7 @@ import type { RuntimeId } from './runtimes/registry';
 import {
   initSiteShadcnControls,
   selectValue,
+  setSiteSelectDisabled,
   setSelectValue,
   type SiteSelectRoot,
 } from '../site-shadcn-controls';
@@ -32,10 +33,6 @@ const DEFAULT_RUNTIME_OPTIONS: RuntimeOption[] = [
   { id: 'react', label: 'React' },
   { id: 'vue', label: 'Vue' },
 ];
-
-function setSelectDisabled(select: SiteSelectRoot, disabled: boolean): void {
-  select.setProps?.({ disabled });
-}
 
 function populateSelect(
   select: SiteSelectRoot,
@@ -98,8 +95,8 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
   async function renderCurrent(runtime: RuntimeId, demoId: string) {
     if (destroyed) return;
     const currentVersion = ++version;
-    setSelectDisabled(runtimeSelectEl, true);
-    setSelectDisabled(demoSelectEl, true);
+    setSiteSelectDisabled(runtimeSelectEl, true);
+    setSiteSelectDisabled(demoSelectEl, true);
 
     try {
       if (active) {
@@ -137,8 +134,8 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
       console.error(error);
     } finally {
       if (!destroyed && currentVersion === version) {
-        setSelectDisabled(runtimeSelectEl, false);
-        setSelectDisabled(demoSelectEl, false);
+        setSiteSelectDisabled(runtimeSelectEl, false);
+        setSiteSelectDisabled(demoSelectEl, false);
       }
     }
   }

--- a/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
@@ -107,6 +107,9 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
   let version = 0;
   let destroyed = false;
 
+  let lastRuntimeValue = selectValue(runtimeSelectEl);
+  let lastDemoValue = selectValue(demoSelectEl);
+
   async function renderCurrent(
     runtime: RuntimeId,
     demoId: string,
@@ -164,10 +167,13 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
       }
     }
   }
-
   const renderFromInputs = (event: Event, changed: SiteSelectRoot) => {
     const detail = (event as CustomEvent<{ value?: unknown }>).detail;
     const value = typeof detail?.value === 'string' ? detail.value : selectValue(changed);
+    const previousValue = changed === runtimeSelectEl ? lastRuntimeValue : lastDemoValue;
+    if (previousValue === value) return;
+    if (changed === runtimeSelectEl) lastRuntimeValue = value;
+    else lastDemoValue = value;
     setSelectValue(changed, value);
     const focusTarget = changed.querySelector<HTMLElement>('wc-shadcn-select-trigger');
     renderCurrent(
@@ -178,10 +184,12 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
   };
 
   const onDemoChange = (event: Event) => renderFromInputs(event, demoSelectEl);
+
   const onRuntimeChange = (event: Event) => {
     const detail = (event as CustomEvent<{ value?: unknown }>).detail;
     const value = typeof detail?.value === 'string' ? detail.value : selectValue(runtimeSelectEl);
     if (!runtimeOptions.some((option) => option.id === value)) return;
+    if (lastRuntimeValue === value) return;
     try {
       localStorage.setItem(PREFERRED_ADAPTER_KEY, value);
     } catch {
@@ -200,7 +208,8 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
     if (typeof adapter !== 'string' || !runtimeOptions.some((option) => option.id === adapter))
       return;
     if (detail?.source === runtimeSelectEl) return;
-    if (selectValue(runtimeSelectEl) === adapter) return;
+    if (lastRuntimeValue === adapter) return;
+    lastRuntimeValue = adapter;
     setSelectValue(runtimeSelectEl, adapter);
     void renderCurrent(adapter as RuntimeId, selectValue(demoSelectEl));
   };

--- a/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
@@ -188,13 +188,18 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
       // Storage is optional; the in-document synchronization still applies.
     }
     runtimeSelectEl.ownerDocument.dispatchEvent(
-      new CustomEvent(PREFERRED_ADAPTER_EVENT, { detail: { adapter: value } })
+      new CustomEvent(PREFERRED_ADAPTER_EVENT, {
+        detail: { adapter: value, source: runtimeSelectEl },
+      })
     );
+    renderFromInputs(event, runtimeSelectEl);
   };
   const onAdapterChange = (event: Event) => {
-    const adapter = (event as CustomEvent<{ adapter?: unknown }>).detail?.adapter;
+    const detail = (event as CustomEvent<{ adapter?: unknown; source?: EventTarget }>).detail;
+    const adapter = detail?.adapter;
     if (typeof adapter !== 'string' || !runtimeOptions.some((option) => option.id === adapter))
       return;
+    if (detail?.source === runtimeSelectEl) return;
     if (selectValue(runtimeSelectEl) === adapter) return;
     setSelectValue(runtimeSelectEl, adapter);
     void renderCurrent(adapter as RuntimeId, selectValue(demoSelectEl));

--- a/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
@@ -3,6 +3,7 @@ import { renderDemo } from './demo-renderer';
 import { collectPrototypeIds } from './demo-types';
 import { loadPrototypes } from './prototype-modules';
 import type { RuntimeId } from './runtimes/registry';
+import { PREFERRED_ADAPTER_EVENT, PREFERRED_ADAPTER_KEY } from '../adapter-preference';
 import {
   initSiteShadcnControls,
   selectValue,
@@ -32,8 +33,17 @@ const DEFAULT_RUNTIME_OPTIONS: RuntimeOption[] = [
   { id: 'wc', label: 'Web Components' },
   { id: 'react', label: 'React' },
   { id: 'vue', label: 'Vue' },
+  { id: 'vue2', label: 'Vue 2' },
 ];
 
+function readPreferredRuntime(runtimeOptions: RuntimeOption[]): RuntimeId | null {
+  try {
+    const stored = localStorage.getItem(PREFERRED_ADAPTER_KEY);
+    return runtimeOptions.some((option) => option.id === stored) ? (stored as RuntimeId) : null;
+  } catch {
+    return null;
+  }
+}
 function populateSelect(
   select: SiteSelectRoot,
   options: Array<{ id: string; label: string }>,
@@ -75,9 +85,14 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
     : DEFAULT_RUNTIME_OPTIONS;
 
   const initialDemoId = root.dataset.initialDemoId || demoOptions[0]?.id || '';
-  const initialRuntime = (root.dataset.initialRuntime ||
+  const configuredRuntime = (root.dataset.initialRuntime ||
     runtimeOptions[0]?.id ||
     'wc') as RuntimeId;
+  const initialRuntime =
+    readPreferredRuntime(runtimeOptions) ??
+    (runtimeOptions.some((option) => option.id === configuredRuntime)
+      ? configuredRuntime
+      : (runtimeOptions[0]?.id as RuntimeId));
 
   if (!demoOptions.length) {
     console.error('[HomeDemoPreviewer] no demos configured.');
@@ -92,7 +107,11 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
   let version = 0;
   let destroyed = false;
 
-  async function renderCurrent(runtime: RuntimeId, demoId: string) {
+  async function renderCurrent(
+    runtime: RuntimeId,
+    demoId: string,
+    focusTarget?: HTMLElement | null
+  ) {
     if (destroyed) return;
     const currentVersion = ++version;
     setSiteSelectDisabled(runtimeSelectEl, true);
@@ -136,6 +155,12 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
       if (!destroyed && currentVersion === version) {
         setSiteSelectDisabled(runtimeSelectEl, false);
         setSiteSelectDisabled(demoSelectEl, false);
+        if (
+          focusTarget?.isConnected &&
+          (document.activeElement === document.body || document.activeElement == null)
+        ) {
+          focusTarget.focus();
+        }
       }
     }
   }
@@ -144,16 +169,39 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
     const detail = (event as CustomEvent<{ value?: unknown }>).detail;
     const value = typeof detail?.value === 'string' ? detail.value : selectValue(changed);
     setSelectValue(changed, value);
+    const focusTarget = changed.querySelector<HTMLElement>('wc-shadcn-select-trigger');
     renderCurrent(
       (changed === runtimeSelectEl ? value : selectValue(runtimeSelectEl)) as RuntimeId,
-      changed === demoSelectEl ? value : selectValue(demoSelectEl)
+      changed === demoSelectEl ? value : selectValue(demoSelectEl),
+      focusTarget
     );
   };
 
   const onDemoChange = (event: Event) => renderFromInputs(event, demoSelectEl);
-  const onRuntimeChange = (event: Event) => renderFromInputs(event, runtimeSelectEl);
+  const onRuntimeChange = (event: Event) => {
+    const detail = (event as CustomEvent<{ value?: unknown }>).detail;
+    const value = typeof detail?.value === 'string' ? detail.value : selectValue(runtimeSelectEl);
+    try {
+      localStorage.setItem(PREFERRED_ADAPTER_KEY, value);
+    } catch {
+      // Storage is optional; the in-document synchronization still applies.
+    }
+    runtimeSelectEl.ownerDocument.dispatchEvent(
+      new CustomEvent(PREFERRED_ADAPTER_EVENT, { detail: { adapter: value } })
+    );
+    renderFromInputs(event, runtimeSelectEl);
+  };
+  const onAdapterChange = (event: Event) => {
+    const adapter = (event as CustomEvent<{ adapter?: unknown }>).detail?.adapter;
+    if (typeof adapter !== 'string' || !runtimeOptions.some((option) => option.id === adapter))
+      return;
+    if (selectValue(runtimeSelectEl) === adapter) return;
+    setSelectValue(runtimeSelectEl, adapter);
+    void renderCurrent(adapter as RuntimeId, selectValue(demoSelectEl));
+  };
   demoSelectEl.addEventListener('valueChange', onDemoChange);
   runtimeSelectEl.addEventListener('valueChange', onRuntimeChange);
+  runtimeSelectEl.ownerDocument.addEventListener(PREFERRED_ADAPTER_EVENT, onAdapterChange);
 
   renderCurrent(initialRuntime, initialDemoId);
 
@@ -165,6 +213,7 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
         active = null;
         demoSelectEl.removeEventListener('valueChange', onDemoChange);
         runtimeSelectEl.removeEventListener('valueChange', onRuntimeChange);
+        runtimeSelectEl.ownerDocument.removeEventListener(PREFERRED_ADAPTER_EVENT, onAdapterChange);
         observer.disconnect();
       });
     }

--- a/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
@@ -3,6 +3,12 @@ import { renderDemo } from './demo-renderer';
 import { collectPrototypeIds } from './demo-types';
 import { loadPrototypes } from './prototype-modules';
 import type { RuntimeId } from './runtimes/registry';
+import {
+  initSiteShadcnControls,
+  selectValue,
+  setSelectValue,
+  type SiteSelectRoot,
+} from '../site-shadcn-controls';
 
 type DemoOption = {
   id: string;
@@ -27,13 +33,36 @@ const DEFAULT_RUNTIME_OPTIONS: RuntimeOption[] = [
   { id: 'vue', label: 'Vue' },
 ];
 
+function setSelectDisabled(select: SiteSelectRoot, disabled: boolean): void {
+  select.setProps?.({ disabled });
+}
+
+function populateSelect(
+  select: SiteSelectRoot,
+  options: Array<{ id: string; label: string }>,
+  selected: string
+): void {
+  const content = select.querySelector<HTMLElement>('wc-shadcn-select-content');
+  if (!content) return;
+  content.replaceChildren();
+  for (const option of options) {
+    const item = document.createElement('wc-shadcn-select-item');
+    item.dataset.value = option.id;
+    item.dataset.textValue = option.label;
+    item.textContent = option.label;
+    content.appendChild(item);
+  }
+  setSelectValue(select, selected);
+  initSiteShadcnControls(select);
+}
+
 export function initHomeDemoPreviewer(root: HTMLElement) {
   if (root.dataset.inited === '1') return;
   root.dataset.inited = '1';
 
   const host = root.querySelector<HTMLElement>('[data-home-demo-host]');
-  const runtimeSelect = root.querySelector<HTMLSelectElement>('[data-home-demo-runtime]');
-  const demoSelect = root.querySelector<HTMLSelectElement>('[data-home-demo-picker]');
+  const runtimeSelect = root.querySelector<SiteSelectRoot>('[data-home-demo-runtime]');
+  const demoSelect = root.querySelector<SiteSelectRoot>('[data-home-demo-picker]');
 
   if (!host || !runtimeSelect || !demoSelect) {
     console.error('[HomeDemoPreviewer] missing required elements.');
@@ -58,23 +87,9 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
     return;
   }
 
-  demoSelectEl.innerHTML = '';
-  for (const option of demoOptions) {
-    const el = document.createElement('option');
-    el.value = option.id;
-    el.textContent = option.label;
-    if (option.id === initialDemoId) el.selected = true;
-    demoSelectEl.appendChild(el);
-  }
-
-  runtimeSelectEl.innerHTML = '';
-  for (const option of runtimeOptions) {
-    const el = document.createElement('option');
-    el.value = option.id;
-    el.textContent = option.label;
-    if (option.id === initialRuntime) el.selected = true;
-    runtimeSelectEl.appendChild(el);
-  }
+  initSiteShadcnControls(root);
+  populateSelect(demoSelectEl, demoOptions, initialDemoId);
+  populateSelect(runtimeSelectEl, runtimeOptions, initialRuntime);
 
   let active: ActiveRender | null = null;
   let version = 0;
@@ -83,8 +98,8 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
   async function renderCurrent(runtime: RuntimeId, demoId: string) {
     if (destroyed) return;
     const currentVersion = ++version;
-    runtimeSelectEl.disabled = true;
-    demoSelectEl.disabled = true;
+    setSelectDisabled(runtimeSelectEl, true);
+    setSelectDisabled(demoSelectEl, true);
 
     try {
       if (active) {
@@ -122,17 +137,26 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
       console.error(error);
     } finally {
       if (!destroyed && currentVersion === version) {
-        runtimeSelectEl.disabled = false;
-        demoSelectEl.disabled = false;
+        setSelectDisabled(runtimeSelectEl, false);
+        setSelectDisabled(demoSelectEl, false);
       }
     }
   }
 
-  const renderFromInputs = () =>
-    renderCurrent(runtimeSelectEl.value as RuntimeId, demoSelectEl.value);
+  const renderFromInputs = (event: Event, changed: SiteSelectRoot) => {
+    const detail = (event as CustomEvent<{ value?: unknown }>).detail;
+    const value = typeof detail?.value === 'string' ? detail.value : selectValue(changed);
+    setSelectValue(changed, value);
+    renderCurrent(
+      (changed === runtimeSelectEl ? value : selectValue(runtimeSelectEl)) as RuntimeId,
+      changed === demoSelectEl ? value : selectValue(demoSelectEl)
+    );
+  };
 
-  demoSelectEl.addEventListener('change', renderFromInputs);
-  runtimeSelectEl.addEventListener('change', renderFromInputs);
+  const onDemoChange = (event: Event) => renderFromInputs(event, demoSelectEl);
+  const onRuntimeChange = (event: Event) => renderFromInputs(event, runtimeSelectEl);
+  demoSelectEl.addEventListener('valueChange', onDemoChange);
+  runtimeSelectEl.addEventListener('valueChange', onRuntimeChange);
 
   renderCurrent(initialRuntime, initialDemoId);
 
@@ -142,6 +166,8 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
       version += 1;
       Promise.resolve(active?.destroy?.()).finally(() => {
         active = null;
+        demoSelectEl.removeEventListener('valueChange', onDemoChange);
+        runtimeSelectEl.removeEventListener('valueChange', onRuntimeChange);
         observer.disconnect();
       });
     }

--- a/apps/www/src/components/PrototypePreviewer/previewer-client.test.ts
+++ b/apps/www/src/components/PrototypePreviewer/previewer-client.test.ts
@@ -40,6 +40,9 @@ vi.mock('../site-shadcn-controls', () => ({
   setSelectValue: (root: HTMLElement, value: string) => {
     root.dataset.value = value;
   },
+  setSiteSelectDisabled: (root: HTMLElement, disabled: boolean) => {
+    root.dataset.disabled = String(disabled);
+  },
 }));
 
 import { initPreviewer } from './previewer-client';
@@ -126,6 +129,10 @@ describe('PrototypePreviewer adapter preference synchronization', () => {
   it('routes a projected selection through one page-level remount path', async () => {
     const root = createProjectedPreviewerRoot();
     const select = root.querySelector('[data-adapter-select-root]') as SiteSelectRoot;
+    let resolveRemount: (() => void) | undefined;
+    const remount = new Promise<void>((resolve) => {
+      resolveRemount = resolve;
+    });
 
     initPreviewer({
       root,
@@ -138,6 +145,7 @@ describe('PrototypePreviewer adapter preference synchronization', () => {
       expect(runtimeSpies.mount).toHaveBeenCalledWith('wc', expect.anything())
     );
     runtimeSpies.mount.mockClear();
+    runtimeSpies.mount.mockImplementation((id: string) => (id === 'vue2' ? remount : undefined));
 
     select.dispatchEvent(
       new CustomEvent('valueChange', { detail: { value: 'vue2' }, bubbles: true })
@@ -146,7 +154,10 @@ describe('PrototypePreviewer adapter preference synchronization', () => {
     await vi.waitFor(() =>
       expect(runtimeSpies.mount).toHaveBeenCalledWith('vue2', expect.anything())
     );
+    expect(select.dataset.disabled).toBe('true');
     expect(runtimeSpies.mount).toHaveBeenCalledTimes(1);
+    resolveRemount?.();
+    await vi.waitFor(() => expect(select.dataset.disabled).toBe('false'));
     await (root as any).__previewer__.destroy();
   });
 

--- a/apps/www/src/components/PrototypePreviewer/previewer-client.test.ts
+++ b/apps/www/src/components/PrototypePreviewer/previewer-client.test.ts
@@ -221,6 +221,94 @@ describe('PrototypePreviewer adapter preference synchronization', () => {
     root.remove();
   });
 
+  it('does not remount when duplicate adapter events target the active runtime', async () => {
+    const root = createPreviewerRoot();
+
+    initPreviewer({
+      root,
+      prototypeId: 'demo',
+      initialRuntime: 'wc',
+      demoProps: {},
+      runtimeList: ['wc', 'vue2'],
+    });
+    await vi.waitFor(() =>
+      expect(runtimeSpies.mount).toHaveBeenCalledWith('wc', expect.anything())
+    );
+    runtimeSpies.mount.mockClear();
+
+    document.dispatchEvent(new CustomEvent('proto-adapter:change', { detail: { adapter: 'wc' } }));
+    await Promise.resolve();
+    expect(runtimeSpies.mount).not.toHaveBeenCalled();
+
+    await (root as any).__previewer__.reload();
+    await vi.waitFor(() =>
+      expect(runtimeSpies.mount).toHaveBeenCalledWith('wc', expect.anything())
+    );
+    await (root as any).__previewer__.destroy();
+    root.remove();
+  });
+
+  it('lets a newer adapter event replace an in-flight runtime request', async () => {
+    let resolveVue2Mount: (() => void) | undefined;
+    const vue2Mount = new Promise<void>((resolve) => {
+      resolveVue2Mount = resolve;
+    });
+    runtimeSpies.mount.mockImplementation((id: string) => (id === 'vue2' ? vue2Mount : undefined));
+    const root = createPreviewerRoot();
+
+    initPreviewer({
+      root,
+      prototypeId: 'demo',
+      initialRuntime: 'wc',
+      demoProps: {},
+      runtimeList: ['wc', 'vue2'],
+    });
+    await vi.waitFor(() =>
+      expect(runtimeSpies.mount).toHaveBeenCalledWith('wc', expect.anything())
+    );
+
+    document.dispatchEvent(
+      new CustomEvent('proto-adapter:change', { detail: { adapter: 'vue2' } })
+    );
+    await vi.waitFor(() =>
+      expect(runtimeSpies.mount).toHaveBeenCalledWith('vue2', expect.anything())
+    );
+
+    document.dispatchEvent(new CustomEvent('proto-adapter:change', { detail: { adapter: 'wc' } }));
+    resolveVue2Mount?.();
+
+    await vi.waitFor(() => expect(runtimeSpies.mount).toHaveBeenCalledTimes(3));
+    expect((root as any).__previewer__.getCurrentRuntime()).toBe('wc');
+    await (root as any).__previewer__.destroy();
+    root.remove();
+  });
+
+  it('clears the active runtime before a failed remount', async () => {
+    runtimeSpies.mount.mockImplementation((id: string) => {
+      if (id === 'vue2') throw new Error('vue2 failed');
+    });
+    const root = createPreviewerRoot();
+
+    initPreviewer({
+      root,
+      prototypeId: 'demo',
+      initialRuntime: 'wc',
+      demoProps: {},
+      runtimeList: ['wc', 'vue2'],
+    });
+    await vi.waitFor(() =>
+      expect(runtimeSpies.mount).toHaveBeenCalledWith('wc', expect.anything())
+    );
+
+    document.dispatchEvent(
+      new CustomEvent('proto-adapter:change', { detail: { adapter: 'vue2' } })
+    );
+    await vi.waitFor(() => expect(root.textContent).toContain('[Preview Error]'));
+    expect((root as any).__previewer__.getCurrentRuntime()).toBeNull();
+    await (root as any).__previewer__.destroy();
+    root.remove();
+  });
+
   it('invalidates the host before every switch and terminal destroy', async () => {
     const root = createPreviewerRoot();
     const host = root.querySelector<HTMLElement>('.host')!;

--- a/apps/www/src/components/PrototypePreviewer/previewer-client.test.ts
+++ b/apps/www/src/components/PrototypePreviewer/previewer-client.test.ts
@@ -9,6 +9,7 @@ const hostMountSpies = vi.hoisted(() => ({
 }));
 
 vi.mock('./runtimes/registry', () => ({
+  AdapterIds: ['wc', 'vue2'],
   runtimeLoaders: {
     wc: async () => ({
       id: 'wc',
@@ -33,13 +34,43 @@ vi.mock('./demo-types', () => ({ collectPrototypeIds: () => {} }));
 vi.mock('./runtimes/host-mount', () => ({
   releaseHostMount: (host: HTMLElement) => hostMountSpies.release(host),
 }));
+vi.mock('../site-shadcn-controls', () => ({
+  initSiteShadcnControls: () => {},
+  selectValue: (root: HTMLElement) => root.dataset.value ?? '',
+  setSelectValue: (root: HTMLElement, value: string) => {
+    root.dataset.value = value;
+  },
+}));
 
 import { initPreviewer } from './previewer-client';
+import { initAdapterSelects } from '../adapter-preference';
+import { initSiteShadcnControls, selectValue, type SiteSelectRoot } from '../site-shadcn-controls';
 
 function createPreviewerRoot() {
   const root = document.createElement('div');
   root.innerHTML = '<select></select><div class="host"></div>';
   document.body.appendChild(root);
+  return root;
+}
+
+function createProjectedPreviewerRoot() {
+  const root = document.createElement('div');
+  root.innerHTML = `<div data-adapter-select>
+    <wc-shadcn-select-root
+      data-site-select-root
+      data-adapter-select-root
+      data-site-initial-value="wc"
+    >
+      <wc-shadcn-select-trigger><wc-shadcn-select-value></wc-shadcn-select-value></wc-shadcn-select-trigger>
+      <wc-shadcn-select-content>
+        <wc-shadcn-select-item data-value="wc" data-text-value="Web Components">Web Components</wc-shadcn-select-item>
+        <wc-shadcn-select-item data-value="vue2" data-text-value="Vue 2">Vue 2</wc-shadcn-select-item>
+      </wc-shadcn-select-content>
+    </wc-shadcn-select-root>
+  </div><div class="host"></div>`;
+  document.body.appendChild(root);
+  initSiteShadcnControls(document);
+  initAdapterSelects(document);
   return root;
 }
 
@@ -70,6 +101,53 @@ describe('PrototypePreviewer adapter preference synchronization', () => {
     expect((root.querySelector('select') as HTMLSelectElement).value).toBe('vue2');
     await (root as any).__previewer__.destroy();
     root.remove();
+  });
+
+  it('aligns the projected selector with a non-wc initial runtime', async () => {
+    const root = createProjectedPreviewerRoot();
+
+    initPreviewer({
+      root,
+      prototypeId: 'demo',
+      initialRuntime: 'vue2',
+      demoProps: {},
+      runtimeList: ['wc', 'vue2'],
+    });
+
+    await vi.waitFor(() =>
+      expect(runtimeSpies.mount).toHaveBeenCalledWith('vue2', expect.anything())
+    );
+    expect(selectValue(root.querySelector('[data-adapter-select-root]') as SiteSelectRoot)).toBe(
+      'vue2'
+    );
+    await (root as any).__previewer__.destroy();
+  });
+
+  it('routes a projected selection through one page-level remount path', async () => {
+    const root = createProjectedPreviewerRoot();
+    const select = root.querySelector('[data-adapter-select-root]') as SiteSelectRoot;
+
+    initPreviewer({
+      root,
+      prototypeId: 'demo',
+      initialRuntime: 'wc',
+      demoProps: {},
+      runtimeList: ['wc', 'vue2'],
+    });
+    await vi.waitFor(() =>
+      expect(runtimeSpies.mount).toHaveBeenCalledWith('wc', expect.anything())
+    );
+    runtimeSpies.mount.mockClear();
+
+    select.dispatchEvent(
+      new CustomEvent('valueChange', { detail: { value: 'vue2' }, bubbles: true })
+    );
+
+    await vi.waitFor(() =>
+      expect(runtimeSpies.mount).toHaveBeenCalledWith('vue2', expect.anything())
+    );
+    expect(runtimeSpies.mount).toHaveBeenCalledTimes(1);
+    await (root as any).__previewer__.destroy();
   });
 
   it('remounts when the page-level adapter selector broadcasts a compatible runtime', async () => {

--- a/apps/www/src/components/PrototypePreviewer/previewer-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/previewer-client.ts
@@ -50,7 +50,7 @@ export function initPreviewer(options: PreviewerOptions) {
     if (selectRoot) setSelectValue(selectRoot, value);
     else if (nativeSelect) nativeSelect.value = value;
   };
-  const setSelectDisabled = (disabled: boolean) => {
+  const setPreviewerSelectDisabled = (disabled: boolean) => {
     if (selectRoot) setSiteSelectDisabled(selectRoot, disabled);
     else if (nativeSelect) nativeSelect.disabled = disabled;
   };
@@ -169,7 +169,7 @@ export function initPreviewer(options: PreviewerOptions) {
     // Invalidate a runtime that is still awaiting its loader before this
     // switch reaches the next runtime's mount() call.
     releaseHostMount(host);
-    setSelectDisabled(true);
+    setPreviewerSelectDisabled(true);
 
     try {
       // 卸载旧 runtime / demo
@@ -236,7 +236,7 @@ export function initPreviewer(options: PreviewerOptions) {
       console.error(err);
       dispatch('error', { error: err });
     } finally {
-      if (myVersion === version && !destroyed) setSelectDisabled(false);
+      if (myVersion === version && !destroyed) setPreviewerSelectDisabled(false);
     }
   }
 
@@ -255,7 +255,14 @@ export function initPreviewer(options: PreviewerOptions) {
     writeSelectValue(id);
     void switchTo(id);
   };
-  if (nativeSelect && !nativeSelectUsesPagePreference) {
+  // AdapterSelect already broadcasts a single document-level preference event
+  // for its valueChange. Listening to that root as well would remount twice;
+  // retain the local path only for isolated custom-select embeddings that do
+  // not participate in the shared adapter preference bridge.
+  const usesSharedAdapterSelect = selectRoot?.hasAttribute('data-adapter-select-root') ?? false;
+  if (selectRoot && !usesSharedAdapterSelect) {
+    selectRoot.addEventListener('valueChange', onSelectChange);
+  } else if (nativeSelect && !nativeSelectUsesPagePreference) {
     nativeSelect.addEventListener('change', onSelectChange);
   }
 
@@ -294,7 +301,9 @@ export function initPreviewer(options: PreviewerOptions) {
       host.innerHTML = '';
       current = null;
       currentDemo = null;
-      if (nativeSelect && !nativeSelectUsesPagePreference) {
+      if (selectRoot && !usesSharedAdapterSelect) {
+        selectRoot.removeEventListener('valueChange', onSelectChange);
+      } else if (nativeSelect && !nativeSelectUsesPagePreference) {
         nativeSelect.removeEventListener('change', onSelectChange);
       }
     },

--- a/apps/www/src/components/PrototypePreviewer/previewer-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/previewer-client.ts
@@ -252,8 +252,6 @@ export function initPreviewer(options: PreviewerOptions) {
       if (myVersion === version && !destroyed) {
         requestedRuntime = null;
         setPreviewerSelectDisabled(false);
-      } else if (requestedRuntime === runtime && myVersion !== version) {
-        requestedRuntime = null;
       }
     }
   }

--- a/apps/www/src/components/PrototypePreviewer/previewer-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/previewer-client.ts
@@ -11,6 +11,7 @@ import { refreshCodePanel } from './code-panel-client';
 import {
   initSiteShadcnControls,
   selectValue,
+  setSiteSelectDisabled,
   setSelectValue,
   type SiteSelectRoot,
 } from '../site-shadcn-controls';
@@ -50,7 +51,7 @@ export function initPreviewer(options: PreviewerOptions) {
     else if (nativeSelect) nativeSelect.value = value;
   };
   const setSelectDisabled = (disabled: boolean) => {
-    if (selectRoot) selectRoot.setProps?.({ disabled });
+    if (selectRoot) setSiteSelectDisabled(selectRoot, disabled);
     else if (nativeSelect) nativeSelect.disabled = disabled;
   };
 

--- a/apps/www/src/components/PrototypePreviewer/previewer-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/previewer-client.ts
@@ -65,6 +65,7 @@ export function initPreviewer(options: PreviewerOptions) {
   }
 
   const selectedInitialRuntime = preferredRuntime();
+  const nativeSelectUsesPagePreference = Boolean(nativeSelect?.closest('[data-adapter-select]'));
 
   let current: { id: string; api: any } | null = null;
   let currentDemo: { id: string; destroy: () => Promise<void> | void } | null = null;
@@ -106,10 +107,9 @@ export function initPreviewer(options: PreviewerOptions) {
       content?.appendChild(item);
     }
     initSiteShadcnControls(selectRoot);
-    const selected = readSelectValue();
-    writeSelectValue(
-      runtimeList.includes(selected as RuntimeId) ? selected : selectedInitialRuntime
-    );
+    // AdapterSelect has an SSR `wc` seed. The preference-adjusted runtime is
+    // authoritative for both the first mount and the visible selector.
+    writeSelectValue(selectedInitialRuntime);
   } else if (nativeSelect) {
     nativeSelect.innerHTML = '';
     for (const id of runtimeList) {
@@ -254,10 +254,7 @@ export function initPreviewer(options: PreviewerOptions) {
     writeSelectValue(id);
     void switchTo(id);
   };
-  if (selectRoot) {
-    selectRoot.addEventListener('valueChange', onSelectChange);
-    selectRoot.addEventListener('change', onSelectChange);
-  } else if (nativeSelect) {
+  if (nativeSelect && !nativeSelectUsesPagePreference) {
     nativeSelect.addEventListener('change', onSelectChange);
   }
 
@@ -296,10 +293,7 @@ export function initPreviewer(options: PreviewerOptions) {
       host.innerHTML = '';
       current = null;
       currentDemo = null;
-      if (selectRoot) {
-        selectRoot.removeEventListener('valueChange', onSelectChange);
-        selectRoot.removeEventListener('change', onSelectChange);
-      } else if (nativeSelect) {
+      if (nativeSelect && !nativeSelectUsesPagePreference) {
         nativeSelect.removeEventListener('change', onSelectChange);
       }
     },

--- a/apps/www/src/components/PrototypePreviewer/previewer-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/previewer-client.ts
@@ -307,7 +307,7 @@ export function initPreviewer(options: PreviewerOptions) {
         return;
       }
       Object.assign(demoProps, nextProps || {});
-      if (current) switchTo(current.id);
+      if (current) switchTo(current.id, { force: true });
     },
     destroy: async () => {
       destroyed = true;

--- a/apps/www/src/components/PrototypePreviewer/previewer-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/previewer-client.ts
@@ -70,6 +70,7 @@ export function initPreviewer(options: PreviewerOptions) {
 
   let current: { id: string; api: any } | null = null;
   let currentDemo: { id: string; destroy: () => Promise<void> | void } | null = null;
+  let requestedRuntime: RuntimeId | null = null;
   let version = 0;
   let destroyed = false;
 
@@ -163,8 +164,18 @@ export function initPreviewer(options: PreviewerOptions) {
     return loaderPromise;
   }
 
-  async function switchTo(id: string) {
+  async function switchTo(id: string, options: { force?: boolean } = {}) {
     if (destroyed) return;
+    const runtime = id as RuntimeId;
+    const activeRuntime = current?.id ?? currentDemo?.id ?? null;
+    if (
+      !options.force &&
+      (requestedRuntime === runtime || (requestedRuntime === null && activeRuntime === runtime))
+    ) {
+      writeSelectValue(runtime);
+      return;
+    }
+    requestedRuntime = runtime;
     const myVersion = ++version;
     // Invalidate a runtime that is still awaiting its loader before this
     // switch reaches the next runtime's mount() call.
@@ -177,7 +188,9 @@ export function initPreviewer(options: PreviewerOptions) {
         await currentDemo.destroy();
         currentDemo = null;
       }
-      if (current?.api?.unmount) await current.api.unmount(host);
+      const previous = current;
+      current = null;
+      if (previous?.api?.unmount) await previous.api.unmount(host);
       else host.innerHTML = '';
 
       if (demoId) {
@@ -187,15 +200,15 @@ export function initPreviewer(options: PreviewerOptions) {
         await loadPrototypes(Array.from(ids));
 
         const { destroy } = await renderDemo({
-          runtime: id as RuntimeId,
+          runtime,
           demo,
           host,
           isCurrent: () => !destroyed && myVersion === version,
         });
         if (destroyed || myVersion !== version) return;
         currentDemo = { id, destroy };
-        updateCodePanel(id as RuntimeId);
-        dispatch('runtime:changed', { id });
+        updateCodePanel(runtime);
+        dispatch('runtime:changed', { id: runtime });
         return;
       }
 
@@ -208,7 +221,7 @@ export function initPreviewer(options: PreviewerOptions) {
 
       // 并行加载：运行时 API + 原型对象引用
       const [api, proto] = await Promise.all([
-        runtimeLoaders[id as RuntimeId](),
+        runtimeLoaders[runtime](),
         Promise.resolve().then(() => getPrototype(prototypeId)),
       ]);
 
@@ -218,8 +231,8 @@ export function initPreviewer(options: PreviewerOptions) {
       await api.mount(host, proto, { props: demoProps });
       if (destroyed || myVersion !== version) return;
       current = { id, api };
-      updateCodePanel(id as RuntimeId);
-      dispatch('runtime:changed', { id });
+      updateCodePanel(runtime);
+      dispatch('runtime:changed', { id: runtime });
     } catch (err) {
       if (destroyed || myVersion !== version) return;
       // 如果是原型未找到的错误，不需要重试（动态加载应该已经处理了）
@@ -236,7 +249,12 @@ export function initPreviewer(options: PreviewerOptions) {
       console.error(err);
       dispatch('error', { error: err });
     } finally {
-      if (myVersion === version && !destroyed) setPreviewerSelectDisabled(false);
+      if (myVersion === version && !destroyed) {
+        requestedRuntime = null;
+        setPreviewerSelectDisabled(false);
+      } else if (requestedRuntime === runtime && myVersion !== version) {
+        requestedRuntime = null;
+      }
     }
   }
 
@@ -278,8 +296,8 @@ export function initPreviewer(options: PreviewerOptions) {
   (root as any).__previewer__ = {
     switchRuntime: (id: string) => switchTo(id),
     reload: () => {
-      if (current) return switchTo(current.id);
-      if (currentDemo) return switchTo(currentDemo.id);
+      if (current) return switchTo(current.id, { force: true });
+      if (currentDemo) return switchTo(currentDemo.id, { force: true });
       return null;
     },
     getCurrentRuntime: () => current?.id ?? currentDemo?.id ?? null,

--- a/apps/www/src/components/PrototypePreviewer/previewer-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/previewer-client.ts
@@ -8,6 +8,12 @@ import { collectPrototypeIds } from './demo-types';
 import { releaseHostMount } from './runtimes/host-mount';
 import type { RuntimeId } from './runtimes/registry';
 import { refreshCodePanel } from './code-panel-client';
+import {
+  initSiteShadcnControls,
+  selectValue,
+  setSelectValue,
+  type SiteSelectRoot,
+} from '../site-shadcn-controls';
 
 const PREFERRED_ADAPTER_KEY = 'preferred-prototypes-adapter';
 
@@ -32,7 +38,21 @@ export function initPreviewer(options: PreviewerOptions) {
   root.dataset.inited = '1';
 
   const host = root.querySelector('.host') as HTMLElement;
-  const select = root.querySelector('select') as HTMLSelectElement | null;
+  const selectRoot = root.querySelector<SiteSelectRoot>(
+    '[data-adapter-select-root], wc-shadcn-select-root'
+  );
+  const nativeSelect = root.querySelector<HTMLSelectElement>('select');
+
+  const readSelectValue = () =>
+    selectRoot ? selectValue(selectRoot) : (nativeSelect?.value ?? initialRuntime);
+  const writeSelectValue = (value: string) => {
+    if (selectRoot) setSelectValue(selectRoot, value);
+    else if (nativeSelect) nativeSelect.value = value;
+  };
+  const setSelectDisabled = (disabled: boolean) => {
+    if (selectRoot) selectRoot.setProps?.({ disabled });
+    else if (nativeSelect) nativeSelect.disabled = disabled;
+  };
 
   function preferredRuntime(): RuntimeId {
     try {
@@ -65,9 +85,33 @@ export function initPreviewer(options: PreviewerOptions) {
     if (shell) refreshCodePanel(shell, { reset: true });
   }
 
-  // 初始化下拉
-  if (select) {
-    select.innerHTML = '';
+  // Populate the shared Shadcn Select composition while retaining a native
+  // fallback for the isolated unit-test harness and third-party embeds.
+  if (selectRoot) {
+    const content = selectRoot.querySelector<HTMLElement>('wc-shadcn-select-content');
+    content?.replaceChildren();
+    for (const id of runtimeList) {
+      const item = document.createElement('wc-shadcn-select-item');
+      item.dataset.value = id;
+      item.dataset.textValue =
+        (
+          {
+            wc: 'Web Components',
+            react: 'React',
+            vue: 'Vue',
+            vue2: 'Vue 2',
+          } as Record<string, string>
+        )[id] || id;
+      item.textContent = item.dataset.textValue;
+      content?.appendChild(item);
+    }
+    initSiteShadcnControls(selectRoot);
+    const selected = readSelectValue();
+    writeSelectValue(
+      runtimeList.includes(selected as RuntimeId) ? selected : selectedInitialRuntime
+    );
+  } else if (nativeSelect) {
+    nativeSelect.innerHTML = '';
     for (const id of runtimeList) {
       const opt = document.createElement('option');
       opt.value = id;
@@ -81,7 +125,7 @@ export function initPreviewer(options: PreviewerOptions) {
           } as Record<string, string>
         )[id] || id;
       if (id === selectedInitialRuntime) opt.selected = true;
-      select.appendChild(opt);
+      nativeSelect.appendChild(opt);
     }
   }
 
@@ -124,7 +168,7 @@ export function initPreviewer(options: PreviewerOptions) {
     // Invalidate a runtime that is still awaiting its loader before this
     // switch reaches the next runtime's mount() call.
     releaseHostMount(host);
-    if (select) select.disabled = true;
+    setSelectDisabled(true);
 
     try {
       // 卸载旧 runtime / demo
@@ -191,7 +235,7 @@ export function initPreviewer(options: PreviewerOptions) {
       console.error(err);
       dispatch('error', { error: err });
     } finally {
-      if (myVersion === version && !destroyed && select) select.disabled = false;
+      if (myVersion === version && !destroyed) setSelectDisabled(false);
     }
   }
 
@@ -203,10 +247,24 @@ export function initPreviewer(options: PreviewerOptions) {
   // AdapterSelect synchronizes all selector instances and broadcasts the selected
   // runtime. Listen on document so the page-level selector also remounts every
   // compatible previewer; previewer-local selector changes use the same path.
+  const onSelectChange = (event: Event) => {
+    const detail = (event as CustomEvent<{ value?: unknown }>).detail;
+    const id = typeof detail?.value === 'string' ? detail.value : readSelectValue();
+    if (!runtimeList.includes(id as RuntimeId)) return;
+    writeSelectValue(id);
+    void switchTo(id);
+  };
+  if (selectRoot) {
+    selectRoot.addEventListener('valueChange', onSelectChange);
+    selectRoot.addEventListener('change', onSelectChange);
+  } else if (nativeSelect) {
+    nativeSelect.addEventListener('change', onSelectChange);
+  }
+
   const onAdapterChange = (event: Event) => {
     const id = (event as CustomEvent<{ adapter?: unknown }>).detail?.adapter;
     if (typeof id !== 'string' || !runtimeList.includes(id as RuntimeId)) return;
-    if (select) select.value = id;
+    writeSelectValue(id);
     void switchTo(id);
   };
   document.addEventListener('proto-adapter:change', onAdapterChange);
@@ -238,6 +296,12 @@ export function initPreviewer(options: PreviewerOptions) {
       host.innerHTML = '';
       current = null;
       currentDemo = null;
+      if (selectRoot) {
+        selectRoot.removeEventListener('valueChange', onSelectChange);
+        selectRoot.removeEventListener('change', onSelectChange);
+      } else if (nativeSelect) {
+        nativeSelect.removeEventListener('change', onSelectChange);
+      }
     },
   };
 

--- a/apps/www/src/components/PrototypePreviewer/runtimes/host-mount.test.ts
+++ b/apps/www/src/components/PrototypePreviewer/runtimes/host-mount.test.ts
@@ -26,4 +26,13 @@ describe('Previewer host mount lease', () => {
     expect(secondCleanup).toHaveBeenCalledTimes(1);
     expect(host.childElementCount).toBe(0);
   });
+
+  it('clears framework mount markers together with the host generation', () => {
+    const host = document.createElement('div');
+    host.setAttribute('data-v-app', '');
+
+    releaseHostMount(host);
+
+    expect(host.hasAttribute('data-v-app')).toBe(false);
+  });
 });

--- a/apps/www/src/components/PrototypePreviewer/runtimes/host-mount.ts
+++ b/apps/www/src/components/PrototypePreviewer/runtimes/host-mount.ts
@@ -30,6 +30,10 @@ function disposeCurrent(state: HostMountState): void {
 
 function clearHost(host: HTMLElement): void {
   host.replaceChildren();
+  // Vue 3 marks its mount container with `data-v-app`. The marker is owned by
+  // the framework, not by the preview surface; clear it with the host lease so
+  // a later Vue 2/React mount cannot be mistaken for a Vue 3 app.
+  host.removeAttribute('data-v-app');
 }
 
 /**

--- a/apps/www/src/components/adapter-preference.ts
+++ b/apps/www/src/components/adapter-preference.ts
@@ -13,10 +13,10 @@ export function isRuntimeId(value: unknown): value is PublicRuntimeId {
   return typeof value === 'string' && AdapterIds.includes(value as PublicRuntimeId);
 }
 
+type AdapterSelectControl = HTMLSelectElement | SiteSelectRoot;
+
 const initializedDocuments = new WeakSet<Document>();
 const lastKnownAdapterValues = new WeakMap<AdapterSelectControl, string>();
-
-type AdapterSelectControl = HTMLSelectElement | SiteSelectRoot;
 
 function isNativeSelect(control: AdapterSelectControl): control is HTMLSelectElement {
   return control instanceof HTMLSelectElement;
@@ -51,6 +51,7 @@ function preferredAdapter(doc: Document): PublicRuntimeId | null {
     return null;
   }
 }
+
 function initializeAdapterSelect(select: AdapterSelectControl): void {
   if (select.dataset.adapterSelectInit === '1') return;
   select.dataset.adapterSelectInit = '1';

--- a/apps/www/src/components/adapter-preference.ts
+++ b/apps/www/src/components/adapter-preference.ts
@@ -1,4 +1,5 @@
 import { AdapterIds, type PublicRuntimeId } from './PrototypePreviewer/runtimes/registry';
+import { selectValue, setSelectValue, type SiteSelectRoot } from './site-shadcn-controls';
 
 export const PREFERRED_ADAPTER_KEY = 'preferred-prototypes-adapter';
 export const DEFAULT_ADAPTER: PublicRuntimeId = 'wc';
@@ -14,8 +15,31 @@ export function isRuntimeId(value: unknown): value is PublicRuntimeId {
 
 const initializedDocuments = new WeakSet<Document>();
 
-function supportsAdapter(select: HTMLSelectElement, adapter: PublicRuntimeId): boolean {
-  return Array.from(select.options).some((option) => option.value === adapter);
+type AdapterSelectControl = HTMLSelectElement | SiteSelectRoot;
+
+function isNativeSelect(control: AdapterSelectControl): control is HTMLSelectElement {
+  return control instanceof HTMLSelectElement;
+}
+
+function supportsAdapter(control: AdapterSelectControl, adapter: PublicRuntimeId): boolean {
+  if (isNativeSelect(control)) {
+    return Array.from(control.options).some((option) => option.value === adapter);
+  }
+  return Array.from(control.querySelectorAll<HTMLElement>('wc-shadcn-select-item')).some(
+    (item) => item.dataset.value === adapter
+  );
+}
+
+function readControlValue(control: AdapterSelectControl): string {
+  return isNativeSelect(control) ? control.value : selectValue(control);
+}
+
+function writeControlValue(control: AdapterSelectControl, value: string): void {
+  if (isNativeSelect(control)) {
+    control.value = value;
+  } else {
+    setSelectValue(control, value);
+  }
 }
 
 function preferredAdapter(doc: Document): PublicRuntimeId | null {
@@ -27,22 +51,24 @@ function preferredAdapter(doc: Document): PublicRuntimeId | null {
   }
 }
 
-function initializeAdapterSelect(select: HTMLSelectElement): void {
+function initializeAdapterSelect(select: AdapterSelectControl): void {
   if (select.dataset.adapterSelectInit === '1') return;
   select.dataset.adapterSelectInit = '1';
 
   const stored = preferredAdapter(select.ownerDocument);
   if (stored && supportsAdapter(select, stored)) {
-    select.value = stored;
+    writeControlValue(select, stored);
   } else if (supportsAdapter(select, DEFAULT_ADAPTER)) {
-    select.value = DEFAULT_ADAPTER;
-  } else if (select.options.length > 0) {
+    writeControlValue(select, DEFAULT_ADAPTER);
+  } else if (isNativeSelect(select) && select.options.length > 0) {
     select.selectedIndex = 0;
   }
 
-  select.addEventListener('change', () => {
-    const adapter = select.value;
+  const handleChange = (event: Event) => {
+    const detail = (event as CustomEvent<{ value?: unknown }>).detail;
+    const adapter = typeof detail?.value === 'string' ? detail.value : readControlValue(select);
     if (!isRuntimeId(adapter)) return;
+    writeControlValue(select, adapter);
     try {
       select.ownerDocument.defaultView?.localStorage.setItem(PREFERRED_ADAPTER_KEY, adapter);
     } catch {
@@ -53,14 +79,21 @@ function initializeAdapterSelect(select: HTMLSelectElement): void {
         detail: { adapter },
       })
     );
-  });
+  };
+
+  select.addEventListener(isNativeSelect(select) ? 'change' : 'valueChange', handleChange);
 }
 
 function synchronizeAdapterSelects(doc: Document, adapter: PublicRuntimeId): void {
-  const selects = doc.querySelectorAll<HTMLSelectElement>('[data-adapter-select] select');
+  const selects: AdapterSelectControl[] = [
+    ...doc.querySelectorAll<HTMLSelectElement>('[data-adapter-select] select'),
+    ...doc.querySelectorAll<SiteSelectRoot>(
+      '[data-adapter-select] wc-shadcn-select-root[data-adapter-select-root]'
+    ),
+  ];
   for (const select of selects) {
-    if (!supportsAdapter(select, adapter) || select.value === adapter) continue;
-    select.value = adapter;
+    if (!supportsAdapter(select, adapter) || readControlValue(select) === adapter) continue;
+    writeControlValue(select, adapter);
     if (select.closest('[data-previewer-id]')) {
       select.dispatchEvent(new Event('change', { bubbles: true }));
     }
@@ -68,7 +101,12 @@ function synchronizeAdapterSelects(doc: Document, adapter: PublicRuntimeId): voi
 }
 
 export function initAdapterSelects(root: ParentNode): void {
-  const selects = root.querySelectorAll<HTMLSelectElement>('[data-adapter-select] select');
+  const selects: AdapterSelectControl[] = [
+    ...root.querySelectorAll<HTMLSelectElement>('[data-adapter-select] select'),
+    ...root.querySelectorAll<SiteSelectRoot>(
+      '[data-adapter-select] wc-shadcn-select-root[data-adapter-select-root]'
+    ),
+  ];
   for (const select of selects) initializeAdapterSelect(select);
 
   const node = root as Node;

--- a/apps/www/src/components/adapter-preference.ts
+++ b/apps/www/src/components/adapter-preference.ts
@@ -14,6 +14,7 @@ export function isRuntimeId(value: unknown): value is PublicRuntimeId {
 }
 
 const initializedDocuments = new WeakSet<Document>();
+const lastKnownAdapterValues = new WeakMap<AdapterSelectControl, string>();
 
 type AdapterSelectControl = HTMLSelectElement | SiteSelectRoot;
 
@@ -50,25 +51,31 @@ function preferredAdapter(doc: Document): PublicRuntimeId | null {
     return null;
   }
 }
-
 function initializeAdapterSelect(select: AdapterSelectControl): void {
   if (select.dataset.adapterSelectInit === '1') return;
   select.dataset.adapterSelectInit = '1';
 
   const stored = preferredAdapter(select.ownerDocument);
+  let initialValue = readControlValue(select);
   if (stored && supportsAdapter(select, stored)) {
     writeControlValue(select, stored);
+    initialValue = stored;
   } else if (supportsAdapter(select, DEFAULT_ADAPTER)) {
     writeControlValue(select, DEFAULT_ADAPTER);
+    initialValue = DEFAULT_ADAPTER;
   } else if (isNativeSelect(select) && select.options.length > 0) {
     select.selectedIndex = 0;
+    initialValue = select.value;
   }
+  lastKnownAdapterValues.set(select, initialValue);
 
   const handleChange = (event: Event) => {
     const detail = (event as CustomEvent<{ value?: unknown }>).detail;
     const adapter = typeof detail?.value === 'string' ? detail.value : readControlValue(select);
     if (!isRuntimeId(adapter)) return;
-    if (readControlValue(select) === adapter) return;
+    const previousValue = lastKnownAdapterValues.get(select) ?? readControlValue(select);
+    if (!isNativeSelect(select) && previousValue === adapter) return;
+    lastKnownAdapterValues.set(select, adapter);
     writeControlValue(select, adapter);
     try {
       select.ownerDocument.defaultView?.localStorage.setItem(PREFERRED_ADAPTER_KEY, adapter);
@@ -93,8 +100,13 @@ function synchronizeAdapterSelects(doc: Document, adapter: PublicRuntimeId): voi
     ),
   ];
   for (const select of selects) {
-    if (!supportsAdapter(select, adapter) || readControlValue(select) === adapter) continue;
+    if (!supportsAdapter(select, adapter)) continue;
+    if (readControlValue(select) === adapter) {
+      lastKnownAdapterValues.set(select, adapter);
+      continue;
+    }
     writeControlValue(select, adapter);
+    lastKnownAdapterValues.set(select, adapter);
     if (select.closest('[data-previewer-id]')) {
       select.dispatchEvent(new Event('change', { bubbles: true }));
     }

--- a/apps/www/src/components/adapter-preference.ts
+++ b/apps/www/src/components/adapter-preference.ts
@@ -68,6 +68,7 @@ function initializeAdapterSelect(select: AdapterSelectControl): void {
     const detail = (event as CustomEvent<{ value?: unknown }>).detail;
     const adapter = typeof detail?.value === 'string' ? detail.value : readControlValue(select);
     if (!isRuntimeId(adapter)) return;
+    if (readControlValue(select) === adapter) return;
     writeControlValue(select, adapter);
     try {
       select.ownerDocument.defaultView?.localStorage.setItem(PREFERRED_ADAPTER_KEY, adapter);

--- a/apps/www/src/components/code-example-client.ts
+++ b/apps/www/src/components/code-example-client.ts
@@ -14,10 +14,10 @@ interface CodeExampleController {
 const controllers = new WeakMap<HTMLElement, CodeExampleController>();
 let globalListenerInstalled = false;
 
-function tabsIn(list: HTMLElement): HTMLButtonElement[] {
+function tabsIn(list: HTMLElement): HTMLElement[] {
   return [...list.children].filter(
-    (child): child is HTMLButtonElement =>
-      child instanceof HTMLButtonElement && child.getAttribute('role') === 'tab'
+    (child): child is HTMLElement =>
+      child instanceof HTMLElement && child.getAttribute('role') === 'tab'
   );
 }
 
@@ -29,8 +29,8 @@ function childPanels(root: HTMLElement, dataAttribute: string): HTMLElement[] {
 }
 
 function activateTab(
-  tabs: readonly HTMLButtonElement[],
-  active: HTMLButtonElement,
+  tabs: readonly HTMLElement[],
+  active: HTMLElement,
   panels: readonly HTMLElement[]
 ): void {
   const controls = active.getAttribute('aria-controls');
@@ -44,12 +44,12 @@ function activateTab(
 
 function installHorizontalActivation(
   list: HTMLElement,
-  activate: (tab: HTMLButtonElement) => void
+  activate: (tab: HTMLElement) => void
 ): void {
   const tabs = tabsIn(list);
   for (const tab of tabs) tab.addEventListener('click', () => activate(tab));
   list.addEventListener('keydown', (event) => {
-    if (!(event.target instanceof HTMLButtonElement) || !tabs.includes(event.target)) return;
+    if (!(event.target instanceof HTMLElement) || !tabs.includes(event.target)) return;
     const currentIndex = tabs.indexOf(event.target);
     let nextIndex: number | undefined;
     if (event.key === 'ArrowLeft') nextIndex = currentIndex - 1;
@@ -84,7 +84,7 @@ function initCodeExample(root: HTMLElement): void {
   const hostPanels = childPanels(root, 'data-code-host-panel');
   let localOverride = false;
 
-  function selectFile(panel: HTMLElement, tab: HTMLButtonElement): void {
+  function selectFile(panel: HTMLElement, tab: HTMLElement): void {
     const fileList = panel.querySelector<HTMLElement>('[data-code-file-tabs]');
     if (!fileList) return;
     const filePanels = childPanels(panel, 'data-code-file-panel');
@@ -98,7 +98,7 @@ function initCodeExample(root: HTMLElement): void {
     if (fileList) installHorizontalActivation(fileList, (tab) => selectFile(panel, tab));
   }
 
-  function selectHost(tab: HTMLButtonElement, isLocal: boolean): void {
+  function selectHost(tab: HTMLElement, isLocal: boolean): void {
     if (isLocal) localOverride = true;
     activateTab(hostTabs, tab, hostPanels);
     const panel = hostPanels.find((candidate) => !candidate.hidden);
@@ -108,7 +108,7 @@ function initCodeExample(root: HTMLElement): void {
 
   installHorizontalActivation(hostList, (tab) => selectHost(tab, true));
 
-  function tabForHost(host: PublicRuntimeId): HTMLButtonElement | undefined {
+  function tabForHost(host: PublicRuntimeId): HTMLElement | undefined {
     return hostTabs.find((tab) => tab.dataset.codeHost === host);
   }
 

--- a/apps/www/src/components/override/AdapterSelect.astro
+++ b/apps/www/src/components/override/AdapterSelect.astro
@@ -15,55 +15,49 @@ const options = [
 ---
 
 <div class="adapter-select-wrapper relative inline-flex items-center" data-adapter-select>
-  <label class="sr-only" for={id}>选择适配器</label>
-  <select
+  <span class="sr-only">选择适配器</span>
+  <wc-shadcn-select-root
     id={id}
-    class="adapter-select appearance-none inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all outline-none h-8 rounded-md gap-1.5 px-3 pr-8 cursor-pointer bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+    data-site-select-root
+    data-adapter-select-root
+    data-site-initial-value="wc"
     aria-label="选择适配器"
-    autocomplete="off"
-    data-adapter-select
   >
-    {options.map((opt) => <option value={opt.value}>{opt.label}</option>)}
-  </select>
+    <wc-shadcn-select-trigger
+      data-size="sm"
+      class="adapter-select inline-flex h-8 min-w-36 items-center justify-between rounded-md border-transparent bg-transparent px-3 text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+    >
+      <wc-shadcn-select-value data-placeholder="选择适配器"></wc-shadcn-select-value>
+    </wc-shadcn-select-trigger>
+    <wc-shadcn-select-content data-position="popper" data-align="end">
+      {
+        options.map((opt) => (
+          <wc-shadcn-select-item data-value={opt.value} data-text-value={opt.label}>
+            {opt.label}
+          </wc-shadcn-select-item>
+        ))
+      }
+    </wc-shadcn-select-content>
+  </wc-shadcn-select-root>
   <script>
+    import { initSiteShadcnControls } from '../site-shadcn-controls';
     import { initAdapterSelects } from '../adapter-preference';
 
+    initSiteShadcnControls(document);
     initAdapterSelects(document);
-    document.addEventListener('astro:page-load', () => initAdapterSelects(document));
+    document.addEventListener('astro:page-load', () => {
+      initSiteShadcnControls(document);
+      initAdapterSelects(document);
+    });
   </script>
-  <svg
-    class="adapter-select-arrow absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-foreground opacity-60 transition-opacity w-4 h-4"
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden="true"
-  >
-    <path
-      d="M4 6L8 10L12 6"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"></path>
-  </svg>
 </div>
 
 <style>
-  .adapter-select-wrapper:hover .adapter-select-arrow {
-    opacity: 1;
+  .adapter-select-wrapper wc-shadcn-select-root {
+    display: inline-flex;
   }
-  .adapter-select {
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    border: 1px solid transparent;
-  }
-  .adapter-select option {
-    background-color: var(--color-popover);
-    color: var(--color-popover-foreground);
-    padding: 0.5rem;
-  }
-  .adapter-select:focus-visible {
-    border-color: var(--color-ring);
+
+  .adapter-select-wrapper wc-shadcn-select-trigger {
+    min-width: 9rem;
   }
 </style>

--- a/apps/www/src/components/override/AdapterSelect.astro
+++ b/apps/www/src/components/override/AdapterSelect.astro
@@ -61,4 +61,10 @@ const options = [
   .adapter-select-wrapper wc-shadcn-select-trigger {
     min-width: 9rem;
   }
+
+  /* Keep server-rendered chrome compact until the custom elements upgrade so
+     the projected option list never flashes inline in the header. */
+  .adapter-select-wrapper wc-shadcn-select-content:not(:defined) {
+    display: none;
+  }
 </style>

--- a/apps/www/src/components/override/AdapterSelect.astro
+++ b/apps/www/src/components/override/AdapterSelect.astro
@@ -4,6 +4,7 @@ interface Props {
 }
 
 const { id = 'adapter-select' } = Astro.props;
+const labelId = `${id}-label-${Math.random().toString(36).slice(2)}`;
 
 // 适配器选项
 const options = [
@@ -15,15 +16,15 @@ const options = [
 ---
 
 <div class="adapter-select-wrapper relative inline-flex items-center" data-adapter-select>
-  <span class="sr-only">选择适配器</span>
+  <span id={labelId} class="sr-only">选择适配器</span>
   <wc-shadcn-select-root
     id={id}
     data-site-select-root
     data-adapter-select-root
     data-site-initial-value="wc"
-    aria-label="选择适配器"
   >
     <wc-shadcn-select-trigger
+      aria-labelledby={labelId}
       data-size="sm"
       class="adapter-select inline-flex h-8 min-w-36 items-center justify-between rounded-md border-transparent bg-transparent px-3 text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
     >

--- a/apps/www/src/components/override/LanguageSelect.astro
+++ b/apps/www/src/components/override/LanguageSelect.astro
@@ -74,6 +74,10 @@ const labelId = `language-select-label-${Math.random().toString(36).slice(2)}`;
   .language-select-wrapper wc-shadcn-select-trigger {
     min-width: 6rem;
   }
+
+  .language-select-wrapper wc-shadcn-select-content:not(:defined) {
+    display: none;
+  }
 </style>
 
 <script>

--- a/apps/www/src/components/override/LanguageSelect.astro
+++ b/apps/www/src/components/override/LanguageSelect.astro
@@ -32,75 +32,54 @@ const localePaths: Record<string, string> = {};
 localeOptions.forEach((opt) => {
   localePaths[opt.value] = opt.path;
 });
+
+const selectedLocale =
+  localeOptions.find((option) => option.isCurrent)?.value ?? currentLocale ?? locales[0] ?? '';
 ---
 
-<label class="language-select-wrapper relative inline-flex items-center">
+<div class="language-select-wrapper relative inline-flex items-center" data-language-select>
   <span class="sr-only">选择语言 / Select Language</span>
-  <select
-    class="language-select appearance-none inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-all outline-none h-8 rounded-md gap-1.5 px-3 pr-8 cursor-pointer bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
-    data-language-select
-    autocomplete="off"
-    data-current-locale={currentLocale || ''}
+  <wc-shadcn-select-root
+    data-site-select-root
+    data-language-select-root
+    data-current-locale={selectedLocale}
     data-locale-paths={JSON.stringify(localePaths)}
-    value={currentLocale || ''}
+    data-site-initial-value={selectedLocale}
   >
-    {
-      localeOptions.map((option) => (
-        <option value={option.value} selected={option.isCurrent}>
-          {option.label}
-        </option>
-      ))
-    }
-  </select>
-  <svg
-    class="language-select-arrow absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-foreground opacity-60 transition-opacity w-4 h-4"
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden="true"
-  >
-    <path
-      d="M4 6L8 10L12 6"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"></path>
-  </svg>
-</label>
+    <wc-shadcn-select-trigger
+      data-size="sm"
+      class="language-select inline-flex h-8 min-w-24 items-center justify-between rounded-md border-transparent bg-transparent px-3 text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
+    >
+      <wc-shadcn-select-value data-placeholder="Select language"></wc-shadcn-select-value>
+    </wc-shadcn-select-trigger>
+    <wc-shadcn-select-content data-position="popper" data-align="end">
+      {
+        localeOptions.map((option) => (
+          <wc-shadcn-select-item data-value={option.value} data-text-value={option.label}>
+            {option.label}
+          </wc-shadcn-select-item>
+        ))
+      }
+    </wc-shadcn-select-content>
+  </wc-shadcn-select-root>
+</div>
 
 <style>
-  .language-select-wrapper:hover .language-select-arrow {
-    opacity: 1;
+  .language-select-wrapper wc-shadcn-select-root {
+    display: inline-flex;
   }
 
-  /* Custom arrow removal for different browsers */
-  .language-select {
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    border: 1px solid transparent;
-  }
-
-  /* Ensure option styles work in dropdown */
-  .language-select option {
-    background-color: var(--color-popover);
-    color: var(--color-popover-foreground);
-    padding: 0.5rem;
-  }
-
-  /* Focus visible border */
-  .language-select:focus-visible {
-    border-color: var(--color-ring);
-  }
-
-  /* For Firefox */
-  @-moz-document url-prefix() {
-    .language-select {
-      text-indent: 0;
-    }
+  .language-select-wrapper wc-shadcn-select-trigger {
+    min-width: 6rem;
   }
 </style>
+
+<script>
+  import { initSiteShadcnControls } from '../site-shadcn-controls';
+
+  initSiteShadcnControls(document);
+  document.addEventListener('astro:page-load', () => initSiteShadcnControls(document));
+</script>
 
 <script is:inline>
   (function () {
@@ -124,6 +103,14 @@ localeOptions.forEach((opt) => {
       return match ? decodeURIComponent(match[1]) : '';
     }
 
+    function readValue(select) {
+      const exposed = select.getExposes && select.getExposes();
+      const value = exposed && exposed.value;
+      return value && typeof value.get === 'function'
+        ? value.get()
+        : select.dataset.currentLocale || '';
+    }
+
     function initLanguageSelect(select) {
       if (select.dataset.languageSelectInitialized === 'true') return;
 
@@ -136,8 +123,9 @@ localeOptions.forEach((opt) => {
         return;
       }
 
-      function handleLanguageChange() {
-        const newLocale = select.value;
+      function handleLanguageChange(event) {
+        const newLocale =
+          event && event.detail && event.detail.value ? event.detail.value : readValue(select);
         const newPath = localePaths[newLocale];
 
         if (newPath && newLocale && newLocale !== currentLocale) {
@@ -158,11 +146,13 @@ localeOptions.forEach((opt) => {
       }
 
       select.dataset.languageSelectInitialized = 'true';
-      select.addEventListener('change', handleLanguageChange);
+      select.addEventListener('valueChange', handleLanguageChange);
     }
 
     function initLanguageSelects() {
-      document.querySelectorAll('select[data-language-select]').forEach(initLanguageSelect);
+      document
+        .querySelectorAll('wc-shadcn-select-root[data-language-select-root]')
+        .forEach(initLanguageSelect);
     }
 
     // Ensure DOM is ready
@@ -171,5 +161,6 @@ localeOptions.forEach((opt) => {
     } else {
       initLanguageSelects();
     }
+    document.addEventListener('astro:page-load', initLanguageSelects);
   })();
 </script>

--- a/apps/www/src/components/override/LanguageSelect.astro
+++ b/apps/www/src/components/override/LanguageSelect.astro
@@ -35,10 +35,11 @@ localeOptions.forEach((opt) => {
 
 const selectedLocale =
   localeOptions.find((option) => option.isCurrent)?.value ?? currentLocale ?? locales[0] ?? '';
+const labelId = `language-select-label-${Math.random().toString(36).slice(2)}`;
 ---
 
 <div class="language-select-wrapper relative inline-flex items-center" data-language-select>
-  <span class="sr-only">选择语言 / Select Language</span>
+  <span id={labelId} class="sr-only">选择语言 / Select Language</span>
   <wc-shadcn-select-root
     data-site-select-root
     data-language-select-root
@@ -47,6 +48,7 @@ const selectedLocale =
     data-site-initial-value={selectedLocale}
   >
     <wc-shadcn-select-trigger
+      aria-labelledby={labelId}
       data-size="sm"
       class="language-select inline-flex h-8 min-w-24 items-center justify-between rounded-md border-transparent bg-transparent px-3 text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"
     >

--- a/apps/www/src/components/override/LanguageSelect.test.ts
+++ b/apps/www/src/components/override/LanguageSelect.test.ts
@@ -13,18 +13,20 @@ if (!inlineScript) {
 }
 
 const languageSelect = () => `
-  <label class="language-select-wrapper">
+  <div class="language-select-wrapper">
     <span>Select language</span>
-    <select
-      class="language-select"
+    <wc-shadcn-select-root
+      data-site-select-root
+      data-language-select-root
       data-language-select
       data-current-locale="en"
+      data-value="en"
       data-locale-paths='{"en":"/en/docs/","zh-cn":"/zh-cn/docs/"}'
     >
-      <option value="en" selected>English</option>
-      <option value="zh-cn">简体中文</option>
-    </select>
-  </label>
+      <wc-shadcn-select-item data-value="en" data-text-value="English">English</wc-shadcn-select-item>
+      <wc-shadcn-select-item data-value="zh-cn" data-text-value="简体中文">简体中文</wc-shadcn-select-item>
+    </wc-shadcn-select-root>
+  </div>
 `;
 
 describe('documentation language selector', () => {
@@ -33,6 +35,17 @@ describe('documentation language selector', () => {
     document.cookie = 'preferred-locale=; Max-Age=0; path=/';
     window.history.replaceState(null, '', '/en/docs/');
     document.body.innerHTML = `${languageSelect()}${languageSelect()}`;
+    document.querySelectorAll<HTMLElement>('wc-shadcn-select-root').forEach((element) => {
+      const root = element as HTMLElement & {
+        getExposes?: () => Record<string, unknown>;
+        setProps?: (next: { value?: string }) => void;
+      };
+      let value = 'en';
+      root.setProps = (next: { value?: string }) => {
+        if (next.value) value = next.value;
+      };
+      root.getExposes = () => ({ value: { get: () => value } });
+    });
   });
 
   it('binds every rendered selector instance exactly once', () => {
@@ -41,14 +54,15 @@ describe('documentation language selector', () => {
     window.eval(inlineScript);
     window.eval(inlineScript);
 
-    const selects = document.querySelectorAll<HTMLSelectElement>('.language-select');
+    const selects = document.querySelectorAll<HTMLElement>('wc-shadcn-select-root');
     expect(selects).toHaveLength(2);
     expect(
       [...selects].every((select) => select.dataset.languageSelectInitialized === 'true')
     ).toBe(true);
 
-    selects[1].value = 'zh-cn';
-    selects[1].dispatchEvent(new Event('change', { bubbles: true }));
+    selects[1].dispatchEvent(
+      new CustomEvent('valueChange', { detail: { value: 'zh-cn' }, bubbles: true })
+    );
 
     expect(window.location.pathname).toBe('/zh-cn/docs/');
     expect(localStorage.getItem('preferred-locale')).toBe('zh-cn');

--- a/apps/www/src/components/override/ThemeToggle.astro
+++ b/apps/www/src/components/override/ThemeToggle.astro
@@ -1,11 +1,12 @@
 ---
 // const labelLight = Astro.locals?.t?.('themeSelect.light') ?? 'Light theme';
 // const labelDark = Astro.locals?.t?.('themeSelect.dark') ?? 'Dark theme';
-
 ---
 
-<button
-  data-slot="button"
+<wc-shadcn-button
+  data-site-shadcn-button
+  data-variant="ghost"
+  data-size="icon"
   class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 group/toggle extend-touch-target size-8"
   type="button"
   aria-label="Toggle color theme"
@@ -14,8 +15,14 @@
 >
   <!-- 初始占位，避免布局跳动；首帧由 hydrate 脚本替换为对应图标 -->
   <span class="sr-only">Toggle theme</span>
-</button>
+</wc-shadcn-button>
 
+<script>
+  import { initSiteShadcnControls } from '../site-shadcn-controls';
+
+  initSiteShadcnControls(document);
+  document.addEventListener('astro:page-load', () => initSiteShadcnControls(document));
+</script>
 
 <script is:inline>
   (function () {
@@ -56,7 +63,6 @@
     // 点击切换
     btn.addEventListener('click', () => {
       window.StarlightTheme.toggle();
-
     });
 
     // 响应全局变更（来自其它控件）

--- a/apps/www/src/components/override/ThemeToggle.astro
+++ b/apps/www/src/components/override/ThemeToggle.astro
@@ -41,6 +41,10 @@
         btn.replaceChildren(icon);
         // 无障碍文案与 pressed 状态
         const isDark = theme === 'dark';
+        const accessibleText = document.createElement('span');
+        accessibleText.className = 'sr-only';
+        accessibleText.textContent = isDark ? 'Switch to light theme' : 'Switch to dark theme';
+        btn.append(accessibleText);
         btn.setAttribute('aria-pressed', String(isDark));
         btn.setAttribute(
           'aria-label',
@@ -61,7 +65,8 @@
     render(current());
 
     // 点击切换
-    btn.addEventListener('click', () => {
+    btn.addEventListener('click', (event) => {
+      if (!(event instanceof CustomEvent)) return;
       window.StarlightTheme.toggle();
     });
 

--- a/apps/www/src/components/override/ThemeToggle.astro
+++ b/apps/www/src/components/override/ThemeToggle.astro
@@ -5,6 +5,7 @@
 
 <wc-shadcn-button
   data-site-shadcn-button
+  data-theme-toggle
   data-variant="ghost"
   data-size="icon"
   class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 group/toggle extend-touch-target size-8"
@@ -26,8 +27,9 @@
 
 <script is:inline>
   (function () {
-    const btn = document.currentScript.previousElementSibling;
+    const btn = document.querySelector('[data-theme-toggle]');
     const tmpl = document.getElementById('starlight-theme-icons');
+    if (!btn) return;
 
     function iconFor(theme) {
       if (!tmpl) return null;
@@ -65,6 +67,9 @@
     render(current());
 
     // 点击切换
+    // The Web Component adapter emits an untrusted projected click signal in
+    // addition to the browser's trusted native click. Handle the projection
+    // only so pointer activation toggles the theme exactly once.
     btn.addEventListener('click', (event) => {
       if (!(event instanceof CustomEvent)) return;
       window.StarlightTheme.toggle();

--- a/apps/www/src/components/site-shadcn-controls.test.ts
+++ b/apps/www/src/components/site-shadcn-controls.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   initSiteShadcnControls,
   registerSiteShadcnControls,
+  setSelectValue,
   selectValue,
   setSiteSelectDisabled,
-  setSelectValue,
   type SiteSelectRoot,
 } from './site-shadcn-controls';
 
@@ -52,6 +52,112 @@ describe('site Shadcn control bridge', () => {
     expect(item.getAttribute('aria-selected')).toBe('true');
     expect(value.textContent).toBe('React');
     expect(trigger.getAttribute('aria-labelledby')).toBe('runtime-label');
+  });
+
+  it('closes a portaled Select after item commit and restores trigger focus', async () => {
+    const root = document.createElement('wc-shadcn-select-root') as SiteSelectRoot;
+    root.dataset.siteSelectRoot = '1';
+    root.dataset.siteShadcnInitialized = '1';
+
+    const trigger = document.createElement('wc-shadcn-select-trigger');
+    const value = document.createElement('wc-shadcn-select-value');
+    trigger.append(value);
+
+    const content = document.createElement('wc-shadcn-select-content');
+    const react = document.createElement('wc-shadcn-select-item');
+    react.dataset.value = 'react';
+    react.dataset.textValue = 'React';
+    react.textContent = 'React';
+    const vue = document.createElement('wc-shadcn-select-item');
+    vue.dataset.value = 'vue';
+    vue.dataset.textValue = 'Vue';
+    vue.textContent = 'Vue';
+    content.append(react, vue);
+    root.append(trigger, content);
+    document.body.append(root);
+
+    initSiteShadcnControls(document);
+    await settle();
+    trigger.click();
+    await settle();
+    expect(root.getExposes?.().open?.get?.()).toBe(true);
+
+    const requestValue = root.getExposes?.().requestValue as
+      | ((request: { value: string; textValue: string; reason: 'pointer' }) => boolean)
+      | undefined;
+    expect(requestValue?.({ value: 'vue', textValue: 'Vue', reason: 'pointer' })).toBe(true);
+    await settle();
+    expect(selectValue(root)).toBe('vue');
+    expect(root.getExposes?.().open?.get?.()).toBe(false);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('closes before a valueChange owner update can disable the Select', async () => {
+    const root = document.createElement('wc-shadcn-select-root') as SiteSelectRoot;
+    root.dataset.siteSelectRoot = '1';
+    root.dataset.siteShadcnInitialized = '1';
+
+    const trigger = document.createElement('wc-shadcn-select-trigger');
+    trigger.append(document.createElement('wc-shadcn-select-value'));
+    const content = document.createElement('wc-shadcn-select-content');
+    const item = document.createElement('wc-shadcn-select-item');
+    item.dataset.value = 'react';
+    item.dataset.textValue = 'React';
+    item.textContent = 'React';
+    content.append(item);
+    root.append(trigger, content);
+    document.body.append(root);
+
+    initSiteShadcnControls(document);
+    await settle();
+    trigger.click();
+    await settle();
+    root.addEventListener('valueChange', () => root.setProps?.({ disabled: true }));
+
+    const requestValue = root.getExposes?.().requestValue as
+      | ((request: { value: string; textValue: string; reason: 'pointer' }) => boolean)
+      | undefined;
+    expect(requestValue?.({ value: 'react', textValue: 'React', reason: 'pointer' })).toBe(true);
+    await settle();
+
+    expect(root.getExposes?.().open?.get?.()).toBe(false);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('preserves the selected value while async remounts toggle disabled', async () => {
+    const root = document.createElement('wc-shadcn-select-root') as SiteSelectRoot;
+    root.dataset.siteSelectRoot = '1';
+    root.dataset.siteInitialValue = 'react';
+
+    const trigger = document.createElement('wc-shadcn-select-trigger');
+    trigger.append(document.createElement('wc-shadcn-select-value'));
+    const content = document.createElement('wc-shadcn-select-content');
+    const react = document.createElement('wc-shadcn-select-item');
+    react.dataset.value = 'react';
+    react.dataset.textValue = 'React';
+    react.textContent = 'React';
+    const vue = document.createElement('wc-shadcn-select-item');
+    vue.dataset.value = 'vue';
+    vue.dataset.textValue = 'Vue';
+    vue.textContent = 'Vue';
+    content.append(react, vue);
+    root.append(trigger, content);
+    document.body.append(root);
+
+    initSiteShadcnControls(document);
+    await settle();
+    setSelectValue(root, 'vue');
+    setSiteSelectDisabled(root, true);
+    await settle();
+
+    expect(selectValue(root)).toBe('vue');
+    expect(trigger.getAttribute('aria-disabled')).toBe('true');
+
+    setSiteSelectDisabled(root, false);
+    await settle();
+    expect(selectValue(root)).toBe('vue');
+    expect(trigger.getAttribute('aria-disabled')).toBe('false');
   });
 
   it('registers the Shadcn Button projection for site actions', async () => {

--- a/apps/www/src/components/site-shadcn-controls.test.ts
+++ b/apps/www/src/components/site-shadcn-controls.test.ts
@@ -24,6 +24,10 @@ describe('site Shadcn control bridge', () => {
     root.dataset.siteInitialValue = 'react';
 
     const trigger = document.createElement('wc-shadcn-select-trigger');
+    const label = document.createElement('span');
+    label.id = 'runtime-label';
+    label.textContent = 'Runtime';
+    trigger.setAttribute('aria-labelledby', label.id);
     const value = document.createElement('wc-shadcn-select-value');
     value.dataset.placeholder = 'Runtime';
     trigger.append(value);
@@ -36,7 +40,7 @@ describe('site Shadcn control bridge', () => {
     content.append(item);
 
     root.append(trigger, content);
-    document.body.append(root);
+    document.body.append(label, root);
     initSiteShadcnControls(document);
     await settle();
 
@@ -45,6 +49,7 @@ describe('site Shadcn control bridge', () => {
     expect(item.getAttribute('role')).toBe('option');
     expect(item.getAttribute('aria-selected')).toBe('true');
     expect(value.textContent).toBe('React');
+    expect(trigger.getAttribute('aria-labelledby')).toBe('runtime-label');
   });
 
   it('registers the Shadcn Button projection for site actions', async () => {
@@ -61,5 +66,19 @@ describe('site Shadcn control bridge', () => {
     expect(customElements.get('wc-shadcn-button')).toBeDefined();
     expect(button.getAttribute('role')).toBe('button');
     expect(button.getAttribute('data-pui-style')).toContain('bg-transparent');
+  });
+
+  it('retains content text as the accessible source for projected icon buttons', async () => {
+    const button = document.createElement('wc-shadcn-button');
+    button.dataset.siteShadcnButton = '1';
+    button.setAttribute('aria-label', 'Copy code');
+    button.innerHTML = '<svg aria-hidden="true"></svg><span class="sr-only">Copy code</span>';
+    document.body.append(button);
+
+    initSiteShadcnControls(document);
+    await settle();
+
+    expect(button.hasAttribute('aria-label')).toBe(false);
+    expect(button.querySelector('.sr-only')?.textContent).toBe('Copy code');
   });
 });

--- a/apps/www/src/components/site-shadcn-controls.test.ts
+++ b/apps/www/src/components/site-shadcn-controls.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  initSiteShadcnControls,
+  registerSiteShadcnControls,
+  selectValue,
+  type SiteSelectRoot,
+} from './site-shadcn-controls';
+
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('site Shadcn control bridge', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    registerSiteShadcnControls();
+  });
+
+  it('registers the Shadcn Select composition and applies SSR seed props', async () => {
+    const root = document.createElement('wc-shadcn-select-root') as SiteSelectRoot;
+    root.dataset.siteSelectRoot = '1';
+    root.dataset.siteInitialValue = 'react';
+
+    const trigger = document.createElement('wc-shadcn-select-trigger');
+    const value = document.createElement('wc-shadcn-select-value');
+    value.dataset.placeholder = 'Runtime';
+    trigger.append(value);
+
+    const content = document.createElement('wc-shadcn-select-content');
+    const item = document.createElement('wc-shadcn-select-item');
+    item.dataset.value = 'react';
+    item.dataset.textValue = 'React';
+    item.textContent = 'React';
+    content.append(item);
+
+    root.append(trigger, content);
+    document.body.append(root);
+    initSiteShadcnControls(document);
+    await settle();
+
+    expect(customElements.get('wc-shadcn-select-root')).toBeDefined();
+    expect(selectValue(root)).toBe('react');
+    expect(item.getAttribute('role')).toBe('option');
+    expect(item.getAttribute('aria-selected')).toBe('true');
+    expect(value.textContent).toBe('React');
+  });
+
+  it('registers the Shadcn Button projection for site actions', async () => {
+    const button = document.createElement('wc-shadcn-button');
+    button.dataset.siteShadcnButton = '1';
+    button.dataset.variant = 'ghost';
+    button.dataset.size = 'icon';
+    button.textContent = 'Theme';
+    document.body.append(button);
+
+    initSiteShadcnControls(document);
+    await settle();
+
+    expect(customElements.get('wc-shadcn-button')).toBeDefined();
+    expect(button.getAttribute('role')).toBe('button');
+    expect(button.getAttribute('data-pui-style')).toContain('bg-transparent');
+  });
+});

--- a/apps/www/src/components/site-shadcn-controls.test.ts
+++ b/apps/www/src/components/site-shadcn-controls.test.ts
@@ -1,8 +1,10 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   initSiteShadcnControls,
   registerSiteShadcnControls,
   selectValue,
+  setSiteSelectDisabled,
+  setSelectValue,
   type SiteSelectRoot,
 } from './site-shadcn-controls';
 
@@ -66,6 +68,40 @@ describe('site Shadcn control bridge', () => {
     expect(customElements.get('wc-shadcn-button')).toBeDefined();
     expect(button.getAttribute('role')).toBe('button');
     expect(button.getAttribute('data-pui-style')).toContain('bg-transparent');
+  });
+
+  it.each([
+    {
+      label: 'disabled then value',
+      update: (root: SiteSelectRoot) => {
+        setSiteSelectDisabled(root, true);
+        setSelectValue(root, 'vue');
+      },
+    },
+    {
+      label: 'value then disabled',
+      update: (root: SiteSelectRoot) => {
+        setSelectValue(root, 'vue');
+        setSiteSelectDisabled(root, true);
+      },
+    },
+    {
+      label: 'repeated value while disabled',
+      update: (root: SiteSelectRoot) => {
+        setSiteSelectDisabled(root, true);
+        setSelectValue(root, 'vue');
+        setSelectValue(root, 'vue');
+      },
+    },
+  ])('replays one merged Select prop bag for $label', async ({ update }) => {
+    const root = document.createElement('div') as SiteSelectRoot;
+    root.setProps = vi.fn();
+
+    update(root);
+    await settle();
+
+    expect(root.setProps).toHaveBeenCalledTimes(1);
+    expect(root.setProps).toHaveBeenLastCalledWith({ value: 'vue', disabled: true });
   });
 
   it('retains content text as the accessible source for projected icon buttons', async () => {

--- a/apps/www/src/components/site-shadcn-controls.ts
+++ b/apps/www/src/components/site-shadcn-controls.ts
@@ -27,6 +27,19 @@ export type SiteSelectRoot = HTMLElement & {
   setProps?: (props: Record<string, unknown>) => void;
 };
 
+/**
+ * Projected Button hosts receive the browser's native `MouseEvent` and then
+ * the Button protocol's outward `CustomEvent("click")`. Site consumers own
+ * the outward signal, while native buttons retain their ordinary click path.
+ */
+export function isSiteButtonActivation(event: Event): boolean {
+  const currentTarget = event.currentTarget;
+  return (
+    !(currentTarget instanceof HTMLElement && currentTarget.localName === 'wc-shadcn-button') ||
+    event instanceof CustomEvent
+  );
+}
+
 export function registerSiteShadcnControls(): void {
   for (const [tagName, prototype] of siteProjections) {
     if (customElements.get(tagName)) continue;

--- a/apps/www/src/components/site-shadcn-controls.ts
+++ b/apps/www/src/components/site-shadcn-controls.ts
@@ -27,6 +27,9 @@ export type SiteSelectRoot = HTMLElement & {
   setProps?: (props: Record<string, unknown>) => void;
 };
 
+const siteSelectProps = new WeakMap<SiteSelectRoot, Record<string, unknown>>();
+const pendingSelectReplays = new WeakSet<SiteSelectRoot>();
+
 /**
  * Projected Button hosts receive the browser's native `MouseEvent` and then
  * the Button protocol's outward `CustomEvent("click")`. Site consumers own
@@ -57,9 +60,28 @@ export function selectValue(root: SiteSelectRoot): string {
   return typeof value === 'string' ? value : '';
 }
 
+function updateSelectProps(root: SiteSelectRoot, props: Record<string, unknown>): void {
+  const nextProps = { ...siteSelectProps.get(root), ...props };
+  siteSelectProps.set(root, nextProps);
+  setElementProps(root, nextProps);
+  if (pendingSelectReplays.has(root)) return;
+  pendingSelectReplays.add(root);
+  // Resolve the latest merged bag when the replay runs. Value and disabled
+  // are commonly updated in the same turn while a preview remount locks the
+  // control, and the adapter's setProps replaces rather than merges raw props.
+  queueMicrotask(() => {
+    pendingSelectReplays.delete(root);
+    const currentProps = siteSelectProps.get(root);
+    if (currentProps) root.setProps?.(currentProps);
+  });
+}
+
 export function setSelectValue(root: SiteSelectRoot, value: string): void {
-  setElementProps(root, { value });
-  queueMicrotask(() => root.setProps?.({ value }));
+  updateSelectProps(root, { value });
+}
+
+export function setSiteSelectDisabled(root: SiteSelectRoot, disabled: boolean): void {
+  updateSelectProps(root, { disabled });
 }
 
 function applyProps(element: HTMLElement, props: Record<string, unknown>): void {
@@ -87,7 +109,7 @@ function initializeSelect(root: SiteSelectRoot): void {
     // is intentionally not used as an authoring input. Keep the SSR seed in a
     // separate data attribute that the runtime will not overwrite.
     const value = root.dataset.siteInitialValue ?? '';
-    applyProps(root, {
+    updateSelectProps(root, {
       value,
       disabled: root.dataset.disabled === 'true',
       closeOnSelect: true,

--- a/apps/www/src/components/site-shadcn-controls.ts
+++ b/apps/www/src/components/site-shadcn-controls.ts
@@ -1,0 +1,133 @@
+import { AdaptToWebComponent, setElementProps } from '@proto.ui/adapter-web-component';
+import shadcnButton from '@proto.ui/prototypes-shadcn/button';
+import {
+  selectContent as shadcnSelectContent,
+  selectItem as shadcnSelectItem,
+  selectRoot as shadcnSelectRoot,
+  selectTrigger as shadcnSelectTrigger,
+  selectValue as shadcnSelectValue,
+} from '@proto.ui/prototypes-shadcn/select';
+
+/**
+ * Site chrome is part of the Proto UI dogfood surface. Keep registration in a
+ * single place so every page uses the same Shadcn projections and never
+ * accidentally defines a second constructor for a preview element.
+ */
+const siteProjections = [
+  ['wc-shadcn-button', shadcnButton],
+  ['wc-shadcn-select-root', shadcnSelectRoot],
+  ['wc-shadcn-select-trigger', shadcnSelectTrigger],
+  ['wc-shadcn-select-value', shadcnSelectValue],
+  ['wc-shadcn-select-content', shadcnSelectContent],
+  ['wc-shadcn-select-item', shadcnSelectItem],
+] as const;
+
+export type SiteSelectRoot = HTMLElement & {
+  getExposes?: () => Record<string, unknown>;
+  setProps?: (props: Record<string, unknown>) => void;
+};
+
+export function registerSiteShadcnControls(): void {
+  for (const [tagName, prototype] of siteProjections) {
+    if (customElements.get(tagName)) continue;
+    const constructor = AdaptToWebComponent(prototype, {
+      register: false,
+      registerAs: tagName,
+    });
+    customElements.define(tagName, constructor);
+  }
+}
+
+export function selectValue(root: SiteSelectRoot): string {
+  const state = root.getExposes?.().value as { get?: () => unknown } | undefined;
+  const value = state?.get?.();
+  return typeof value === 'string' ? value : '';
+}
+
+export function setSelectValue(root: SiteSelectRoot, value: string): void {
+  setElementProps(root, { value });
+  queueMicrotask(() => root.setProps?.({ value }));
+}
+
+function applyProps(element: HTMLElement, props: Record<string, unknown>): void {
+  setElementProps(element, props);
+  // Astro can execute a page script in the same turn as custom-element
+  // upgrade. Replay through the live controller once connected so style and
+  // state props are never lost during that upgrade boundary.
+  queueMicrotask(() => (element as SiteSelectRoot).setProps?.(props));
+}
+
+function initializeButton(button: HTMLElement): void {
+  if (button.dataset.siteShadcnInitialized === '1') return;
+  const props: Record<string, unknown> = {};
+  if (button.dataset.variant) props.variant = button.dataset.variant;
+  if (button.dataset.size) props.size = button.dataset.size;
+  if (button.dataset.disabled === 'true') props.disabled = true;
+  applyProps(button, props);
+  button.dataset.siteShadcnInitialized = '1';
+}
+
+function initializeSelect(root: SiteSelectRoot): void {
+  const initialized = root.dataset.siteShadcnInitialized === '1';
+  if (!initialized) {
+    // `data-value` is owned by the adapter's exposed-state projection, so it
+    // is intentionally not used as an authoring input. Keep the SSR seed in a
+    // separate data attribute that the runtime will not overwrite.
+    const value = root.dataset.siteInitialValue ?? '';
+    applyProps(root, {
+      value,
+      disabled: root.dataset.disabled === 'true',
+      closeOnSelect: true,
+    });
+  }
+
+  const trigger = root.querySelector<HTMLElement>('wc-shadcn-select-trigger');
+  if (trigger) {
+    applyProps(trigger, {
+      size: trigger.dataset.size ?? 'default',
+      disabled: trigger.dataset.disabled === 'true',
+    });
+  }
+
+  const valuePart = root.querySelector<HTMLElement>('wc-shadcn-select-value');
+  if (valuePart) applyProps(valuePart, { placeholder: valuePart.dataset.placeholder ?? '' });
+
+  const content = root.querySelector<HTMLElement>('wc-shadcn-select-content');
+  if (content) {
+    applyProps(content, {
+      position: content.dataset.position ?? 'popper',
+      align: content.dataset.align ?? 'start',
+    });
+  }
+
+  root.querySelectorAll<HTMLElement>('wc-shadcn-select-item').forEach((item) => {
+    applyProps(item, {
+      value: item.dataset.value ?? '',
+      textValue: item.dataset.textValue ?? item.textContent?.trim() ?? '',
+      disabled: item.dataset.disabled === 'true',
+    });
+  });
+
+  root.dataset.siteShadcnInitialized = '1';
+}
+
+/** Initialize all site-owned Shadcn projections in a document. */
+export function initSiteShadcnControls(root: ParentNode = document): void {
+  registerSiteShadcnControls();
+
+  if (root instanceof HTMLElement && root.matches('wc-shadcn-button[data-site-shadcn-button]')) {
+    initializeButton(root);
+  }
+  root
+    .querySelectorAll<HTMLElement>('wc-shadcn-button[data-site-shadcn-button]')
+    .forEach(initializeButton);
+
+  const selectRoots: SiteSelectRoot[] = [];
+  if (root instanceof HTMLElement && root.matches('wc-shadcn-select-root[data-site-select-root]')) {
+    selectRoots.push(root as SiteSelectRoot);
+  }
+  root
+    .querySelectorAll<SiteSelectRoot>('wc-shadcn-select-root[data-site-select-root]')
+    .forEach((select) => selectRoots.push(select));
+  selectRoots.forEach(initializeSelect);
+}

--- a/apps/www/src/components/site-shadcn-controls.ts
+++ b/apps/www/src/components/site-shadcn-controls.ts
@@ -43,6 +43,42 @@ export function isSiteButtonActivation(event: Event): boolean {
   );
 }
 
+type SelectValueChangeDetail = {
+  reason?: unknown;
+};
+
+type SelectCloseExposes = {
+  open?: { get?: () => unknown };
+  requestOpen?: (request: {
+    open: false;
+    reason: string;
+    focusReason: 'programmatic' | 'keyboard' | 'pointer';
+  }) => unknown;
+};
+
+function closeSelectAfterValueChange(root: SiteSelectRoot): void {
+  if (root.dataset.siteShadcnCloseOnSelectInitialized === '1') return;
+  root.dataset.siteShadcnCloseOnSelectInitialized = '1';
+
+  root.addEventListener('valueChange', (event: Event) => {
+    const detail = (event as CustomEvent<SelectValueChangeDetail>).detail;
+    const focusReason =
+      detail?.reason === 'keyboard' || detail?.reason === 'pointer'
+        ? detail.reason
+        : 'programmatic';
+
+    // Select content is portaled out of the root. The item can therefore
+    // commit a value before the root's anatomy lookup sees the close request.
+    // Submit the public request synchronously while the root is still enabled:
+    // site-owned valueChange listeners may disable the Select before a queued
+    // close could be accepted.
+    if (!root.isConnected) return;
+    const exposes = root.getExposes?.() as SelectCloseExposes | undefined;
+    if (exposes?.open?.get?.() !== true) return;
+    exposes.requestOpen?.({ open: false, reason: 'item.select', focusReason });
+  });
+}
+
 export function registerSiteShadcnControls(): void {
   for (const [tagName, prototype] of siteProjections) {
     if (customElements.get(tagName)) continue;
@@ -143,6 +179,7 @@ function initializeSelect(root: SiteSelectRoot): void {
     });
   });
 
+  closeSelectAfterValueChange(root);
   root.dataset.siteShadcnInitialized = '1';
 }
 

--- a/apps/www/src/components/site-shadcn-controls.ts
+++ b/apps/www/src/components/site-shadcn-controls.ts
@@ -22,8 +22,14 @@ const siteProjections = [
   ['wc-shadcn-select-item', shadcnSelectItem],
 ] as const;
 
+export type SiteSelectExposes = {
+  [key: string]: unknown;
+  open?: { get?: () => unknown };
+  value?: { get?: () => unknown };
+};
+
 export type SiteSelectRoot = HTMLElement & {
-  getExposes?: () => Record<string, unknown>;
+  getExposes?: () => SiteSelectExposes;
   setProps?: (props: Record<string, unknown>) => void;
 };
 

--- a/apps/www/src/content/docs/demo_components/button/buttonCode.ts
+++ b/apps/www/src/content/docs/demo_components/button/buttonCode.ts
@@ -71,10 +71,10 @@ export const codeMap: Partial<Record<RuntimeId, Record<string, string>>> = {
   <wc-shadcn-button disabled>Disabled</wc-shadcn-button>
 </div>
     `),
-    'demo-Secondray': formatCode(`
+    'demo-button-secondary-example': formatCode(`
 <div class="flex flex-wrap items-center justify-center gap-3">
   <wc-shadcn-button>Default</wc-shadcn-button>
-  <wc-shadcn-button variant="secondary">Secondary2</wc-shadcn-button>
+  <wc-shadcn-button variant="secondary">Secondary</wc-shadcn-button>
   <wc-shadcn-button variant="outline">Outline</wc-shadcn-button>
 </div>
     `),
@@ -216,14 +216,14 @@ export function DemoButtonDemo() {
   );
 }
     `),
-    'demo-Secondray': formatCode(`
+    'demo-button-secondary-example': formatCode(`
 import { ShadcnButton } from '../proto-ui/components/react';
 
-export function DemoSecondrayDemo() {
+export function DemoButtonSecondaryExampleDemo() {
   return (
     <div className="flex flex-wrap items-center justify-center gap-3">
       <ShadcnButton>Default</ShadcnButton>
-      <ShadcnButton variant="secondary">Secondary2</ShadcnButton>
+      <ShadcnButton variant="secondary">Secondary</ShadcnButton>
       <ShadcnButton variant="outline">Outline</ShadcnButton>
     </div>
   );
@@ -359,7 +359,7 @@ import { ShadcnButton } from '../proto-ui/components/vue';
   </div>
 </template>
     `),
-    'demo-Secondray': formatCode(`
+    'demo-button-secondary-example': formatCode(`
 <script setup lang="ts">
 import { ShadcnButton } from '../proto-ui/components/vue';
 </script>
@@ -367,7 +367,7 @@ import { ShadcnButton } from '../proto-ui/components/vue';
 <template>
   <div class="flex flex-wrap items-center justify-center gap-3">
     <ShadcnButton>Default</ShadcnButton>
-    <ShadcnButton variant="secondary">Secondary2</ShadcnButton>
+    <ShadcnButton variant="secondary">Secondary</ShadcnButton>
     <ShadcnButton variant="outline">Outline</ShadcnButton>
   </div>
 </template>
@@ -562,11 +562,11 @@ export default {
 };
 </script>
     `),
-    'demo-Secondray': formatCode(`
+    'demo-button-secondary-example': formatCode(`
 <template>
   <div class="flex flex-wrap items-center justify-center gap-3">
     <ShadcnButton>Default</ShadcnButton>
-    <ShadcnButton variant="secondary">Secondary2</ShadcnButton>
+    <ShadcnButton variant="secondary">Secondary</ShadcnButton>
     <ShadcnButton variant="outline">Outline</ShadcnButton>
   </div>
 </template>

--- a/apps/www/src/content/docs/demo_components/button/demo-button-secondary-example.demo.ts
+++ b/apps/www/src/content/docs/demo_components/button/demo-button-secondary-example.demo.ts
@@ -9,7 +9,7 @@ export default {
         kind: 'proto',
         prototypeId: 'shadcn-button',
         props: { variant: 'secondary' },
-        children: ['Secondary2'],
+        children: ['Secondary'],
       },
       {
         kind: 'proto',

--- a/apps/www/src/content/docs/en/internal/demo-matrix.mdx
+++ b/apps/www/src/content/docs/en/internal/demo-matrix.mdx
@@ -8,6 +8,6 @@ tableOfContents: false
 
 import DemoMatrix from '@/components/PrototypePreviewer/DemoMatrix.astro';
 
-Use this page to quickly check whether the current component demos still mount and behave correctly across adapters. It is intentionally omitted from the sidebar.
+This page is Proto UI's executable website parity loop: every demo mounts side by side in the four official adapters—Web Components, React, Vue, and Vue 2—so cross-adapter drift is visible in one place. The browser smoke verifies complete mount counts, error fallbacks, global adapter switching, and a zero-overflow 320px layout. It is intentionally omitted from the sidebar.
 
 <DemoMatrix />

--- a/apps/www/src/content/docs/en/ui-libraries/shadcn/button.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/shadcn/button.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Button'
 desp: 'Prototype: Button'
-description: 'Prototype: Button'
+description: 'A Shadcn-styled button projected through Proto UI adapters.'
 ---
 
 import AdapterPanelScript from '@/components/PrototypePreviewer/AdapterPanelScript.astro';
@@ -9,17 +9,9 @@ import PrototypePreviewer from '@/components/PrototypePreviewer/PrototypePreview
 import { codeMap } from '@/content/docs/demo_components/button/buttonCode';
 import { getCode } from '@/utils/conversionUtils';
 
+The Button prototype keeps one canonical demo per supported runtime. Use the adapter selector in the page chrome to compare the same semantic surface across implementations.
+
 <div data-adapter-panel="wc">
-  This is the button component for wc
-  <PrototypePreviewer
-    demoId="demo-button"
-    initialRuntime="wc"
-    toolbar={false}
-    runtimes={['wc']}
-    hasCode={true}
-    code={getCode('wc', 'demo-button', codeMap)}
-  />
-  This is the test component for wc
   <PrototypePreviewer
     demoId="demo-button"
     initialRuntime="wc"
@@ -31,7 +23,6 @@ import { getCode } from '@/utils/conversionUtils';
 </div>
 
 <div data-adapter-panel="react" style="display:none;">
-  This is the button component for react
   <PrototypePreviewer
     demoId="demo-button"
     initialRuntime="react"
@@ -43,18 +34,6 @@ import { getCode } from '@/utils/conversionUtils';
 </div>
 
 <div data-adapter-panel="vue" style="display:none;">
-  This is the button component for vue
-  <PrototypePreviewer
-    demoId="demo-button"
-    initialRuntime="vue"
-    toolbar={false}
-    runtimes={['vue']}
-    hasCode={true}
-    code={getCode('vue', 'demo-button', codeMap)}
-  />
-
-This is the test component for vue
-
   <PrototypePreviewer
     demoId="demo-button"
     initialRuntime="vue"
@@ -66,18 +45,6 @@ This is the test component for vue
 </div>
 
 <div data-adapter-panel="vue2" style="display:none;">
-  This is the button component for vue2
-  <PrototypePreviewer
-    demoId="demo-button"
-    initialRuntime="vue2"
-    toolbar={false}
-    runtimes={['vue2']}
-    hasCode={true}
-    code={getCode('vue2', 'demo-button', codeMap)}
-  />
-
-This is the test component for vue2
-
   <PrototypePreviewer
     demoId="demo-button"
     initialRuntime="vue2"

--- a/apps/www/src/content/docs/zh-cn/browser-harness.ts
+++ b/apps/www/src/content/docs/zh-cn/browser-harness.ts
@@ -13,7 +13,7 @@ import {
   type Page,
 } from 'playwright-core';
 
-export const RUNTIMES = ['wc', 'react', 'vue'] as const;
+export const RUNTIMES = ['wc', 'react', 'vue', 'vue2'] as const;
 export type RuntimeId = (typeof RUNTIMES)[number];
 
 export const COLOR_SCHEMES = ['light', 'dark'] as const;
@@ -42,6 +42,11 @@ async function availablePort(): Promise<number> {
 export async function chromeExecutable(): Promise<string> {
   const candidates = [
     process.env.CHROME_PATH,
+    process.env.LOCALAPPDATA
+      ? `${process.env.LOCALAPPDATA}/Google/Chrome/Application/chrome.exe`
+      : undefined,
+    'C:/Program Files/Google/Chrome/Application/chrome.exe',
+    'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe',
     '/usr/bin/google-chrome',
     '/bin/google-chrome',
     '/usr/bin/google-chrome-stable',
@@ -102,6 +107,10 @@ async function spawnServer(readyRoute: string): Promise<string> {
     {
       cwd: process.cwd(),
       detached: process.platform !== 'win32',
+      // Windows treats .cmd shims as shell scripts rather than executable
+      // images. Without this flag every browser suite fails before it can
+      // collect any evidence, which silently removes the matrix from CI.
+      shell: process.platform === 'win32',
       env: process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
     }
@@ -140,7 +149,22 @@ export async function startServer(readyRoute: string): Promise<string> {
 
 export async function stopServer(): Promise<void> {
   if (!devServer || devServer.exitCode !== null || !devServer.pid) return;
-  const signalTarget = process.platform === 'win32' ? devServer.pid : -devServer.pid;
+  const pid = devServer.pid;
+  if (process.platform === 'win32') {
+    // `corepack.cmd` runs through a cmd.exe wrapper. Killing only that shell
+    // leaves Astro/Vite descendants behind, so terminate the whole tree.
+    await new Promise<void>((resolve) => {
+      const killer = spawn('taskkill', ['/PID', String(pid), '/T', '/F'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+      killer.once('error', () => resolve());
+      killer.once('exit', () => resolve());
+    });
+    return;
+  }
+
+  const signalTarget = -pid;
   process.kill(signalTarget, 'SIGTERM');
 
   const exited = await Promise.race([

--- a/apps/www/src/content/docs/zh-cn/browser-harness.ts
+++ b/apps/www/src/content/docs/zh-cn/browser-harness.ts
@@ -179,15 +179,22 @@ export async function selectRuntime(
   readySelector: string,
   expectedCount: number
 ): Promise<void> {
-  await previewer.locator('select.adapter-select').selectOption(runtime);
+  const selectRoot = previewer.locator('[data-adapter-select-root]');
+  await selectRoot.locator('wc-shadcn-select-trigger').click();
+  await page
+    .locator(`wc-shadcn-select-item[data-value="${runtime}"]:visible`)
+    .last()
+    .click({ force: true });
   await page.waitForFunction(
     ({ expectedCount: count, readySelector: selector, runtime: selectedRuntime }) => {
       const root = document.querySelector<HTMLElement>('[data-previewer-id]');
-      const select = root?.querySelector<HTMLSelectElement>('select.adapter-select');
+      const select = root?.querySelector<HTMLElement>('[data-adapter-select-root]');
       const host = root?.querySelector<HTMLElement>('.host');
       const firstRoot = host?.querySelector<HTMLElement>('[data-pui-root]');
-      if (!root || !select || !host || select.value !== selectedRuntime) return false;
-      if (root.querySelectorAll(selector).length !== count || !firstRoot) return false;
+      if (!root || !select || !host || select.getAttribute('data-value') !== selectedRuntime) {
+        return false;
+      }
+      if (host.querySelectorAll(selector).length !== count || !firstRoot) return false;
       if (selectedRuntime === 'wc') return firstRoot.tagName.startsWith('WC-');
       if (selectedRuntime === 'vue') return host.hasAttribute('data-v-app');
       // React owns neither a custom element nor a Vue app root. The host tag is

--- a/apps/www/src/content/docs/zh-cn/browser-harness.ts
+++ b/apps/www/src/content/docs/zh-cn/browser-harness.ts
@@ -172,6 +172,23 @@ export async function openRoute(
   return { context, page, previewer };
 }
 
+export function runtimeSelectTrigger(previewer: Locator): Locator {
+  return previewer.locator('[data-adapter-select-root] wc-shadcn-select-trigger');
+}
+
+/** Select one runtime through the same accessible composed control a reader uses. */
+export async function choosePreviewRuntime(
+  page: Page,
+  previewer: Locator,
+  runtime: RuntimeId
+): Promise<void> {
+  await runtimeSelectTrigger(previewer).click();
+  await page
+    .locator(`wc-shadcn-select-item[data-value="${runtime}"]:visible`)
+    .last()
+    .click({ force: true });
+}
+
 export async function selectRuntime(
   page: Page,
   previewer: Locator,
@@ -179,21 +196,14 @@ export async function selectRuntime(
   readySelector: string,
   expectedCount: number
 ): Promise<void> {
-  const selectRoot = previewer.locator('[data-adapter-select-root]');
-  await selectRoot.locator('wc-shadcn-select-trigger').click();
-  await page
-    .locator(`wc-shadcn-select-item[data-value="${runtime}"]:visible`)
-    .last()
-    .click({ force: true });
+  await choosePreviewRuntime(page, previewer, runtime);
   await page.waitForFunction(
     ({ expectedCount: count, readySelector: selector, runtime: selectedRuntime }) => {
       const root = document.querySelector<HTMLElement>('[data-previewer-id]');
       const select = root?.querySelector<HTMLElement>('[data-adapter-select-root]');
       const host = root?.querySelector<HTMLElement>('.host');
       const firstRoot = host?.querySelector<HTMLElement>('[data-pui-root]');
-      if (!root || !select || !host || select.getAttribute('data-value') !== selectedRuntime) {
-        return false;
-      }
+      if (!root || !select || !host || select.dataset.value !== selectedRuntime) return false;
       if (host.querySelectorAll(selector).length !== count || !firstRoot) return false;
       if (selectedRuntime === 'wc') return firstRoot.tagName.startsWith('WC-');
       if (selectedRuntime === 'vue') return host.hasAttribute('data-v-app');

--- a/apps/www/src/content/docs/zh-cn/browser-harness.ts
+++ b/apps/www/src/content/docs/zh-cn/browser-harness.ts
@@ -231,6 +231,9 @@ export async function selectRuntime(
       if (host.querySelectorAll(selector).length !== count || !firstRoot) return false;
       if (selectedRuntime === 'wc') return firstRoot.tagName.startsWith('WC-');
       if (selectedRuntime === 'vue') return host.hasAttribute('data-v-app');
+      if (selectedRuntime === 'vue2') {
+        return Boolean((firstRoot as HTMLElement & { __vue__?: unknown }).__vue__);
+      }
       // React owns neither a custom element nor a Vue app root. The host tag is
       // not always a div: a text-control Prototype roots on its native control.
       return !firstRoot.tagName.startsWith('WC-') && !host.hasAttribute('data-v-app');

--- a/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
@@ -181,15 +181,22 @@ async function selectRuntime(
   readySelector: string,
   expectedCount: number
 ): Promise<void> {
-  await previewer.locator('select.adapter-select').selectOption(runtime);
+  const selectRoot = previewer.locator('[data-adapter-select-root]');
+  await selectRoot.locator('wc-shadcn-select-trigger').click();
+  await page
+    .locator(`wc-shadcn-select-item[data-value="${runtime}"]:visible`)
+    .last()
+    .click({ force: true });
   await page.waitForFunction(
     ({ expectedCount: count, readySelector: selector, runtime: selectedRuntime }) => {
       const root = document.querySelector<HTMLElement>('[data-previewer-id]');
-      const select = root?.querySelector<HTMLSelectElement>('select.adapter-select');
+      const select = root?.querySelector<HTMLElement>('[data-adapter-select-root]');
       const host = root?.querySelector<HTMLElement>('.host');
       const firstRoot = host?.querySelector<HTMLElement>('[data-pui-root]');
-      if (!root || !select || !host || select.value !== selectedRuntime) return false;
-      if (root.querySelectorAll(selector).length !== count || !firstRoot) return false;
+      if (!root || !select || !host || select.getAttribute('data-value') !== selectedRuntime) {
+        return false;
+      }
+      if (host.querySelectorAll(selector).length !== count || !firstRoot) return false;
       if (selectedRuntime === 'wc') return firstRoot.tagName.startsWith('WC-');
       if (selectedRuntime === 'vue') return host.hasAttribute('data-v-app');
       // React owns neither a custom element nor a Vue app root. The host tag is
@@ -531,7 +538,7 @@ describe.sequential('Base control documentation browser regressions', () => {
         await selectRuntime(page, previewer, runtime, VIEWPORT_SELECTOR, 2);
         await waitForCanScroll(page, SCROLLING, true);
 
-        await previewer.locator('select.adapter-select').focus();
+        await previewer.locator('.adapter-select').focus();
         await page.keyboard.press('Tab');
         await page.waitForTimeout(200);
 
@@ -568,7 +575,7 @@ describe.sequential('Base control documentation browser regressions', () => {
         await waitForCanScroll(page, SCROLLING, true);
 
         const viewport = previewer.locator(VIEWPORT_SELECTOR).first();
-        await previewer.locator('select.adapter-select').focus();
+        await previewer.locator('.adapter-select').focus();
         await page.keyboard.press('Tab');
         await page.waitForTimeout(100);
 

--- a/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
@@ -11,6 +11,7 @@ import {
   type Page,
 } from 'playwright-core';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { choosePreviewRuntime, runtimeSelectTrigger } from './browser-harness';
 
 const RUNTIMES = ['wc', 'react', 'vue'] as const;
 type RuntimeId = (typeof RUNTIMES)[number];
@@ -181,21 +182,14 @@ async function selectRuntime(
   readySelector: string,
   expectedCount: number
 ): Promise<void> {
-  const selectRoot = previewer.locator('[data-adapter-select-root]');
-  await selectRoot.locator('wc-shadcn-select-trigger').click();
-  await page
-    .locator(`wc-shadcn-select-item[data-value="${runtime}"]:visible`)
-    .last()
-    .click({ force: true });
+  await choosePreviewRuntime(page, previewer, runtime);
   await page.waitForFunction(
     ({ expectedCount: count, readySelector: selector, runtime: selectedRuntime }) => {
       const root = document.querySelector<HTMLElement>('[data-previewer-id]');
       const select = root?.querySelector<HTMLElement>('[data-adapter-select-root]');
       const host = root?.querySelector<HTMLElement>('.host');
       const firstRoot = host?.querySelector<HTMLElement>('[data-pui-root]');
-      if (!root || !select || !host || select.getAttribute('data-value') !== selectedRuntime) {
-        return false;
-      }
+      if (!root || !select || !host || select.dataset.value !== selectedRuntime) return false;
       if (host.querySelectorAll(selector).length !== count || !firstRoot) return false;
       if (selectedRuntime === 'wc') return firstRoot.tagName.startsWith('WC-');
       if (selectedRuntime === 'vue') return host.hasAttribute('data-v-app');
@@ -538,7 +532,7 @@ describe.sequential('Base control documentation browser regressions', () => {
         await selectRuntime(page, previewer, runtime, VIEWPORT_SELECTOR, 2);
         await waitForCanScroll(page, SCROLLING, true);
 
-        await previewer.locator('.adapter-select').focus();
+        await runtimeSelectTrigger(previewer).focus();
         await page.keyboard.press('Tab');
         await page.waitForTimeout(200);
 
@@ -575,7 +569,7 @@ describe.sequential('Base control documentation browser regressions', () => {
         await waitForCanScroll(page, SCROLLING, true);
 
         const viewport = previewer.locator(VIEWPORT_SELECTOR).first();
-        await previewer.locator('.adapter-select').focus();
+        await runtimeSelectTrigger(previewer).focus();
         await page.keyboard.press('Tab');
         await page.waitForTimeout(100);
 

--- a/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
@@ -55,6 +55,11 @@ async function availablePort(): Promise<number> {
 async function chromeExecutable(): Promise<string> {
   const candidates = [
     process.env.CHROME_PATH,
+    process.env.LOCALAPPDATA
+      ? `${process.env.LOCALAPPDATA}/Google/Chrome/Application/chrome.exe`
+      : undefined,
+    'C:/Program Files/Google/Chrome/Application/chrome.exe',
+    'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe',
     '/usr/bin/google-chrome',
     '/bin/google-chrome',
     '/usr/bin/google-chrome-stable',
@@ -115,6 +120,7 @@ async function spawnServer(): Promise<string> {
     {
       cwd: process.cwd(),
       detached: process.platform !== 'win32',
+      shell: process.platform === 'win32',
       env: process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
     }
@@ -153,7 +159,20 @@ async function startServer(): Promise<string> {
 
 async function stopServer(): Promise<void> {
   if (!devServer || devServer.exitCode !== null || !devServer.pid) return;
-  const signalTarget = process.platform === 'win32' ? devServer.pid : -devServer.pid;
+  const pid = devServer.pid;
+  if (process.platform === 'win32') {
+    await new Promise<void>((resolve) => {
+      const killer = spawn('taskkill', ['/PID', String(pid), '/T', '/F'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+      killer.once('error', () => resolve());
+      killer.once('exit', () => resolve());
+    });
+    return;
+  }
+
+  const signalTarget = -pid;
   process.kill(signalTarget, 'SIGTERM');
 
   const exited = await Promise.race([

--- a/apps/www/src/content/docs/zh-cn/demo-base-select.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-select.demo.ts
@@ -1,5 +1,26 @@
+import type { DemoSetupContext, DemoSpec } from '../../../components/PrototypePreviewer/demo-types';
+
+function setup({ host }: DemoSetupContext) {
+  const trigger = host.querySelector<HTMLElement>('[role="combobox"]');
+  if (!trigger) return;
+
+  const label = 'Framework selector';
+  const restoreLabel = () => {
+    if (trigger.getAttribute('aria-label') !== label) trigger.setAttribute('aria-label', label);
+  };
+  restoreLabel();
+
+  // Select's protocol intentionally derives its name from content. A native
+  // combobox needs an explicit label, so keep this demo-only label in place
+  // when the protocol refreshes aria-expanded or other state attributes.
+  const observer = new MutationObserver(restoreLabel);
+  observer.observe(trigger, { attributes: true, attributeFilter: ['aria-label'] });
+  return () => observer.disconnect();
+}
+
 export default {
   type: 'demo',
+  setup,
   root: {
     kind: 'proto',
     prototypeId: 'base-select-root',
@@ -56,4 +77,4 @@ export default {
       },
     ],
   },
-};
+} satisfies DemoSpec;

--- a/apps/www/src/content/docs/zh-cn/demo-base-switch.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-switch.demo.ts
@@ -15,6 +15,7 @@ export default {
             prototypeId: 'base-switch-thumb',
             className: 'block size-5 rounded-full border bg-white',
           },
+          { kind: 'box', className: 'sr-only', children: ['Email alerts'] },
         ],
       },
       {
@@ -28,6 +29,7 @@ export default {
             prototypeId: 'base-switch-thumb',
             className: 'block size-5 rounded-full border bg-white',
           },
+          { kind: 'box', className: 'sr-only', children: ['Release alerts'] },
         ],
       },
     ],

--- a/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
@@ -177,15 +177,22 @@ async function selectRuntime(
   readySelector: string,
   expectedCount: number
 ): Promise<void> {
-  await previewer.locator('select.adapter-select').selectOption(runtime);
+  const selectRoot = previewer.locator('[data-adapter-select-root]');
+  await selectRoot.locator('wc-shadcn-select-trigger').click();
+  await page
+    .locator(`wc-shadcn-select-item[data-value="${runtime}"]:visible`)
+    .last()
+    .click({ force: true });
   await page.waitForFunction(
     ({ expectedCount: count, readySelector: selector, runtime: selectedRuntime }) => {
       const root = document.querySelector<HTMLElement>('[data-previewer-id]');
-      const select = root?.querySelector<HTMLSelectElement>('select.adapter-select');
+      const select = root?.querySelector<HTMLElement>('[data-adapter-select-root]');
       const host = root?.querySelector<HTMLElement>('.host');
       const firstRoot = host?.querySelector<HTMLElement>('[data-pui-root]');
-      if (!root || !select || !host || select.value !== selectedRuntime) return false;
-      if (root.querySelectorAll(selector).length !== count || !firstRoot) return false;
+      if (!root || !select || !host || select.getAttribute('data-value') !== selectedRuntime) {
+        return false;
+      }
+      if (host.querySelectorAll(selector).length !== count || !firstRoot) return false;
       if (selectedRuntime === 'wc') return firstRoot.tagName.startsWith('WC-');
       if (selectedRuntime === 'vue') return host.hasAttribute('data-v-app');
       // React owns neither a custom element nor a Vue app root. The host tag is
@@ -475,7 +482,7 @@ describe.sequential('Brutalist control documentation browser regressions', () =>
     try {
       for (const runtime of RUNTIMES) {
         await selectRuntime(page, previewer, runtime, '[data-pui-root]', 5);
-        const trigger = previewer.locator('[data-pui-root]').nth(1);
+        const trigger = previewer.locator('.host [data-pui-root]').nth(1);
         await trigger.click();
         await expect.poll(() => page.getByRole('menu').count(), { message: runtime }).toBe(1);
         await page.waitForTimeout(200);
@@ -577,7 +584,7 @@ describe.sequential('Brutalist control documentation browser regressions', () =>
     try {
       await previewer.scrollIntoViewIfNeeded();
       await selectRuntime(page, previewer, 'wc', 'textarea', 1);
-      const runtimeSelect = previewer.locator('select.adapter-select');
+      const runtimeSelect = previewer.locator('.adapter-select');
       const textarea = previewer.locator('textarea');
 
       const initial = await wcTextareaFocusSnapshot(previewer);
@@ -790,7 +797,7 @@ describe.sequential('Brutalist control documentation browser regressions', () =>
           expect(resting.focusVisible, `${label}/resting-focus`).toBe(false);
           expect(resting.insetLayers, `${label}/resting-ring`).toHaveLength(0);
 
-          await previewer.locator('select.adapter-select').focus();
+          await previewer.locator('.adapter-select').focus();
           await page.keyboard.press('Tab');
           await page.waitForFunction(
             () =>

--- a/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
@@ -69,6 +69,11 @@ async function availablePort(): Promise<number> {
 async function chromeExecutable(): Promise<string> {
   const candidates = [
     process.env.CHROME_PATH,
+    process.env.LOCALAPPDATA
+      ? `${process.env.LOCALAPPDATA}/Google/Chrome/Application/chrome.exe`
+      : undefined,
+    'C:/Program Files/Google/Chrome/Application/chrome.exe',
+    'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe',
     '/usr/bin/google-chrome',
     '/bin/google-chrome',
     '/usr/bin/google-chrome-stable',
@@ -135,6 +140,7 @@ async function startServer(): Promise<string> {
     {
       cwd: process.cwd(),
       detached: process.platform !== 'win32',
+      shell: process.platform === 'win32',
       env: process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
     }
@@ -149,7 +155,20 @@ async function startServer(): Promise<string> {
 
 async function stopServer(): Promise<void> {
   if (!devServer || devServer.exitCode !== null || !devServer.pid) return;
-  const signalTarget = process.platform === 'win32' ? devServer.pid : -devServer.pid;
+  const pid = devServer.pid;
+  if (process.platform === 'win32') {
+    await new Promise<void>((resolve) => {
+      const killer = spawn('taskkill', ['/PID', String(pid), '/T', '/F'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+      killer.once('error', () => resolve());
+      killer.once('exit', () => resolve());
+    });
+    return;
+  }
+
+  const signalTarget = -pid;
   process.kill(signalTarget, 'SIGTERM');
 
   const exited = await Promise.race([

--- a/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
@@ -11,6 +11,7 @@ import {
   type Page,
 } from 'playwright-core';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { choosePreviewRuntime, runtimeSelectTrigger } from './browser-harness';
 
 const RUNTIMES = ['wc', 'react', 'vue'] as const;
 type RuntimeId = (typeof RUNTIMES)[number];
@@ -177,21 +178,14 @@ async function selectRuntime(
   readySelector: string,
   expectedCount: number
 ): Promise<void> {
-  const selectRoot = previewer.locator('[data-adapter-select-root]');
-  await selectRoot.locator('wc-shadcn-select-trigger').click();
-  await page
-    .locator(`wc-shadcn-select-item[data-value="${runtime}"]:visible`)
-    .last()
-    .click({ force: true });
+  await choosePreviewRuntime(page, previewer, runtime);
   await page.waitForFunction(
     ({ expectedCount: count, readySelector: selector, runtime: selectedRuntime }) => {
       const root = document.querySelector<HTMLElement>('[data-previewer-id]');
       const select = root?.querySelector<HTMLElement>('[data-adapter-select-root]');
       const host = root?.querySelector<HTMLElement>('.host');
       const firstRoot = host?.querySelector<HTMLElement>('[data-pui-root]');
-      if (!root || !select || !host || select.getAttribute('data-value') !== selectedRuntime) {
-        return false;
-      }
+      if (!root || !select || !host || select.dataset.value !== selectedRuntime) return false;
       if (host.querySelectorAll(selector).length !== count || !firstRoot) return false;
       if (selectedRuntime === 'wc') return firstRoot.tagName.startsWith('WC-');
       if (selectedRuntime === 'vue') return host.hasAttribute('data-v-app');
@@ -584,7 +578,7 @@ describe.sequential('Brutalist control documentation browser regressions', () =>
     try {
       await previewer.scrollIntoViewIfNeeded();
       await selectRuntime(page, previewer, 'wc', 'textarea', 1);
-      const runtimeSelect = previewer.locator('.adapter-select');
+      const runtimeSelect = runtimeSelectTrigger(previewer);
       const textarea = previewer.locator('textarea');
 
       const initial = await wcTextareaFocusSnapshot(previewer);
@@ -797,7 +791,7 @@ describe.sequential('Brutalist control documentation browser regressions', () =>
           expect(resting.focusVisible, `${label}/resting-focus`).toBe(false);
           expect(resting.insetLayers, `${label}/resting-ring`).toHaveLength(0);
 
-          await previewer.locator('.adapter-select').focus();
+          await runtimeSelectTrigger(previewer).focus();
           await page.keyboard.press('Tab');
           await page.waitForFunction(
             () =>

--- a/apps/www/src/content/docs/zh-cn/demo-brutalist-select.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-brutalist-select.demo.ts
@@ -1,5 +1,22 @@
+import type { DemoSetupContext, DemoSpec } from '../../../components/PrototypePreviewer/demo-types';
+
+function setup({ host }: DemoSetupContext) {
+  const trigger = host.querySelector<HTMLElement>('[role="combobox"]');
+  if (!trigger) return;
+
+  const label = 'Surface selector';
+  const restoreLabel = () => {
+    if (trigger.getAttribute('aria-label') !== label) trigger.setAttribute('aria-label', label);
+  };
+  restoreLabel();
+  const observer = new MutationObserver(restoreLabel);
+  observer.observe(trigger, { attributes: true, attributeFilter: ['aria-label'] });
+  return () => observer.disconnect();
+}
+
 export default {
   type: 'demo',
+  setup,
   root: {
     kind: 'proto',
     prototypeId: 'brutalist-select-root',
@@ -30,4 +47,4 @@ export default {
       },
     ],
   },
-};
+} satisfies DemoSpec;

--- a/apps/www/src/content/docs/zh-cn/demo-composed-style-isolation.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-composed-style-isolation.browser.test.ts
@@ -8,6 +8,7 @@ import {
   applyColorScheme,
   launchBrowser,
   openRoute,
+  runtimeSelectTrigger,
   selectRuntime,
   startServer,
   stopServer,
@@ -96,7 +97,7 @@ async function switchShadows(page: Page): Promise<SwitchShadows> {
 
 /** Real keyboard focus, so the ring comes from the host's own focus-visible determination. */
 async function focusFirstSwitch(page: Page, previewer: Locator): Promise<void> {
-  await previewer.locator('.adapter-select').focus();
+  await runtimeSelectTrigger(previewer).focus();
   await page.keyboard.press('Tab');
   await page.waitForFunction(
     () =>

--- a/apps/www/src/content/docs/zh-cn/demo-composed-style-isolation.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-composed-style-isolation.browser.test.ts
@@ -96,7 +96,7 @@ async function switchShadows(page: Page): Promise<SwitchShadows> {
 
 /** Real keyboard focus, so the ring comes from the host's own focus-visible determination. */
 async function focusFirstSwitch(page: Page, previewer: Locator): Promise<void> {
-  await previewer.locator('select.adapter-select').focus();
+  await previewer.locator('.adapter-select').focus();
   await page.keyboard.press('Tab');
   await page.waitForFunction(
     () =>

--- a/apps/www/src/content/docs/zh-cn/demo-matrix.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-matrix.browser.test.ts
@@ -13,8 +13,25 @@ type MatrixFacts = {
   errors: number;
   overflow: number;
   adapterColumns: string;
+  adapterColumnCount: number;
   runtimeRows: Record<string, number>;
 };
+
+type InteractiveFact = {
+  role: string;
+  name: string;
+};
+
+const INTERACTIVE_ROLES = [
+  'button',
+  'checkbox',
+  'combobox',
+  'menuitem',
+  'radio',
+  'switch',
+  'tab',
+  'textbox',
+] as const;
 
 async function waitForMatrix(page: Page): Promise<void> {
   await page.waitForFunction(
@@ -62,6 +79,11 @@ async function readMatrixFacts(page: Page): Promise<MatrixFacts> {
       ])
     );
     const firstGrid = document.querySelector<HTMLElement>('.demo-matrix__adapters');
+    const firstColumns = new Set(
+      [...(firstGrid?.querySelectorAll<HTMLElement>(':scope > .demo-matrix__adapter') ?? [])].map(
+        (adapter) => Math.round(adapter.getBoundingClientRect().left)
+      )
+    );
     return {
       demos: document.querySelectorAll('.demo-matrix__item').length,
       previewers: document.querySelectorAll('[data-previewer-id]').length,
@@ -71,9 +93,73 @@ async function readMatrixFacts(page: Page): Promise<MatrixFacts> {
       ).length,
       overflow: root.scrollWidth - root.clientWidth,
       adapterColumns: firstGrid ? getComputedStyle(firstGrid).gridTemplateColumns : '',
+      adapterColumnCount: firstColumns.size,
       runtimeRows,
     };
   }, RUNTIMES);
+}
+
+/**
+ * Read only rendered, non-zero-sized controls. Portaled dialog/menu parts are
+ * present in the document while closed, but are not part of the visible
+ * matrix surface until the corresponding trigger opens them.
+ */
+async function readInteractiveFacts(page: Page): Promise<Record<string, InteractiveFact[][]>> {
+  return page.evaluate((interactiveRoles) => {
+    const roles = new Set<string>(interactiveRoles);
+    const accessibleName = (element: HTMLElement): string => {
+      const labelledBy = element.getAttribute('aria-labelledby');
+      const labelledText = labelledBy
+        ? labelledBy
+            .split(/\s+/)
+            .map((id) => document.getElementById(id)?.textContent ?? '')
+            .join(' ')
+        : '';
+      return (
+        element.getAttribute('aria-label') ||
+        labelledText ||
+        element.getAttribute('title') ||
+        element.textContent ||
+        ''
+      )
+        .trim()
+        .replace(/\s+/g, ' ');
+    };
+    const visible = (element: HTMLElement): boolean => {
+      const rect = element.getBoundingClientRect();
+      const style = getComputedStyle(element);
+      return (
+        rect.width > 0 &&
+        rect.height > 0 &&
+        style.display !== 'none' &&
+        style.visibility !== 'hidden'
+      );
+    };
+
+    const result: Record<string, InteractiveFact[][]> = {};
+    document.querySelectorAll<HTMLElement>('.demo-matrix__item').forEach((item) => {
+      result[item.id] = Array.from(
+        item.querySelectorAll<HTMLElement>(
+          ':scope > .demo-matrix__adapters > .demo-matrix__adapter'
+        )
+      ).map((adapter) =>
+        Array.from(adapter.querySelectorAll<HTMLElement>('[role],button,input,select,textarea'))
+          .filter((element) => {
+            const role = element.getAttribute('role');
+            return (
+              ((role && roles.has(role)) ||
+                ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'].includes(element.tagName)) &&
+              visible(element)
+            );
+          })
+          .map((element) => ({
+            role: element.getAttribute('role') || element.tagName.toLowerCase(),
+            name: accessibleName(element),
+          }))
+      );
+    });
+    return result;
+  }, INTERACTIVE_ROLES);
 }
 
 async function chooseGlobalAdapter(page: Page, runtime: string): Promise<void> {
@@ -121,8 +207,24 @@ describe.sequential('Website Demo Matrix browser smoke', () => {
       expect(facts.initialized).toBe(facts.previewers);
       expect(facts.errors).toBe(0);
       expect(facts.overflow).toBeLessThanOrEqual(0);
+      expect(facts.adapterColumnCount).toBe(RUNTIMES.length);
       for (const runtime of RUNTIMES) {
         expect(facts.runtimeRows[runtime], runtime).toBe(facts.demos);
+      }
+
+      const interactive = await readInteractiveFacts(page);
+      for (const [demoId, adapters] of Object.entries(interactive)) {
+        const signatures = adapters.map((controls) =>
+          controls.map(({ role, name }) => `${role}|${name}`)
+        );
+        expect(
+          signatures.flat().every((signature) => signature.endsWith('|') === false),
+          `${demoId} has an unnamed visible interactive control`
+        ).toBe(true);
+        expect(
+          new Set(signatures.map((signature) => JSON.stringify(signature))).size,
+          `${demoId} accessible controls differ across runtimes`
+        ).toBeLessThanOrEqual(1);
       }
 
       await chooseGlobalAdapter(page, 'vue2');
@@ -156,23 +258,25 @@ describe.sequential('Website Demo Matrix browser smoke', () => {
     }
   }, 180_000);
 
-  it('keeps the four-column matrix readable at 320px', async () => {
-    const { context, page } = await openRoute(browser, baseUrl, MATRIX_ROUTE, {
-      width: 320,
-      height: 900,
-    });
+  for (const width of [320, 390]) {
+    it(`keeps the matrix readable at ${width}px`, async () => {
+      const { context, page } = await openRoute(browser, baseUrl, MATRIX_ROUTE, {
+        width,
+        height: 900,
+      });
 
-    try {
-      await waitForMatrix(page);
-      const facts = await readMatrixFacts(page);
-      expect(facts.errors).toBe(0);
-      expect(facts.overflow).toBeLessThanOrEqual(0);
-      expect(facts.adapterColumns.split(' ').filter(Boolean)).toHaveLength(1);
-      expect(facts.previewers).toBe(facts.demos * RUNTIMES.length);
-    } finally {
-      await context.close();
-    }
-  }, 180_000);
+      try {
+        await waitForMatrix(page);
+        const facts = await readMatrixFacts(page);
+        expect(facts.errors).toBe(0);
+        expect(facts.overflow).toBeLessThanOrEqual(0);
+        expect(facts.adapterColumnCount).toBe(1);
+        expect(facts.previewers).toBe(facts.demos * RUNTIMES.length);
+      } finally {
+        await context.close();
+      }
+    }, 180_000);
+  }
 
   it('moves focus into the Base Dialog content in every runtime', async () => {
     const { context, page } = await openRoute(browser, baseUrl, MATRIX_ROUTE, {

--- a/apps/www/src/content/docs/zh-cn/demo-matrix.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-matrix.browser.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment node
+
+import type { Browser, Page } from 'playwright-core';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { RUNTIMES, launchBrowser, openRoute, startServer, stopServer } from './browser-harness';
+
+const MATRIX_ROUTE = '/zh-cn/internal/demo-matrix/';
+
+type MatrixFacts = {
+  demos: number;
+  previewers: number;
+  initialized: number;
+  errors: number;
+  overflow: number;
+  adapterColumns: string;
+  runtimeRows: Record<string, number>;
+};
+
+async function waitForMatrix(page: Page): Promise<void> {
+  await page.waitForFunction(
+    (runtimeCount) => {
+      const demos = document.querySelectorAll('.demo-matrix__item').length;
+      const previewers = document.querySelectorAll('[data-previewer-id]').length;
+      const initialized = document.querySelectorAll('[data-previewer-id][data-inited="1"]').length;
+      return demos > 0 && previewers === demos * runtimeCount && initialized === previewers;
+    },
+    RUNTIMES.length,
+    { timeout: 60_000 }
+  );
+
+  // Framework loaders settle after the preview roots are marked initialized;
+  // wait for the final host content so a slow import cannot be reported as a
+  // false matrix failure.
+  await page.waitForFunction(
+    () =>
+      [...document.querySelectorAll<HTMLElement>('[data-previewer-id] .host')].every(
+        (host) => host.childElementCount > 0 || host.textContent?.includes('[Preview Error]')
+      ),
+    undefined,
+    { timeout: 60_000 }
+  );
+}
+
+async function readMatrixFacts(page: Page): Promise<MatrixFacts> {
+  return page.evaluate((runtimeIds) => {
+    const root = document.documentElement;
+    const adapters = [...document.querySelectorAll<HTMLElement>('.demo-matrix__adapter')];
+    const runtimeRows = Object.fromEntries(
+      runtimeIds.map((runtime) => [
+        runtime,
+        adapters.filter((adapter) =>
+          adapter
+            .getAttribute('aria-label')
+            ?.endsWith(
+              runtime === 'wc'
+                ? 'Web Components'
+                : runtime === 'vue2'
+                  ? 'Vue 2'
+                  : runtime[0].toUpperCase() + runtime.slice(1)
+            )
+        ).length,
+      ])
+    );
+    const firstGrid = document.querySelector<HTMLElement>('.demo-matrix__adapters');
+    return {
+      demos: document.querySelectorAll('.demo-matrix__item').length,
+      previewers: document.querySelectorAll('[data-previewer-id]').length,
+      initialized: document.querySelectorAll('[data-previewer-id][data-inited="1"]').length,
+      errors: [...document.querySelectorAll('[data-previewer-id]')].filter((previewer) =>
+        previewer.textContent?.includes('[Preview Error]')
+      ).length,
+      overflow: root.scrollWidth - root.clientWidth,
+      adapterColumns: firstGrid ? getComputedStyle(firstGrid).gridTemplateColumns : '',
+      runtimeRows,
+    };
+  }, RUNTIMES);
+}
+
+async function chooseGlobalAdapter(page: Page, runtime: string): Promise<void> {
+  const root = page.locator('wc-shadcn-select-root[data-adapter-select-root]').first();
+  await root.locator('wc-shadcn-select-trigger').click();
+  await page
+    .locator(
+      `wc-shadcn-select-content[data-transition-state="entered"] wc-shadcn-select-item[data-value="${runtime}"]`
+    )
+    .click({ force: true });
+  await page.waitForFunction(
+    (selected) =>
+      document.querySelector<HTMLElement>('wc-shadcn-select-root[data-adapter-select-root]')
+        ?.dataset.value === selected,
+    runtime,
+    { timeout: 10_000 }
+  );
+}
+
+let browser: Browser;
+let baseUrl = '';
+
+beforeAll(async () => {
+  baseUrl = await startServer(MATRIX_ROUTE);
+  browser = await launchBrowser();
+}, 150_000);
+
+afterAll(async () => {
+  await browser?.close();
+  await stopServer();
+}, 60_000);
+
+describe.sequential('Website Demo Matrix browser smoke', () => {
+  it('mounts every demo in every official adapter without errors or overflow', async () => {
+    const { context, page } = await openRoute(browser, baseUrl, MATRIX_ROUTE, {
+      width: 1440,
+      height: 900,
+    });
+
+    try {
+      await waitForMatrix(page);
+      const facts = await readMatrixFacts(page);
+      expect(facts.demos).toBeGreaterThan(0);
+      expect(facts.previewers).toBe(facts.demos * RUNTIMES.length);
+      expect(facts.initialized).toBe(facts.previewers);
+      expect(facts.errors).toBe(0);
+      expect(facts.overflow).toBeLessThanOrEqual(0);
+      for (const runtime of RUNTIMES) {
+        expect(facts.runtimeRows[runtime], runtime).toBe(facts.demos);
+      }
+
+      await chooseGlobalAdapter(page, 'vue2');
+      await page.waitForFunction(
+        () =>
+          [
+            ...document.querySelectorAll<HTMLElement>(
+              '.demo-matrix__adapter[aria-label$="Vue 2"] .host'
+            ),
+          ].every(
+            (host) => host.childElementCount > 0 || host.textContent?.includes('[Preview Error]')
+          ),
+        undefined,
+        { timeout: 30_000 }
+      );
+      await chooseGlobalAdapter(page, 'react');
+      await page.waitForFunction(
+        () =>
+          [
+            ...document.querySelectorAll<HTMLElement>(
+              '.demo-matrix__adapter[aria-label$="React"] .host'
+            ),
+          ].every(
+            (host) => host.childElementCount > 0 || host.textContent?.includes('[Preview Error]')
+          ),
+        undefined,
+        { timeout: 30_000 }
+      );
+    } finally {
+      await context.close();
+    }
+  }, 180_000);
+
+  it('keeps the four-column matrix readable at 320px', async () => {
+    const { context, page } = await openRoute(browser, baseUrl, MATRIX_ROUTE, {
+      width: 320,
+      height: 900,
+    });
+
+    try {
+      await waitForMatrix(page);
+      const facts = await readMatrixFacts(page);
+      expect(facts.errors).toBe(0);
+      expect(facts.overflow).toBeLessThanOrEqual(0);
+      expect(facts.adapterColumns.split(' ').filter(Boolean)).toHaveLength(1);
+      expect(facts.previewers).toBe(facts.demos * RUNTIMES.length);
+    } finally {
+      await context.close();
+    }
+  }, 180_000);
+});

--- a/apps/www/src/content/docs/zh-cn/demo-matrix.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-matrix.browser.test.ts
@@ -125,32 +125,21 @@ describe.sequential('Website Demo Matrix browser smoke', () => {
         expect(facts.runtimeRows[runtime], runtime).toBe(facts.demos);
       }
 
+      const waitForAdapterBroadcast = () =>
+        page.evaluate(
+          () =>
+            new Promise<boolean>((resolve) => {
+              document.addEventListener('proto-adapter:change', () => resolve(true), {
+                once: true,
+              });
+            })
+        );
+      const vue2Broadcast = waitForAdapterBroadcast();
       await chooseGlobalAdapter(page, 'vue2');
-      await page.waitForFunction(
-        () =>
-          [
-            ...document.querySelectorAll<HTMLElement>(
-              '.demo-matrix__adapter[aria-label$="Vue 2"] .host'
-            ),
-          ].every(
-            (host) => host.childElementCount > 0 || host.textContent?.includes('[Preview Error]')
-          ),
-        undefined,
-        { timeout: 30_000 }
-      );
+      await vue2Broadcast;
+      const reactBroadcast = waitForAdapterBroadcast();
       await chooseGlobalAdapter(page, 'react');
-      await page.waitForFunction(
-        () =>
-          [
-            ...document.querySelectorAll<HTMLElement>(
-              '.demo-matrix__adapter[aria-label$="React"] .host'
-            ),
-          ].every(
-            (host) => host.childElementCount > 0 || host.textContent?.includes('[Preview Error]')
-          ),
-        undefined,
-        { timeout: 30_000 }
-      );
+      await reactBroadcast;
     } finally {
       await context.close();
     }

--- a/apps/www/src/content/docs/zh-cn/demo-matrix.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-matrix.browser.test.ts
@@ -173,4 +173,68 @@ describe.sequential('Website Demo Matrix browser smoke', () => {
       await context.close();
     }
   }, 180_000);
+
+  it('moves focus into the Base Dialog content in every runtime', async () => {
+    const { context, page } = await openRoute(browser, baseUrl, MATRIX_ROUTE, {
+      width: 1440,
+      height: 900,
+    });
+
+    const runtimeLabels: Record<string, string> = {
+      wc: 'Web Components',
+      react: 'React',
+      vue: 'Vue',
+      vue2: 'Vue 2',
+    };
+
+    try {
+      await waitForMatrix(page);
+      const dialogRow = page.locator('#demo-base-dialog');
+
+      for (const runtime of RUNTIMES) {
+        const region = dialogRow.locator(
+          `.demo-matrix__adapter[aria-label="demo-base-dialog ${runtimeLabels[runtime]}"]`
+        );
+        const trigger = region.locator('[aria-haspopup="dialog"]');
+        await trigger.scrollIntoViewIfNeeded();
+        const contentId = await trigger.getAttribute('aria-controls');
+        expect(contentId, `${runtime} dialog controls`).toBeTruthy();
+        await trigger.click();
+
+        await page.waitForFunction(
+          (id) => {
+            const content = id ? document.getElementById(id) : null;
+            return Boolean(
+              content &&
+              getComputedStyle(content).display !== 'none' &&
+              document.activeElement &&
+              content.contains(document.activeElement)
+            );
+          },
+          contentId,
+          { timeout: 10_000 }
+        );
+
+        const cancel = page
+          .locator(`[id="${contentId}"] [data-pui-a11y-actions="activate"]`)
+          .first();
+        await cancel.click();
+        await page.waitForFunction(
+          (id) => {
+            const content = id ? document.getElementById(id) : null;
+            return !content || getComputedStyle(content).display === 'none';
+          },
+          contentId,
+          { timeout: 10_000 }
+        );
+        await expect
+          .poll(() => trigger.evaluate((element) => document.activeElement === element), {
+            timeout: 10_000,
+          })
+          .toBe(true);
+      }
+    } finally {
+      await context.close();
+    }
+  }, 180_000);
 });

--- a/apps/www/src/content/docs/zh-cn/demo-ring-offset-default.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-ring-offset-default.browser.test.ts
@@ -26,7 +26,7 @@ type RingOffsetSample = {
 };
 
 async function focusDropdownTrigger(page: Page, previewer: Locator): Promise<void> {
-  await previewer.locator('select.adapter-select').focus();
+  await previewer.locator('.adapter-select').focus();
   await page.keyboard.press('Tab');
   await page.waitForFunction(
     () => {

--- a/apps/www/src/content/docs/zh-cn/demo-ring-offset-default.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-ring-offset-default.browser.test.ts
@@ -7,6 +7,7 @@ import {
   applyColorScheme,
   launchBrowser,
   openRoute,
+  runtimeSelectTrigger,
   selectRuntime,
   startServer,
   stopServer,
@@ -26,7 +27,7 @@ type RingOffsetSample = {
 };
 
 async function focusDropdownTrigger(page: Page, previewer: Locator): Promise<void> {
-  await previewer.locator('.adapter-select').focus();
+  await runtimeSelectTrigger(previewer).focus();
   await page.keyboard.press('Tab');
   await page.waitForFunction(
     () => {

--- a/apps/www/src/content/docs/zh-cn/demo-select-first-paint.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-select-first-paint.browser.test.ts
@@ -77,7 +77,7 @@ async function readClosedSelect(page: Page): Promise<ClosedSelect> {
       // collection even though nothing has opened it.
       registeredItems: host.querySelectorAll('[data-collection-index]').length,
       mountedRoots: host.querySelectorAll('[data-pui-root]').length,
-      detachedHosts: document.querySelectorAll('[data-pui-view-detached]').length,
+      detachedHosts: host.querySelectorAll('[data-pui-view-detached]').length,
       everOpened: !!host.querySelector('[data-open]'),
     };
   });

--- a/apps/www/src/content/docs/zh-cn/demo-select-first-paint.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-select-first-paint.browser.test.ts
@@ -72,10 +72,10 @@ async function readClosedSelect(page: Page): Promise<ClosedSelect> {
       displayValue: value?.getAttribute('data-display-value') ?? null,
       // Items live inside the closed content; they register with the Root's
       // collection even though nothing has opened it.
-      registeredItems: document.querySelectorAll('[data-collection-index]').length,
+      registeredItems: host.querySelectorAll('[data-collection-index]').length,
       mountedRoots: document.querySelectorAll('[data-previewer-id] [data-pui-root]').length,
       detachedHosts: document.querySelectorAll('[data-pui-view-detached]').length,
-      everOpened: !!document.querySelector('[data-open]'),
+      everOpened: !!host.querySelector('[data-open]'),
     };
   });
 }

--- a/apps/www/src/content/docs/zh-cn/demo-select-first-paint.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-select-first-paint.browser.test.ts
@@ -22,13 +22,17 @@ const MOUNTED_ROOT_COUNT = 6;
  * timeout that says nothing about the label.
  */
 async function showRuntime(page: Page, previewer: Locator, runtime: string): Promise<void> {
-  await previewer.locator('select.adapter-select').selectOption(runtime);
+  const selectRoot = previewer.locator('[data-adapter-select-root]');
+  await selectRoot.locator('wc-shadcn-select-trigger').click();
+  // Select content is portalled while open, so resolve the visible item from
+  // the document rather than assuming it remains a child of the previewer.
+  await page.locator(`wc-shadcn-select-item[data-value="${runtime}"]:visible`).last().click();
   await page.waitForFunction(
     (selected) => {
       const root = document.querySelector('[data-previewer-id]');
-      const select = root?.querySelector<HTMLSelectElement>('select.adapter-select');
+      const select = root?.querySelector<HTMLElement>('[data-adapter-select-root]');
       const host = root?.querySelector('.host');
-      if (!host || select?.value !== selected) return false;
+      if (!host || select?.getAttribute('data-value') !== selected) return false;
       return Array.from(host.querySelectorAll('*')).some(
         (element) => element.getAttribute('role') === 'combobox'
       );

--- a/apps/www/src/content/docs/zh-cn/demo-select-first-paint.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-select-first-paint.browser.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Locator } from 'playwright-core';
 import { RUNTIMES, launchBrowser, openRoute, startServer, stopServer } from './browser-harness';
 
-const SELECT_RUNTIMES = [...RUNTIMES, 'vue2'] as const;
+const SELECT_RUNTIMES = RUNTIMES;
 
 const SELECT_ROUTE = '/en/ui-libraries/brutalist/components/select/';
 

--- a/apps/www/src/content/docs/zh-cn/demo-select-first-paint.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-select-first-paint.browser.test.ts
@@ -26,7 +26,10 @@ async function showRuntime(page: Page, previewer: Locator, runtime: string): Pro
   await selectRoot.locator('wc-shadcn-select-trigger').click();
   // Select content is portalled while open, so resolve the visible item from
   // the document rather than assuming it remains a child of the previewer.
-  await page.locator(`wc-shadcn-select-item[data-value="${runtime}"]:visible`).last().click();
+  await page
+    .locator(`wc-shadcn-select-item[data-value="${runtime}"]:visible`)
+    .last()
+    .click({ force: true });
   await page.waitForFunction(
     (selected) => {
       const root = document.querySelector('[data-previewer-id]');
@@ -73,7 +76,7 @@ async function readClosedSelect(page: Page): Promise<ClosedSelect> {
       // Items live inside the closed content; they register with the Root's
       // collection even though nothing has opened it.
       registeredItems: host.querySelectorAll('[data-collection-index]').length,
-      mountedRoots: document.querySelectorAll('[data-previewer-id] [data-pui-root]').length,
+      mountedRoots: host.querySelectorAll('[data-pui-root]').length,
       detachedHosts: document.querySelectorAll('[data-pui-view-detached]').length,
       everOpened: !!host.querySelector('[data-open]'),
     };

--- a/apps/www/src/content/docs/zh-cn/demo-shadcn-checkbox.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-shadcn-checkbox.demo.ts
@@ -17,6 +17,7 @@ export default {
                 kind: 'proto',
                 prototypeId: 'shadcn-checkbox-indicator',
               },
+              { kind: 'box', className: 'sr-only', children: ['Unchecked'] },
             ],
           },
           {
@@ -39,6 +40,7 @@ export default {
                 kind: 'proto',
                 prototypeId: 'shadcn-checkbox-indicator',
               },
+              { kind: 'box', className: 'sr-only', children: ['Checked'] },
             ],
           },
           {
@@ -61,6 +63,7 @@ export default {
                 kind: 'proto',
                 prototypeId: 'shadcn-checkbox-indicator',
               },
+              { kind: 'box', className: 'sr-only', children: ['Mixed'] },
             ],
           },
           {
@@ -83,6 +86,7 @@ export default {
                 kind: 'proto',
                 prototypeId: 'shadcn-checkbox-indicator',
               },
+              { kind: 'box', className: 'sr-only', children: ['Disabled'] },
             ],
           },
           {
@@ -105,6 +109,7 @@ export default {
                 kind: 'proto',
                 prototypeId: 'shadcn-checkbox-indicator',
               },
+              { kind: 'box', className: 'sr-only', children: ['Focus ring'] },
             ],
           },
           {

--- a/apps/www/src/content/docs/zh-cn/demo-shadcn-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-shadcn-controls.browser.test.ts
@@ -205,6 +205,11 @@ describe.sequential('shadcn control documentation browser regressions', () => {
 
     try {
       await previewer.scrollIntoViewIfNeeded();
+      const mountScope = await previewer.evaluate((root) => ({
+        previewerRoots: root.querySelectorAll('[data-pui-root]').length,
+        demoRoots: root.querySelector('.host')?.querySelectorAll('[data-pui-root]').length ?? 0,
+      }));
+      expect(mountScope.previewerRoots).toBeGreaterThan(mountScope.demoRoots);
       for (const runtime of RUNTIMES) {
         await selectRuntime(page, previewer, runtime, '[data-pui-root]', 3);
         await applyColorScheme(page, 'light');

--- a/apps/www/src/content/docs/zh-cn/demo-shadcn-select.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-shadcn-select.demo.ts
@@ -1,5 +1,26 @@
+import type { DemoSetupContext, DemoSpec } from '../../../components/PrototypePreviewer/demo-types';
+
+function setup({ host }: DemoSetupContext) {
+  const trigger = host.querySelector<HTMLElement>('[role="combobox"]');
+  if (!trigger) return;
+
+  const label = 'Adapter selector';
+  const restoreLabel = () => {
+    if (trigger.getAttribute('aria-label') !== label) trigger.setAttribute('aria-label', label);
+  };
+  restoreLabel();
+
+  // Select's protocol intentionally derives its name from content. A native
+  // combobox needs an explicit label, so keep this demo-only label in place
+  // when the protocol refreshes aria-expanded or other state attributes.
+  const observer = new MutationObserver(restoreLabel);
+  observer.observe(trigger, { attributes: true, attributeFilter: ['aria-label'] });
+  return () => observer.disconnect();
+}
+
 export default {
   type: 'demo',
+  setup,
   root: {
     kind: 'proto',
     prototypeId: 'shadcn-select-root',
@@ -49,4 +70,4 @@ export default {
       },
     ],
   },
-};
+} satisfies DemoSpec;

--- a/apps/www/src/content/docs/zh-cn/demo-shadcn-switch.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-shadcn-switch.demo.ts
@@ -13,6 +13,7 @@ export default {
             kind: 'proto',
             prototypeId: 'shadcn-switch-thumb',
           },
+          { kind: 'box', className: 'sr-only', children: ['Email alerts'] },
         ],
       },
       {
@@ -24,6 +25,7 @@ export default {
             kind: 'proto',
             prototypeId: 'shadcn-switch-thumb',
           },
+          { kind: 'box', className: 'sr-only', children: ['Release alerts'] },
         ],
       },
       {
@@ -35,6 +37,7 @@ export default {
             kind: 'proto',
             prototypeId: 'shadcn-switch-thumb',
           },
+          { kind: 'box', className: 'sr-only', children: ['Archived alerts'] },
         ],
       },
     ],

--- a/apps/www/src/content/docs/zh-cn/demo-shadcn-textarea.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-shadcn-textarea.demo.ts
@@ -46,6 +46,7 @@ export default {
             props: {
               defaultValue: 'This editor is disabled.',
               disabled: true,
+              ariaLabel: 'Disabled release note',
               rows: 2,
             },
           },
@@ -66,6 +67,7 @@ export default {
             props: {
               defaultValue: 'This editor is read only, and still focusable.',
               readOnly: true,
+              ariaLabel: 'Read-only release note',
               rows: 2,
             },
           },

--- a/apps/www/src/content/docs/zh-cn/demo-shadcn-toggle.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-shadcn-toggle.demo.ts
@@ -14,6 +14,7 @@ export default {
             className: 'inline-flex size-4 shrink-0 pointer-events-none',
             props: { name: 'bold', size: 16 },
           },
+          { kind: 'box', className: 'sr-only', children: ['Bold'] },
         ],
       },
       {
@@ -27,6 +28,7 @@ export default {
             className: 'inline-flex size-4 shrink-0 pointer-events-none',
             props: { name: 'italic', size: 16 },
           },
+          { kind: 'box', className: 'sr-only', children: ['Italic'] },
         ],
       },
       {
@@ -40,6 +42,7 @@ export default {
             className: 'inline-flex size-4 shrink-0 pointer-events-none',
             props: { name: 'underline', size: 16 },
           },
+          { kind: 'box', className: 'sr-only', children: ['Underline'] },
         ],
       },
       {
@@ -53,6 +56,7 @@ export default {
             className: 'inline-flex size-4 shrink-0 pointer-events-none',
             props: { name: 'strikethrough', size: 16 },
           },
+          { kind: 'box', className: 'sr-only', children: ['Strikethrough'] },
         ],
       },
     ],

--- a/apps/www/src/content/docs/zh-cn/home-demo-runtime.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/home-demo-runtime.browser.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+
+import type { Browser, Page } from 'playwright-core';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { RUNTIMES, launchBrowser, startServer, stopServer } from './browser-harness';
+
+const HOME_ROUTE = '/zh-cn/';
+const HOME_SELECTOR = '[data-home-demo-options]';
+
+async function waitForHomeRuntime(page: Page, runtime: string): Promise<void> {
+  await page.waitForFunction(
+    ({ homeSelector, selectedRuntime }) => {
+      const root = document.querySelector<HTMLElement>(homeSelector);
+      const select = root?.querySelector<HTMLElement>('[data-home-demo-runtime]');
+      const host = root?.querySelector<HTMLElement>('[data-home-demo-host]');
+      return (
+        select?.dataset.value === selectedRuntime &&
+        (host?.querySelector('[data-pui-root]') != null ||
+          host?.textContent?.includes('[Home Demo Error]') === true)
+      );
+    },
+    { homeSelector: HOME_SELECTOR, selectedRuntime: runtime },
+    { timeout: 30_000 }
+  );
+
+  const error = await page.locator(`${HOME_SELECTOR} [data-home-demo-host]`).textContent();
+  expect(error, `${runtime} home demo`).not.toContain('[Home Demo Error]');
+}
+
+async function chooseRuntime(page: Page, root: ReturnType<Page['locator']>, runtime: string) {
+  await root.locator('[data-home-demo-runtime] wc-shadcn-select-trigger').click();
+  await page
+    .locator(`wc-shadcn-select-item[data-value="${runtime}"]:visible`)
+    .last()
+    .click({ force: true });
+  await waitForHomeRuntime(page, runtime);
+}
+
+let browser: Browser;
+let baseUrl = '';
+
+beforeAll(async () => {
+  baseUrl = await startServer(HOME_ROUTE);
+  browser = await launchBrowser();
+}, 150_000);
+
+afterAll(async () => {
+  await browser?.close();
+  await stopServer();
+}, 60_000);
+
+describe.sequential('Homepage Runtime demobox browser smoke', () => {
+  it('remounts locally and follows the global adapter preference across all runtimes', async () => {
+    const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    const page = await context.newPage();
+    await page.goto(`${baseUrl}${HOME_ROUTE}`, { waitUntil: 'networkidle' });
+    const home = page.locator(HOME_SELECTOR);
+    const globalRoot = page.locator('wc-shadcn-select-root[data-adapter-select-root]').first();
+
+    try {
+      await home.waitFor({ state: 'visible' });
+      await waitForHomeRuntime(page, 'wc');
+      for (const runtime of RUNTIMES) {
+        await chooseRuntime(page, home, runtime);
+        expect(
+          await page
+            .locator('wc-shadcn-select-root[data-adapter-select-root]')
+            .first()
+            .getAttribute('data-value'),
+          `${runtime} global preference`
+        ).toBe(runtime);
+      }
+
+      await globalRoot.locator('wc-shadcn-select-trigger').click();
+      await page
+        .locator('wc-shadcn-select-item[data-value="vue"]:visible')
+        .last()
+        .click({ force: true });
+      await waitForHomeRuntime(page, 'vue');
+      expect(await home.locator('[data-home-demo-runtime]').getAttribute('data-value')).toBe('vue');
+    } finally {
+      await context.close();
+    }
+  }, 180_000);
+});

--- a/apps/www/src/content/docs/zh-cn/home-demo-runtime.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/home-demo-runtime.browser.test.ts
@@ -62,6 +62,15 @@ describe.sequential('Homepage Runtime demobox browser smoke', () => {
       await waitForHomeRuntime(page, 'wc');
       for (const runtime of RUNTIMES) {
         await chooseRuntime(page, home, runtime);
+        await expect
+          .poll(
+            () =>
+              home
+                .locator('[data-home-demo-runtime] wc-shadcn-select-trigger')
+                .evaluate((element) => document.activeElement === element),
+            { timeout: 10_000 }
+          )
+          .toBe(true);
         expect(
           await page
             .locator('wc-shadcn-select-root[data-adapter-select-root]')

--- a/apps/www/src/content/docs/zh-cn/internal/demo-matrix.mdx
+++ b/apps/www/src/content/docs/zh-cn/internal/demo-matrix.mdx
@@ -8,6 +8,6 @@ tableOfContents: false
 
 import DemoMatrix from '@/components/PrototypePreviewer/DemoMatrix.astro';
 
-这个页面用于快速检查当前所有组件 demo 在各个适配器下是否仍然能正常挂载与交互。它不会出现在左侧导航里。
+这个页面是 Proto UI 官网的可执行 parity loop：当前所有 demo 会在 Web Components、React、Vue 与 Vue 2 四个官方适配器下同时挂载，便于在同一个页面发现跨适配器差异。浏览器 smoke 会验证完整挂载数、错误回退、全局适配器切换，以及 320px 窄屏的零溢出布局。它不会出现在左侧导航里。
 
 <DemoMatrix />

--- a/internal/records/2026-08-29-shadcn-demobox-dogfood-followup.zh-CN.md
+++ b/internal/records/2026-08-29-shadcn-demobox-dogfood-followup.zh-CN.md
@@ -1,0 +1,25 @@
+# Shadcn site controls 与 Runtime demobox dogfood 跟进
+
+日期：2026-08-29
+
+本文记录 PR #567 与 Issue #568 的一次实现和 dogfood 验证跟进，不改变 `spec/**` 的规范语义，也不替代可执行测试。
+
+## 观察到的事实
+
+- 首页 Runtime demobox 在本地触发切换后会经过一次 document-level teardown/remount；当前实现把发起切换的 trigger 作为 focus target 传入该路径，并在 remount 解锁 Select 后恢复焦点。
+- Previewer 对过期异步完成、无变化请求和强制更新分别做了保护；较新的请求不会被旧请求的 finally 分支清空。
+- Demo Matrix 的浏览器覆盖在 1440px、390px 和 320px 验证 runtime 行数、mount 数、列几何、无水平溢出，以及每个交互控件的稳定非空 role/name；首页覆盖验证 Dialog focus/restore journey。
+
+## 当前证据
+
+- Matrix 与首页 browser suites：5/5。
+- 相关 Vitest focused suites：17/17。
+- `apps-www check`：178 files，0 errors/warnings/hints。
+- `check:agent-doc`：通过。
+- `check:agent-operations`：56/56。
+- Demo Matrix policy tests：3/3。
+
+## 后续
+
+- PR #567 仍需独立维护者审查；作者不能自我 approval 或 merge。
+- Issue #568 继续作为站点控件、Runtime demobox 和 dogfood matrix 的聚合跟踪；新增发现应绑定到具体 head、可观察行为和对应测试。

--- a/packages/adapters/react/src/adapt.ts
+++ b/packages/adapters/react/src/adapt.ts
@@ -441,8 +441,8 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
             scheduleAfterWebLayout(
               rootRef.current,
               () => {
-                notifyFocusTargetReady();
                 focusTargetRetryScheduledRef.current = false;
+                notifyFocusTargetReady();
               },
               schedule
             );

--- a/packages/adapters/react/src/adapt.ts
+++ b/packages/adapters/react/src/adapt.ts
@@ -144,6 +144,7 @@ function hasSameRawProps(
   );
 }
 
+const MAX_FOCUS_TARGET_RETRIES = 3;
 export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
   const runtime = normalizeRuntime(runtimeInput);
   const sharedOverlayLayerScheduler = createZIndexOverlayLayerScheduler();
@@ -206,10 +207,12 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
       const viewReadyRef = runtime.useRef(false);
       const focusTargetReadyListenersRef = runtime.useRef<Set<() => void>>(new Set());
       const focusTargetRetryScheduledRef = runtime.useRef(false);
+      const focusTargetRetryCountRef = runtime.useRef(0);
       const notifyFocusTargetReady = () => {
         const target = rootRef.current;
         if (!viewReadyRef.current || !target?.isConnected) return;
         for (const listener of Array.from(focusTargetReadyListenersRef.current)) listener();
+        if (target.ownerDocument.activeElement === target) focusTargetRetryCountRef.current = 0;
       };
 
       const controllerRef = runtime.useRef<RuntimeController | null>(null);
@@ -363,6 +366,7 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
           if (ownerRef.current?.hasView) void ownerRef.current.detachView();
           setHostTokens([]);
           viewReadyRef.current = false;
+          focusTargetRetryCountRef.current = 0;
           return;
         }
 
@@ -436,8 +440,14 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
             return () => focusTargetReadyListenersRef.current.delete(listener);
           },
           retryTargetReady: () => {
-            if (focusTargetRetryScheduledRef.current) return;
+            if (
+              focusTargetRetryScheduledRef.current ||
+              focusTargetRetryCountRef.current >= MAX_FOCUS_TARGET_RETRIES
+            ) {
+              return;
+            }
             focusTargetRetryScheduledRef.current = true;
+            focusTargetRetryCountRef.current += 1;
             scheduleAfterWebLayout(
               rootRef.current,
               () => {
@@ -473,6 +483,7 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
         ownerDisposalRef.current?.retain();
         return () => {
           viewReadyRef.current = false;
+          focusTargetRetryCountRef.current = 0;
           rootRef.current?.setAttribute(PUI_VIEW_PENDING_ATTR, '');
           void ownerRef.current?.detachView();
           ownerDisposalRef.current?.release();
@@ -483,6 +494,7 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
         if (!pendingCommitRef.current) return;
         pendingCommitRef.current = false;
         viewReadyRef.current = true;
+        focusTargetRetryCountRef.current = 0;
         rootRef.current?.removeAttribute(PUI_VIEW_PENDING_ATTR);
         eventGateRef.current?.enable();
         notifyFocusTargetReady();

--- a/packages/adapters/vue/src/adapt.ts
+++ b/packages/adapters/vue/src/adapt.ts
@@ -134,6 +134,8 @@ function shallowEqualHostProps(
   );
 }
 
+const MAX_FOCUS_TARGET_RETRIES = 3;
+
 export function createVueAdapter(runtime: VueRuntime) {
   const sharedOverlayLayerScheduler = createZIndexOverlayLayerScheduler();
   const logicalOwnerKey = Symbol('@proto.ui/adapter-vue/logical-owner');
@@ -210,10 +212,12 @@ export function createVueAdapter(runtime: VueRuntime) {
         let viewReady = false;
         const focusTargetReadyListeners = new Set<() => void>();
         let focusTargetRetryScheduled = false;
+        let focusTargetRetryCount = 0;
         const notifyFocusTargetReady = () => {
           const target = rootRef.value;
           if (!viewReady || !target?.isConnected) return;
           for (const listener of Array.from(focusTargetReadyListeners)) listener();
+          if (target.ownerDocument.activeElement === target) focusTargetRetryCount = 0;
         };
 
         const subs = new Set<() => void>();
@@ -335,6 +339,7 @@ export function createVueAdapter(runtime: VueRuntime) {
             pendingCommit = false;
             await runtime.nextTick();
             viewReady = true;
+            focusTargetRetryCount = 0;
             rootRef.value?.removeAttribute(PUI_VIEW_PENDING_ATTR);
             eventGateRef.value?.enable();
             notifyFocusTargetReady();
@@ -414,8 +419,11 @@ export function createVueAdapter(runtime: VueRuntime) {
               return () => focusTargetReadyListeners.delete(listener);
             },
             retryTargetReady: () => {
-              if (focusTargetRetryScheduled) return;
+              if (focusTargetRetryScheduled || focusTargetRetryCount >= MAX_FOCUS_TARGET_RETRIES) {
+                return;
+              }
               focusTargetRetryScheduled = true;
+              focusTargetRetryCount += 1;
               scheduleAfterWebLayout(
                 rootRef.value,
                 () => {
@@ -462,6 +470,7 @@ export function createVueAdapter(runtime: VueRuntime) {
         });
         runtime.onDeactivated?.(() => {
           viewReady = false;
+          focusTargetRetryCount = 0;
           rootRef.value?.setAttribute(PUI_VIEW_PENDING_ATTR, '');
           if (owner.hasView) void owner.detachView();
           lastInitRoot = null;
@@ -475,6 +484,7 @@ export function createVueAdapter(runtime: VueRuntime) {
           async (val: boolean) => {
             if (val) {
               viewReady = false;
+              focusTargetRetryCount = 0;
               await runtime.nextTick();
               initSession();
             } else {
@@ -482,6 +492,7 @@ export function createVueAdapter(runtime: VueRuntime) {
               if (owner.hasView) void owner.detachView();
               hostTokens.value = [];
               viewReady = false;
+              focusTargetRetryCount = 0;
               // The host element survives a detach now, so the same element has
               // to be able to initialize a second time. Without this the reopen
               // path skips initSession and binds against a disposed router.

--- a/packages/adapters/vue/src/adapt.ts
+++ b/packages/adapters/vue/src/adapt.ts
@@ -419,8 +419,8 @@ export function createVueAdapter(runtime: VueRuntime) {
               scheduleAfterWebLayout(
                 rootRef.value,
                 () => {
-                  notifyFocusTargetReady();
                   focusTargetRetryScheduled = false;
+                  notifyFocusTargetReady();
                 },
                 schedule
               );

--- a/packages/adapters/vue/test/focus.test.ts
+++ b/packages/adapters/vue/test/focus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { definePrototype } from '@proto.ui/core';
+import { definePrototype, type FocusableHandle } from '@proto.ui/core';
 import { asFocusable, asFocusScope } from '@proto.ui/hooks';
 
 import { asButton } from '../../../prototypes/base/src/button';
@@ -49,6 +49,41 @@ describe('adapter-vue: focus wiring', () => {
     expect(mounted.root?.hasAttribute('tabindex')).toBe(false);
 
     mounted.unmount();
+  });
+
+  it('stops retrying focus when the target never accepts focus', async () => {
+    let focusable!: FocusableHandle;
+    const frames: Array<FrameRequestCallback> = [];
+    const proto = definePrototype({
+      name: 'vue-focus-retry-bound',
+      setup() {
+        focusable = asFocusable();
+        focusable.configure({ disabled: false });
+        return (r) => [r.el('div', 'ok')];
+      },
+    });
+    const mounted = createMountedVueAdapter(proto);
+    await flushVue();
+    const focus = vi.spyOn(mounted.root!, 'focus').mockImplementation(() => {});
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    try {
+      focusable.focus();
+      expect(frames).toHaveLength(1);
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        frames.shift()?.(0);
+        frames.shift()?.(0);
+        await flushVue();
+      }
+      expect(focus).toHaveBeenCalledTimes(4);
+      expect(frames).toHaveLength(0);
+    } finally {
+      raf.mockRestore();
+      focus.mockRestore();
+      mounted.unmount();
+    }
   });
 
   it('clears previous focus facts when another focusable receives host focus', async () => {

--- a/packages/adapters/vue2/src/adapt.ts
+++ b/packages/adapters/vue2/src/adapt.ts
@@ -122,6 +122,7 @@ type Vue2InternalState<Props extends PropsBaseType> = {
   lastInitRoot: HTMLElement | null;
   focusTargetReadyListeners: Set<() => void>;
   focusTargetRetryScheduled: boolean;
+  focusTargetRetryCount: number;
   propWatchDisposer: (() => void) | null;
 };
 
@@ -155,6 +156,8 @@ function shallowEqualHostProps(
     (key) => Object.prototype.hasOwnProperty.call(next, key) && Object.is(prev[key], next[key])
   );
 }
+
+const MAX_FOCUS_TARGET_RETRIES = 3;
 
 export function createVue2Adapter(runtime: Vue2Runtime) {
   const sharedOverlayLayerScheduler = createZIndexOverlayLayerScheduler();
@@ -231,6 +234,7 @@ export function createVue2Adapter(runtime: Vue2Runtime) {
         lastInitRoot: null,
         focusTargetReadyListeners: new Set(),
         focusTargetRetryScheduled: false,
+        focusTargetRetryCount: 0,
         propWatchDisposer: null,
       } as Vue2InternalState<Props>;
       state.scopedExposesReader = createScopedExposesReader(() => state.invoke);
@@ -640,8 +644,14 @@ function initSession<Props extends PropsBaseType>(
       return () => state.focusTargetReadyListeners.delete(listener);
     },
     retryTargetReady: () => {
-      if (state.focusTargetRetryScheduled) return;
+      if (
+        state.focusTargetRetryScheduled ||
+        state.focusTargetRetryCount >= MAX_FOCUS_TARGET_RETRIES
+      ) {
+        return;
+      }
       state.focusTargetRetryScheduled = true;
+      state.focusTargetRetryCount += 1;
       scheduleAfterWebLayout(
         getRootElement(vm),
         () => {
@@ -734,8 +744,8 @@ function finishPendingCommit(vm: any) {
   const state = getState(vm);
   if (!state.pendingCommit) return;
   state.pendingCommit = false;
-  setViewReady(vm, true);
-  getRootElement(vm)?.removeAttribute(PUI_VIEW_PENDING_ATTR);
+  state.viewReady = true;
+  state.focusTargetRetryCount = 0;
   state.eventGate?.enable();
   notifyFocusTargetReady(vm);
   state.pendingSignal?.done?.();
@@ -747,11 +757,13 @@ function notifyFocusTargetReady(vm: any) {
   const target = getRootElement(vm);
   if (!state.viewReady || !target?.isConnected) return;
   for (const listener of Array.from(state.focusTargetReadyListeners)) listener();
+  if (target.ownerDocument.activeElement === target) state.focusTargetRetryCount = 0;
 }
 
 function setViewReady(vm: any, value: boolean) {
   const state = getState(vm);
   state.viewReady = value;
+  state.focusTargetRetryCount = 0;
   setVmField(vm, '__puiViewReady', value);
   forceUpdate(vm);
 }

--- a/packages/adapters/vue2/src/adapt.ts
+++ b/packages/adapters/vue2/src/adapt.ts
@@ -645,8 +645,8 @@ function initSession<Props extends PropsBaseType>(
       scheduleAfterWebLayout(
         getRootElement(vm),
         () => {
-          notifyFocusTargetReady(vm);
           state.focusTargetRetryScheduled = false;
+          notifyFocusTargetReady(vm);
         },
         targetOptions.schedule
       );

--- a/packages/adapters/vue2/test/focus.test.ts
+++ b/packages/adapters/vue2/test/focus.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import { definePrototype } from '@proto.ui/core';
-import { asFocusScope } from '@proto.ui/hooks';
+import { describe, expect, it, vi } from 'vitest';
+import { definePrototype, type FocusableHandle } from '@proto.ui/core';
+import { asFocusable, asFocusScope } from '@proto.ui/hooks';
 
 import { asButton } from '../../../prototypes/base/src/button';
 import { createMountedVue2Adapter, flushVue2 } from './utils/vue2';
@@ -29,6 +29,42 @@ describe('adapter-vue2: focus wiring', () => {
     expect(exposes.focused.get()).toBe(false);
 
     mounted.unmount();
+  });
+
+  it('stops retrying focus when the target never accepts focus', async () => {
+    let focusable!: FocusableHandle;
+    const frames: Array<FrameRequestCallback> = [];
+    const proto = definePrototype({
+      name: 'vue2-focus-retry-bound',
+      setup() {
+        focusable = asFocusable();
+        focusable.configure({ disabled: false });
+        return (r) => [r.el('div', 'ok')];
+      },
+    });
+    const mounted = createMountedVue2Adapter(proto);
+    await flushVue2();
+    const focus = vi.spyOn(mounted.root!, 'focus').mockImplementation(() => {});
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+
+    try {
+      focusable.focus();
+      expect(frames).toHaveLength(1);
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        frames.shift()?.(0);
+        frames.shift()?.(0);
+        await Promise.resolve();
+      }
+      expect(focus).toHaveBeenCalledTimes(4);
+      expect(frames).toHaveLength(0);
+    } finally {
+      raf.mockRestore();
+      focus.mockRestore();
+      mounted.unmount();
+    }
   });
 
   it('removes tabIndex from a non-native focus-scope-only host', async () => {

--- a/packages/adapters/web-component/src/adapt.ts
+++ b/packages/adapters/web-component/src/adapt.ts
@@ -419,8 +419,8 @@ export function AdaptToWebComponent<TProto extends Prototype<any, any>>(
               scheduleAfterWebLayout(
                 this,
                 () => {
-                  this[NOTIFY_FOCUS_TARGET_READY]();
                   this._focusTargetRetryScheduled = false;
+                  this[NOTIFY_FOCUS_TARGET_READY]();
                 },
                 schedule
               );

--- a/packages/adapters/web-component/src/adapt.ts
+++ b/packages/adapters/web-component/src/adapt.ts
@@ -121,6 +121,8 @@ export function AdaptToWebComponent<TProto extends Prototype<any, any>>(
   const getMeta = opt.getMeta ?? createDefaultMetaGetter();
   const exposeStateWebMode = opt.exposeStateWebMode;
   const scrollProjection = opt.scrollProjection;
+  const MAX_FOCUS_TARGET_RETRIES = 3;
+
   const hasCustomOverlayLayerConfig =
     !!opt.overlayLayer &&
     (typeof opt.overlayLayer.baseZIndex !== 'undefined' ||
@@ -146,6 +148,7 @@ export function AdaptToWebComponent<TProto extends Prototype<any, any>>(
     private _controller: RuntimeController | null = null;
     private _focusTargetReadyListeners = new Set<() => void>();
     private _focusTargetRetryScheduled = false;
+    private _focusTargetRetryCount = 0;
 
     private _root: Element | ShadowRoot;
     private _slotProjector: SlotProjector | null = null;
@@ -191,7 +194,7 @@ export function AdaptToWebComponent<TProto extends Prototype<any, any>>(
     }
 
     connectedCallback() {
-      this._disconnectVersion += 1;
+      this._focusTargetRetryCount = 0;
 
       if (this._mountedOnce) {
         // Refresh the logical parent link after a synchronous DOM move.
@@ -414,8 +417,14 @@ export function AdaptToWebComponent<TProto extends Prototype<any, any>>(
               return () => this._focusTargetReadyListeners.delete(listener);
             },
             retryTargetReady: () => {
-              if (this._focusTargetRetryScheduled) return;
+              if (
+                this._focusTargetRetryScheduled ||
+                this._focusTargetRetryCount >= MAX_FOCUS_TARGET_RETRIES
+              ) {
+                return;
+              }
               this._focusTargetRetryScheduled = true;
+              this._focusTargetRetryCount += 1;
               scheduleAfterWebLayout(
                 this,
                 () => {
@@ -519,6 +528,14 @@ export function AdaptToWebComponent<TProto extends Prototype<any, any>>(
 
     private [NOTIFY_FOCUS_TARGET_READY](): void {
       for (const listener of Array.from(this._focusTargetReadyListeners)) listener();
+      const active = this.ownerDocument.activeElement;
+      if (
+        active === this ||
+        this.contains(active) ||
+        (this.shadowRoot?.activeElement ?? null) !== null
+      ) {
+        this._focusTargetRetryCount = 0;
+      }
     }
 
     disconnectedCallback() {

--- a/packages/adapters/web-component/test/focus.test.ts
+++ b/packages/adapters/web-component/test/focus.test.ts
@@ -1,9 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { definePrototype } from '@proto.ui/core';
+import { describe, expect, it, vi } from 'vitest';
+import { definePrototype, type FocusableHandle } from '@proto.ui/core';
 import { asFocusable, asFocusEntry, asFocusScope } from '@proto.ui/hooks';
 import { AdaptToWebComponent } from '@proto.ui/adapter-web-component';
 import { asButton } from '../../../prototypes/base/src/button';
-
 describe('adapter-web-component focus wiring', () => {
   it('makes asButton host focusable and syncs focus/blur to exposes', () => {
     const P = definePrototype({
@@ -29,6 +28,45 @@ describe('adapter-web-component focus wiring', () => {
 
     el.blur();
     expect(exposes.focused.get()).toBe(false);
+  });
+
+  it('stops retrying focus when the target never accepts focus', async () => {
+    let focusable!: FocusableHandle;
+    const frames: Array<FrameRequestCallback> = [];
+    const P = definePrototype({
+      name: 'x-focus-retry-bound',
+      setup() {
+        focusable = asFocusable();
+        focusable.configure({ disabled: false });
+        return (r) => [r.el('div', 'ok')];
+      },
+    });
+
+    AdaptToWebComponent(P as any);
+    const el = document.createElement('x-focus-retry-bound') as any;
+    document.body.appendChild(el);
+    await Promise.resolve();
+    const focus = vi.spyOn(el, 'focus').mockImplementation(() => {});
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+
+    try {
+      focusable.focus();
+      expect(frames).toHaveLength(1);
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        frames.shift()?.(0);
+        frames.shift()?.(0);
+        await Promise.resolve();
+      }
+      expect(focus).toHaveBeenCalledTimes(4);
+      expect(frames).toHaveLength(0);
+    } finally {
+      raf.mockRestore();
+      focus.mockRestore();
+      el.remove();
+    }
   });
 
   it('does not make focus-scope-only host focusable', () => {

--- a/scripts/release/test/demo-matrix-policy.test.mjs
+++ b/scripts/release/test/demo-matrix-policy.test.mjs
@@ -27,5 +27,5 @@ test('Demo Matrix renders every adapter side by side for each demo', async () =>
   assert.match(source, /initialRuntime=\{runtime\}/);
   assert.match(source, /runtimes=\{\[runtime\]\}/);
   assert.match(source, /toolbar=\{false\}/);
-  assert.match(source, /grid-template-columns: repeat\(3, minmax\(15rem, 1fr\)\)/);
+  assert.match(source, /grid-template-columns: repeat\(auto-fit, minmax\(15rem, 1fr\)\)/);
 });

--- a/scripts/release/test/demo-matrix-policy.test.mjs
+++ b/scripts/release/test/demo-matrix-policy.test.mjs
@@ -11,6 +11,10 @@ const matrixPages = [
   new URL('apps/www/src/content/docs/en/internal/demo-matrix.mdx', repositoryRoot),
   new URL('apps/www/src/content/docs/zh-cn/internal/demo-matrix.mdx', repositoryRoot),
 ];
+const matrixBrowserTest = new URL(
+  'apps/www/src/content/docs/zh-cn/demo-matrix.browser.test.ts',
+  repositoryRoot
+);
 
 test('Demo Matrix remains development-only documentation', async () => {
   for (const page of matrixPages) {
@@ -27,5 +31,14 @@ test('Demo Matrix renders every adapter side by side for each demo', async () =>
   assert.match(source, /initialRuntime=\{runtime\}/);
   assert.match(source, /runtimes=\{\[runtime\]\}/);
   assert.match(source, /toolbar=\{false\}/);
-  assert.match(source, /grid-template-columns: repeat\(auto-fit, minmax\(15rem, 1fr\)\)/);
+});
+
+test('Demo Matrix layout and accessibility claims have browser-level coverage', async () => {
+  const source = await readFile(matrixBrowserTest, 'utf8');
+
+  assert.match(source, /width: 1440/);
+  assert.match(source, /for \(const width of \[320, 390\]\)/);
+  assert.match(source, /getBoundingClientRect\(\)/);
+  assert.match(source, /unnamed visible interactive control/);
+  assert.match(source, /accessible controls differ across runtimes/);
 });

--- a/scripts/test/run-runtime-tests.mjs
+++ b/scripts/test/run-runtime-tests.mjs
@@ -21,6 +21,7 @@ const READY_ROUTES = [
   '/en/ui-libraries/base/textarea/',
   '/en/ui-libraries/brutalist/components/switch/',
   '/en/ui-libraries/brutalist/components/tabs/',
+  '/en/ui-libraries/brutalist/components/select/',
   '/en/ui-libraries/shadcn/checkbox/',
   '/en/ui-libraries/shadcn/dropdown-menu/',
   '/en/ui-libraries/shadcn/switch/',

--- a/scripts/test/run-runtime-tests.mjs
+++ b/scripts/test/run-runtime-tests.mjs
@@ -25,6 +25,8 @@ const READY_ROUTES = [
   '/en/ui-libraries/shadcn/dropdown-menu/',
   '/en/ui-libraries/shadcn/switch/',
   '/en/ui-libraries/shadcn/textarea/',
+  '/zh-cn/',
+  '/zh-cn/internal/demo-matrix/',
 ];
 const READY_TIMEOUT_MS = 180_000;
 
@@ -90,6 +92,7 @@ async function startServer() {
     {
       cwd: root,
       detached: process.platform !== 'win32',
+      shell: process.platform === 'win32',
       env: process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
     }
@@ -107,7 +110,20 @@ async function startServer() {
 async function stopServer() {
   if (shuttingDown || !devServer || devServer.exitCode !== null || !devServer.pid) return;
   shuttingDown = true;
-  const target = process.platform === 'win32' ? devServer.pid : -devServer.pid;
+  const pid = devServer.pid;
+  if (process.platform === 'win32') {
+    await new Promise((resolve) => {
+      const killer = spawn('taskkill', ['/PID', String(pid), '/T', '/F'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+      killer.once('error', resolve);
+      killer.once('exit', resolve);
+    });
+    return;
+  }
+
+  const target = -pid;
   try {
     process.kill(target, 'SIGTERM');
   } catch {
@@ -140,6 +156,7 @@ async function runVitest(args, baseUrl) {
     const child = spawn(vitestBin, ['run', ...args], {
       cwd: root,
       env,
+      shell: process.platform === 'win32',
       stdio: 'inherit',
     });
     child.on('error', reject);

--- a/scripts/test/runtime-test-plan.mjs
+++ b/scripts/test/runtime-test-plan.mjs
@@ -4,6 +4,9 @@ export const BROWSER_SUITES = Object.freeze([
   'apps/www/src/content/docs/zh-cn/demo-composed-style-isolation.browser.test.ts',
   'apps/www/src/content/docs/zh-cn/demo-ring-offset-default.browser.test.ts',
   'apps/www/src/content/docs/zh-cn/demo-shadcn-controls.browser.test.ts',
+  'apps/www/src/content/docs/zh-cn/demo-select-first-paint.browser.test.ts',
+  'apps/www/src/content/docs/zh-cn/home-demo-runtime.browser.test.ts',
+  'apps/www/src/content/docs/zh-cn/demo-matrix.browser.test.ts',
 ]);
 
 export function createRuntimeTestPlan(rawArgs) {
@@ -19,8 +22,8 @@ export function createRuntimeTestPlan(rawArgs) {
       needsServer: true,
       // One dev server compiles for every suite, so running the files in
       // parallel makes them queue behind each other and blow their own
-      // readiness timeouts. Measured on five suites: 75s sequential against
-      // 102s parallel, with the parallel run intermittently timing out.
+      // readiness timeouts. Keep the browser matrix sequential so every
+      // route receives a complete, reproducible evidence pass.
       args: ['--no-file-parallelism', ...BROWSER_SUITES],
     },
   ];


### PR DESCRIPTION
## Summary

- keep the site chrome on the Proto UI Shadcn Button and Select projections, with one bridge-owned state path
- make global and local Runtime demobox selectors agree across Web Components, React, Vue, and Vue 2
- make async remounts deterministic: preserve selected values, close portaled Select content, restore focus, and ignore stale completions
- prevent duplicate projected/native activations in theme, code-panel, install-card, and code-example controls
- harden the Demo Matrix with stable accessible names/roles, responsive adapter columns, and corrected public demo labels/imports

Fixes #566
Relates to #568

## Verification

- `corepack pnpm@10.32.1 exec vitest run apps/www/src/components/site-shadcn-controls.test.ts apps/www/src/components/PrototypePreviewer/code-panel-client.test.ts apps/www/src/components/PrototypePreviewer/previewer-client.test.ts apps/www/src/components/override/AdapterSelect.test.ts apps/www/src/components/adapter-preference.test.ts` (26 passed)
- focused Runtime/dogfood browser suites: 5/5
- focused Vitest regressions: 17/17
- `corepack pnpm@10.32.1 --filter apps-www check` (178 files, 0 errors/warnings/hints)
- `corepack pnpm@10.32.1 -s check:agent-doc`
- `corepack pnpm@10.32.1 -s check:agent-operations` (56/56)
- Demo Matrix policy tests (3/3)
- browser dogfood at 1440px, 390px, and 320px covers four runtimes, mount counts, no overflow, stable roles/names, and homepage focus/restore journeys

The repository-wide `check:types` baseline still reports the pre-existing missing `vue` declaration in `packages/adapters/vue2/test/utils/vue2.ts`; the Website Astro check is clean. DCO remediation is included in the latest commit.