### PR TITLE
fix(www): remove the React remount transition from Runtime Box

### DIFF
--- a/apps/www/src/components/PrototypePreviewer/HomeDemoPreviewer.astro
+++ b/apps/www/src/components/PrototypePreviewer/HomeDemoPreviewer.astro
@@ -12,11 +12,17 @@ type RuntimeOption = {
   label: string;
 };
 
+type BrowserRunnerResearchOption = {
+  id: 'flutter-wasm' | 'qt-wasm' | 'gpui-wasm';
+  label: string;
+};
+
 interface Props {
   demos: DemoOption[];
   initialDemoId?: string;
   initialRuntime?: RuntimeId;
   runtimes?: RuntimeOption[];
+  browserRunnerResearch?: BrowserRunnerResearchOption[];
   id?: string;
   class?: string;
   pickerLabel?: string;
@@ -30,11 +36,25 @@ const copy =
         eyebrow: 'Homepage Preview',
         title: 'Try switching runtimes to see whether the component stays consistent.',
         lead: 'Behavior stays consistent, while implementation stays replaceable.',
+        canvas: 'Browser preview',
+        loading: 'Preparing',
+        ready: 'Ready',
+        error: 'Error',
+        researchTitle: 'Browser WASM lane',
+        researchLead:
+          'Reserved for presenting Proto UI through future Flutter, Qt, and GPUI runners. Research only; no Adapter or conformance claim.',
       }
     : {
         eyebrow: '首页预览',
         title: '尝试切换 runtime，观察组件是否保持一致',
         lead: '行为表现保持一致，实现方式允许替换',
+        canvas: '浏览器预览',
+        loading: '准备中',
+        ready: '就绪',
+        error: '错误',
+        researchTitle: '浏览器 WASM 通道',
+        researchLead:
+          '为未来通过 Flutter、Qt 与 GPUI runner 在浏览器中展示 Proto UI 预留。仅表示研究方向，不代表 Adapter 或一致性支持。',
       };
 
 const {
@@ -47,6 +67,11 @@ const {
     { id: 'vue', label: 'Vue' },
     { id: 'vue2', label: 'Vue 2' },
   ],
+  browserRunnerResearch = [
+    { id: 'flutter-wasm', label: 'Flutter' },
+    { id: 'qt-wasm', label: 'Qt' },
+    { id: 'gpui-wasm', label: 'GPUI' },
+  ],
   id = 'home-demo-previewer',
   class: className = '',
   pickerLabel = 'Component',
@@ -58,6 +83,12 @@ if (!Array.isArray(demos) || demos.length === 0) {
 }
 
 const initialDemo = demos.find((demo) => demo.id === initialDemoId) ?? demos[0];
+const researchOptions = browserRunnerResearch.map((option) => ({
+  ...option,
+  status: 'research' as const,
+}));
+const initialRuntimeLabel =
+  runtimes.find((runtime) => runtime.id === initialRuntime)?.label ?? initialRuntime;
 const instanceToken = Math.random().toString(36).slice(2);
 const pickerLabelId = `${id}-picker-label-${instanceToken}`;
 const runtimeLabelId = `${id}-runtime-label-${instanceToken}`;
@@ -68,8 +99,14 @@ const runtimeLabelId = `${id}-runtime-label-${instanceToken}`;
   class:list={['home-demo-previewer', className]}
   data-home-demo-options={JSON.stringify(demos)}
   data-runtime-options={JSON.stringify(runtimes)}
+  data-browser-runner-research={JSON.stringify(researchOptions)}
   data-initial-demo-id={initialDemo.id}
   data-initial-runtime={initialRuntime}
+  data-runner-state="loading"
+  data-runner-runtime={initialRuntime}
+  data-status-loading={copy.loading}
+  data-status-ready={copy.ready}
+  data-status-error={copy.error}
 >
   <div class="home-demo-previewer__panel">
     <div class="home-demo-previewer__header">
@@ -124,8 +161,28 @@ const runtimeLabelId = `${id}-runtime-label-${instanceToken}`;
       </div>
     </div>
 
-    <div class="home-demo-previewer__stage">
-      <div class="home-demo-previewer__host" data-home-demo-host></div>
+    <div class="home-demo-previewer__stage" data-home-demo-runner>
+      <div class="home-demo-previewer__stage-header">
+        <span class="home-demo-previewer__stage-label">{copy.canvas}</span>
+        <output class="home-demo-previewer__status" data-home-demo-status aria-live="polite">
+          {initialRuntimeLabel} · {copy.loading}
+        </output>
+      </div>
+      <div class="home-demo-previewer__host" data-home-demo-host aria-busy="true"></div>
+    </div>
+
+    <div class="home-demo-previewer__research">
+      <div class="home-demo-previewer__research-copy">
+        <p class="home-demo-previewer__research-title">{copy.researchTitle}</p>
+        <p class="home-demo-previewer__research-lead">{copy.researchLead}</p>
+      </div>
+      <ul class="home-demo-previewer__research-targets" aria-label={copy.researchTitle}>
+        {
+          researchOptions.map((option) => (
+            <li data-browser-runner-research-id={option.id}>{option.label}</li>
+          ))
+        }
+      </ul>
     </div>
   </div>
 
@@ -163,15 +220,12 @@ const runtimeLabelId = `${id}-runtime-label-${instanceToken}`;
   }
 
   .home-demo-previewer__panel {
-    border: 1px solid color-mix(in oklch, var(--color-border) 86%, transparent);
-    border-radius: 1.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-xl, 0.875rem);
     overflow: hidden;
-    background: var(--color-background);
-    box-shadow: 0 16px 48px color-mix(in oklch, black 10%, transparent);
-  }
-
-  :global([data-theme='dark']) .home-demo-previewer__panel {
-    box-shadow: 0 20px 56px color-mix(in oklch, black 22%, transparent);
+    background: var(--color-card);
+    color: var(--color-card-foreground);
+    box-shadow: 0 1px 2px color-mix(in oklch, black 8%, transparent);
   }
 
   .home-demo-previewer__header {
@@ -179,7 +233,8 @@ const runtimeLabelId = `${id}-runtime-label-${instanceToken}`;
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 1rem;
     align-items: start;
-    padding: 1.25rem 1.25rem 0;
+    padding: 1.25rem;
+    border-bottom: 1px solid var(--color-border);
   }
 
   .home-demo-previewer__intro {
@@ -192,10 +247,9 @@ const runtimeLabelId = `${id}-runtime-label-${instanceToken}`;
 
   .home-demo-previewer__intro-eyebrow {
     margin: 0;
-    font-size: 0.74rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: color-mix(in oklch, var(--color-foreground) 68%, var(--color-accent) 32%);
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--color-muted-foreground);
   }
 
   .home-demo-previewer__intro-title {
@@ -210,22 +264,22 @@ const runtimeLabelId = `${id}-runtime-label-${instanceToken}`;
 
   .home-demo-previewer__toolbar {
     display: grid;
-    grid-template-columns: minmax(0, 10rem) minmax(0, 11.5rem);
-    gap: 0.65rem;
+    grid-template-columns: minmax(0, 10rem) minmax(0, 11rem);
+    gap: 0.75rem;
     align-self: start;
   }
 
   .home-demo-previewer__control {
     display: flex;
     flex-direction: column;
-    gap: 0.3rem;
+    gap: 0.375rem;
   }
 
   .home-demo-previewer__label {
-    font-size: 0.7rem;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: color-mix(in oklch, var(--color-foreground) 52%, var(--color-muted-foreground) 48%);
+    font-size: 0.8125rem;
+    line-height: 1.25rem;
+    font-weight: 500;
+    color: var(--color-foreground);
   }
 
   .home-demo-previewer__select-wrap {
@@ -239,27 +293,10 @@ const runtimeLabelId = `${id}-runtime-label-${instanceToken}`;
 
   .home-demo-previewer__select {
     width: 100%;
-    min-height: 2.65rem;
-    border: 1px solid var(--color-border);
-    border-radius: 0.8rem;
-    background: color-mix(in oklch, var(--color-background) 94%, var(--color-muted) 6%);
-    color: var(--color-foreground);
-    font-size: 0.88rem;
-    padding: 0.7rem 0.85rem;
-    outline: none;
-    transition:
-      border-color 160ms ease,
-      background 160ms ease,
-      box-shadow 160ms ease;
   }
 
-  .home-demo-previewer__select:hover {
-    background: color-mix(in oklch, var(--color-background) 86%, var(--color-muted) 14%);
-  }
-
-  .home-demo-previewer__select:focus-visible {
-    border-color: var(--color-ring);
-    box-shadow: 0 0 0 3px color-mix(in oklch, var(--color-ring) 18%, transparent);
+  .home-demo-previewer__select[data-pressed]:not([data-disabled]) {
+    transform: translateY(1px);
   }
 
   .home-demo-previewer__description {
@@ -275,7 +312,47 @@ const runtimeLabelId = `${id}-runtime-label-${instanceToken}`;
 
   .home-demo-previewer__stage {
     position: relative;
-    padding: 1.25rem;
+    background: color-mix(in oklch, var(--color-muted) 24%, var(--color-card) 76%);
+  }
+
+  .home-demo-previewer__stage-header {
+    min-height: 2.75rem;
+    padding: 0.625rem 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-card);
+  }
+
+  .home-demo-previewer__stage-label,
+  .home-demo-previewer__status {
+    font-size: 0.75rem;
+    line-height: 1rem;
+    color: var(--color-muted-foreground);
+  }
+
+  .home-demo-previewer__status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+  }
+
+  .home-demo-previewer__status::before {
+    content: '';
+    width: 0.4rem;
+    height: 0.4rem;
+    border-radius: 50%;
+    background: var(--color-muted-foreground);
+  }
+
+  .home-demo-previewer[data-runner-state='ready'] .home-demo-previewer__status::before {
+    background: var(--color-primary);
+  }
+
+  .home-demo-previewer[data-runner-state='error'] .home-demo-previewer__status::before {
+    background: var(--color-destructive);
   }
 
   .home-demo-previewer__host {
@@ -284,25 +361,63 @@ const runtimeLabelId = `${id}-runtime-label-${instanceToken}`;
     align-items: center;
     justify-content: center;
     width: 100%;
-    border-radius: 1.15rem;
-    border: 1px solid color-mix(in oklch, var(--color-border) 88%, transparent);
-    background: var(--color-background);
-    box-shadow:
-      inset 0 1px 0 color-mix(in oklch, white 18%, transparent),
-      0 1px 0 color-mix(in oklch, var(--color-border) 24%, transparent);
-    padding: 1.5rem;
-  }
-
-  :global([data-theme='dark']) .home-demo-previewer__host {
-    background: var(--color-background);
-    box-shadow:
-      inset 0 1px 0 color-mix(in oklch, white 6%, transparent),
-      0 1px 0 color-mix(in oklch, black 14%, transparent);
+    padding: 2rem 1.5rem;
   }
 
   .home-demo-previewer__host > :global(*) {
     max-width: 100%;
     margin-inline: auto;
+  }
+
+  .home-demo-previewer__research {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.875rem 1.25rem;
+    border-top: 1px solid var(--color-border);
+    background: var(--color-card);
+  }
+
+  .home-demo-previewer__research-copy {
+    min-width: 0;
+  }
+
+  .home-demo-previewer__research-title,
+  .home-demo-previewer__research-lead {
+    margin: 0;
+  }
+
+  .home-demo-previewer__research-title {
+    font-size: 0.8125rem;
+    line-height: 1.25rem;
+    font-weight: 500;
+    color: var(--color-foreground);
+  }
+
+  .home-demo-previewer__research-lead {
+    margin-top: 0.125rem;
+    font-size: 0.75rem;
+    line-height: 1.125rem;
+    color: var(--color-muted-foreground);
+  }
+
+  .home-demo-previewer__research-targets {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    color: var(--color-muted-foreground);
+    font-size: 0.75rem;
+    white-space: nowrap;
+  }
+
+  .home-demo-previewer__research-targets li + li::before {
+    content: '/';
+    margin-inline: 0.5rem;
+    color: color-mix(in oklch, var(--color-muted-foreground) 48%, transparent);
   }
 
   @media (max-width: 720px) {
@@ -317,12 +432,29 @@ const runtimeLabelId = `${id}-runtime-label-${instanceToken}`;
     }
 
     .home-demo-previewer__toolbar {
-      grid-template-columns: 1fr;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
     .home-demo-previewer__host {
       min-height: 16rem;
       padding: 1rem;
+    }
+
+    .home-demo-previewer__research {
+      grid-template-columns: 1fr;
+      gap: 0.5rem;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .home-demo-previewer__toolbar {
+      grid-template-columns: 1fr;
+    }
+
+    .home-demo-previewer__stage-header {
+      align-items: flex-start;
+      flex-direction: column;
+      gap: 0.25rem;
     }
   }
 </style>

--- a/apps/www/src/components/PrototypePreviewer/demo-renderer.ts
+++ b/apps/www/src/components/PrototypePreviewer/demo-renderer.ts
@@ -10,6 +10,7 @@ import { loadVue2, toVue2ComponentData, toVue2Runtime } from './runtimes/vue2-ru
 import { claimHostMount, type HostMountLease } from './runtimes/host-mount';
 import type { DemoChild, DemoRenderOptions, DemoRenderResult, DemoRuntimeApi } from './demo-types';
 import { ensurePreviewWcRegistered } from './wc-registry';
+import type { RuntimeId } from './runtimes/registry';
 
 type PropsBaseType = Record<string, unknown>;
 
@@ -18,6 +19,33 @@ const vueComponentCache = new WeakMap<object, Map<string, any>>();
 const wcSurfaceProps = new WeakMap<HTMLElement, Record<string, unknown>>();
 
 const EMPTY_DEMO_RENDER: DemoRenderResult = { destroy: () => {} };
+
+function unsupportedRuntime(runtime: never): Error {
+  return new Error(`[PrototypePreviewer] unsupported runtime: ${String(runtime)}`);
+}
+
+/**
+ * Resolve a framework's browser dependency before replacing the currently
+ * mounted demo. The renderer still owns the host lease and performs its own
+ * load so direct callers remain safe; browser module imports are cached.
+ */
+export async function prepareDemoRuntime(runtime: RuntimeId): Promise<void> {
+  switch (runtime) {
+    case 'wc':
+      return;
+    case 'react':
+      await loadReact();
+      return;
+    case 'vue':
+      await loadVue();
+      return;
+    case 'vue2':
+      await loadVue2();
+      return;
+    default:
+      throw unsupportedRuntime(runtime);
+  }
+}
 
 function ownsLease(opt: DemoRenderOptions, lease: HostMountLease): boolean {
   return lease.isCurrent() && opt.isCurrent?.() !== false;
@@ -583,8 +611,17 @@ function nextVue2(Vue: { nextTick: (fn?: () => void) => Promise<void> | void }) 
 export async function renderDemo(opt: DemoRenderOptions): Promise<DemoRenderResult> {
   if (opt.isCurrent?.() === false) return EMPTY_DEMO_RENDER;
   const lease = claimHostMount(opt.host);
-  if (opt.runtime === 'react') return renderDemoReact(opt, lease);
-  if (opt.runtime === 'vue') return renderDemoVue(opt, lease);
-  if (opt.runtime === 'vue2') return renderDemoVue2(opt, lease);
-  return renderDemoWc(opt, lease);
+  switch (opt.runtime) {
+    case 'wc':
+      return renderDemoWc(opt, lease);
+    case 'react':
+      return renderDemoReact(opt, lease);
+    case 'vue':
+      return renderDemoVue(opt, lease);
+    case 'vue2':
+      return renderDemoVue2(opt, lease);
+    default:
+      lease.release();
+      throw unsupportedRuntime(opt.runtime);
+  }
 }

--- a/apps/www/src/components/PrototypePreviewer/home-demo-client.test.ts
+++ b/apps/www/src/components/PrototypePreviewer/home-demo-client.test.ts
@@ -4,6 +4,7 @@ const demoLoader = vi.hoisted(() => ({
   loadDemo: vi.fn(),
   collectPrototypeIds: vi.fn(),
   loadPrototypes: vi.fn(),
+  prepareDemoRuntime: vi.fn(),
   renderDemo: vi.fn(),
 }));
 
@@ -17,6 +18,7 @@ vi.mock('./prototype-modules', () => ({
   loadPrototypes: demoLoader.loadPrototypes,
 }));
 vi.mock('./demo-renderer', () => ({
+  prepareDemoRuntime: demoLoader.prepareDemoRuntime,
   renderDemo: demoLoader.renderDemo,
 }));
 vi.mock('../adapter-preference', () => ({
@@ -48,6 +50,9 @@ function createHomeRoot(): HTMLElement {
   ]);
   root.dataset.initialDemoId = 'demo-one';
   root.dataset.initialRuntime = 'wc';
+  root.dataset.statusLoading = 'Preparing';
+  root.dataset.statusReady = 'Ready';
+  root.dataset.statusError = 'Error';
   root.innerHTML = `
     <div data-home-demo-picker>
       <wc-shadcn-select-trigger></wc-shadcn-select-trigger>
@@ -57,6 +62,7 @@ function createHomeRoot(): HTMLElement {
       <wc-shadcn-select-trigger></wc-shadcn-select-trigger>
       <wc-shadcn-select-content></wc-shadcn-select-content>
     </div>
+    <output data-home-demo-status></output>
     <div data-home-demo-host></div>
   `;
   document.body.append(root);
@@ -70,6 +76,7 @@ describe('Home demo runtime selector', () => {
     demoLoader.loadDemo.mockReset().mockResolvedValue({ root: {} });
     demoLoader.collectPrototypeIds.mockReset();
     demoLoader.loadPrototypes.mockReset().mockResolvedValue(undefined);
+    demoLoader.prepareDemoRuntime.mockReset().mockResolvedValue(undefined);
     demoLoader.renderDemo.mockReset().mockImplementation(async () => ({ destroy: vi.fn() }));
   });
 
@@ -96,6 +103,176 @@ describe('Home demo runtime selector', () => {
     );
     expect(demoLoader.renderDemo).toHaveBeenCalledTimes(2);
     expect(runtimeSelect.dataset.disabled).toBe('false');
+    expect(root.dataset.runnerState).toBe('ready');
+    expect(root.querySelector('[data-home-demo-status]')?.textContent).toBe('React · Ready');
+  });
+
+  it('keeps the current demo mounted while the next runtime dependencies load', async () => {
+    const firstDestroy = vi.fn();
+    let resolveNextRuntime!: () => void;
+    const nextRuntime = new Promise<void>((resolve) => {
+      resolveNextRuntime = resolve;
+    });
+    demoLoader.prepareDemoRuntime.mockResolvedValueOnce(undefined).mockReturnValueOnce(nextRuntime);
+    demoLoader.renderDemo
+      .mockResolvedValueOnce({ destroy: firstDestroy })
+      .mockResolvedValueOnce({ destroy: vi.fn() });
+
+    const root = createHomeRoot();
+    initHomeDemoPreviewer(root);
+    await vi.waitFor(() => expect(root.dataset.runnerState).toBe('ready'));
+
+    const runtimeSelect = root.querySelector<HTMLElement>('[data-home-demo-runtime]')!;
+    runtimeSelect.dataset.value = 'react';
+    runtimeSelect.dispatchEvent(
+      new CustomEvent('valueChange', { detail: { value: 'react' }, bubbles: true })
+    );
+
+    await vi.waitFor(() => expect(demoLoader.prepareDemoRuntime).toHaveBeenCalledTimes(2));
+    expect(firstDestroy).not.toHaveBeenCalled();
+    expect(root.dataset.runnerState).toBe('loading');
+
+    resolveNextRuntime();
+    await vi.waitFor(() => expect(demoLoader.renderDemo).toHaveBeenCalledTimes(2));
+    expect(firstDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the newest active cleanup when an older teardown completes late', async () => {
+    let resolveFirstDestroy!: () => void;
+    const firstDestroyPending = new Promise<void>((resolve) => {
+      resolveFirstDestroy = resolve;
+    });
+    let firstDestroyCalls = 0;
+    const firstDestroy = vi.fn(() => {
+      firstDestroyCalls += 1;
+      return firstDestroyCalls === 1 ? firstDestroyPending : Promise.resolve();
+    });
+    const newestDestroy = vi.fn();
+    demoLoader.renderDemo
+      .mockResolvedValueOnce({ destroy: firstDestroy })
+      .mockResolvedValueOnce({ destroy: newestDestroy });
+
+    const root = createHomeRoot();
+    initHomeDemoPreviewer(root);
+    await vi.waitFor(() => expect(root.dataset.runnerState).toBe('ready'));
+
+    const runtimeSelect = root.querySelector<HTMLElement>('[data-home-demo-runtime]')!;
+    runtimeSelect.dataset.value = 'react';
+    runtimeSelect.dispatchEvent(
+      new CustomEvent('valueChange', { detail: { value: 'react' }, bubbles: true })
+    );
+    await vi.waitFor(() => expect(firstDestroy).toHaveBeenCalledTimes(1));
+
+    document.dispatchEvent(
+      new CustomEvent('proto-adapter:change', {
+        detail: { adapter: 'wc', source: document.body },
+      })
+    );
+    await vi.waitFor(() => {
+      expect(root.dataset.runnerRuntime).toBe('wc');
+      expect(root.dataset.runnerState).toBe('ready');
+    });
+    expect(firstDestroy).toHaveBeenCalledTimes(1);
+
+    resolveFirstDestroy();
+    await firstDestroyPending;
+    await Promise.resolve();
+    expect(demoLoader.renderDemo).toHaveBeenCalledTimes(2);
+
+    document.dispatchEvent(
+      new CustomEvent('proto-adapter:change', {
+        detail: { adapter: 'react', source: document.body },
+      })
+    );
+    await vi.waitFor(() => expect(newestDestroy).toHaveBeenCalledTimes(1));
+  });
+
+  it('destroys a render result that becomes stale before registration', async () => {
+    let resolveStaleRender!: (result: { destroy(): void }) => void;
+    const staleRender = new Promise<{ destroy(): void }>((resolve) => {
+      resolveStaleRender = resolve;
+    });
+    const firstDestroy = vi.fn();
+    const staleDestroy = vi.fn();
+    const newestDestroy = vi.fn();
+    demoLoader.renderDemo
+      .mockResolvedValueOnce({ destroy: firstDestroy })
+      .mockReturnValueOnce(staleRender)
+      .mockResolvedValueOnce({ destroy: newestDestroy });
+
+    const root = createHomeRoot();
+    initHomeDemoPreviewer(root);
+    await vi.waitFor(() => expect(root.dataset.runnerState).toBe('ready'));
+
+    const runtimeSelect = root.querySelector<HTMLElement>('[data-home-demo-runtime]')!;
+    runtimeSelect.dataset.value = 'react';
+    runtimeSelect.dispatchEvent(
+      new CustomEvent('valueChange', { detail: { value: 'react' }, bubbles: true })
+    );
+    await vi.waitFor(() => expect(demoLoader.renderDemo).toHaveBeenCalledTimes(2));
+
+    document.dispatchEvent(
+      new CustomEvent('proto-adapter:change', {
+        detail: { adapter: 'wc', source: document.body },
+      })
+    );
+    await vi.waitFor(() => {
+      expect(demoLoader.renderDemo).toHaveBeenCalledTimes(3);
+      expect(root.dataset.runnerRuntime).toBe('wc');
+      expect(root.dataset.runnerState).toBe('ready');
+    });
+
+    resolveStaleRender({ destroy: staleDestroy });
+    await staleRender;
+    await Promise.resolve();
+    expect(staleDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a runner preload error without leaving a stale runtime visible', async () => {
+    const firstDestroy = vi.fn();
+    demoLoader.prepareDemoRuntime
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('React loader failed'));
+    demoLoader.renderDemo.mockResolvedValueOnce({ destroy: firstDestroy });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const root = createHomeRoot();
+    initHomeDemoPreviewer(root);
+    await vi.waitFor(() => expect(root.dataset.runnerState).toBe('ready'));
+
+    const runtimeSelect = root.querySelector<HTMLElement>('[data-home-demo-runtime]')!;
+    runtimeSelect.dataset.value = 'react';
+    runtimeSelect.dispatchEvent(
+      new CustomEvent('valueChange', { detail: { value: 'react' }, bubbles: true })
+    );
+
+    await vi.waitFor(() => expect(root.dataset.runnerState).toBe('error'));
+    expect(firstDestroy).toHaveBeenCalledTimes(1);
+    expect(demoLoader.renderDemo).toHaveBeenCalledTimes(1);
+    expect(root.querySelector('[data-home-demo-host]')?.textContent).toContain('[Home Demo Error]');
+    expect(root.querySelector('[data-home-demo-host]')?.getAttribute('aria-busy')).toBe('false');
+    expect(root.querySelector('[data-home-demo-status]')?.textContent).toBe('React · Error');
+    consoleError.mockRestore();
+  });
+
+  it('rejects future browser runner research ids at the executable runtime boundary', async () => {
+    const root = createHomeRoot();
+    const adapterChange = vi.fn();
+    document.addEventListener('proto-adapter:change', adapterChange);
+    initHomeDemoPreviewer(root);
+    await vi.waitFor(() => expect(demoLoader.renderDemo).toHaveBeenCalledTimes(1));
+
+    const runtimeSelect = root.querySelector<HTMLElement>('[data-home-demo-runtime]')!;
+    runtimeSelect.dispatchEvent(
+      new CustomEvent('valueChange', { detail: { value: 'gpui-wasm' }, bubbles: true })
+    );
+    await Promise.resolve();
+
+    expect(demoLoader.renderDemo).toHaveBeenCalledTimes(1);
+    expect(adapterChange).not.toHaveBeenCalled();
+    expect(runtimeSelect.dataset.value).toBe('wc');
+    expect(localStorage.getItem('preferred-prototypes-adapter')).toBeNull();
+    document.removeEventListener('proto-adapter:change', adapterChange);
   });
 
   it('does not remount when the active demo or runtime is reselected', async () => {

--- a/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
+++ b/apps/www/src/components/PrototypePreviewer/home-demo-client.ts
@@ -1,8 +1,8 @@
 import { loadDemo } from './demo-modules';
-import { renderDemo } from './demo-renderer';
+import { prepareDemoRuntime, renderDemo } from './demo-renderer';
 import { collectPrototypeIds } from './demo-types';
 import { loadPrototypes } from './prototype-modules';
-import type { RuntimeId } from './runtimes/registry';
+import { isRuntimeId, type RuntimeId } from './runtimes/registry';
 import { PREFERRED_ADAPTER_EVENT, PREFERRED_ADAPTER_KEY } from '../adapter-preference';
 import {
   initSiteShadcnControls,
@@ -22,6 +22,8 @@ type RuntimeOption = {
   id: RuntimeId;
   label: string;
 };
+
+type RunnerState = 'loading' | 'ready' | 'error';
 
 type ActiveRender = {
   runtime: RuntimeId;
@@ -45,11 +47,33 @@ const DEFAULT_RUNTIME_OPTIONS: RuntimeOption[] = [
 function readPreferredRuntime(runtimeOptions: RuntimeOption[]): RuntimeId | null {
   try {
     const stored = localStorage.getItem(PREFERRED_ADAPTER_KEY);
-    return runtimeOptions.some((option) => option.id === stored) ? (stored as RuntimeId) : null;
+    return isRuntimeId(stored) && runtimeOptions.some((option) => option.id === stored)
+      ? stored
+      : null;
   } catch {
     return null;
   }
 }
+
+function readRuntimeOptions(raw: string | undefined): RuntimeOption[] {
+  if (!raw) return DEFAULT_RUNTIME_OPTIONS;
+  const parsed = JSON.parse(raw) as unknown;
+  if (
+    !Array.isArray(parsed) ||
+    parsed.length === 0 ||
+    parsed.some(
+      (option) =>
+        !option ||
+        typeof option !== 'object' ||
+        !isRuntimeId((option as RuntimeOption).id) ||
+        typeof (option as RuntimeOption).label !== 'string'
+    )
+  ) {
+    throw new Error('[HomeDemoPreviewer] runtime options contain an unsupported runtime.');
+  }
+  return parsed as RuntimeOption[];
+}
+
 function populateSelect(
   select: SiteSelectRoot,
   options: Array<{ id: string; label: string }>,
@@ -74,6 +98,7 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
   root.dataset.inited = '1';
 
   const host = root.querySelector<HTMLElement>('[data-home-demo-host]');
+  const status = root.querySelector<HTMLElement>('[data-home-demo-status]');
   const runtimeSelect = root.querySelector<SiteSelectRoot>('[data-home-demo-runtime]');
   const demoSelect = root.querySelector<SiteSelectRoot>('[data-home-demo-picker]');
 
@@ -86,14 +111,13 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
   const demoSelectEl = demoSelect;
 
   const demoOptions = JSON.parse(root.dataset.homeDemoOptions || '[]') as DemoOption[];
-  const runtimeOptions = root.dataset.runtimeOptions
-    ? (JSON.parse(root.dataset.runtimeOptions) as RuntimeOption[])
-    : DEFAULT_RUNTIME_OPTIONS;
+  const runtimeOptions = readRuntimeOptions(root.dataset.runtimeOptions);
 
   const initialDemoId = root.dataset.initialDemoId || demoOptions[0]?.id || '';
-  const configuredRuntime = (root.dataset.initialRuntime ||
-    runtimeOptions[0]?.id ||
-    'wc') as RuntimeId;
+  const configuredRuntimeValue = root.dataset.initialRuntime || runtimeOptions[0]?.id || 'wc';
+  const configuredRuntime = isRuntimeId(configuredRuntimeValue)
+    ? configuredRuntimeValue
+    : runtimeOptions[0].id;
   const initialRuntime =
     readPreferredRuntime(runtimeOptions) ??
     (runtimeOptions.some((option) => option.id === configuredRuntime)
@@ -113,8 +137,31 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
   let version = 0;
   let destroyed = false;
 
+  const takeActive = () => {
+    const current = active;
+    active = null;
+    return current;
+  };
+
   let lastRuntimeValue = selectValue(runtimeSelectEl);
   let lastDemoValue = selectValue(demoSelectEl);
+
+  const runtimeLabel = (runtime: RuntimeId) =>
+    runtimeOptions.find((option) => option.id === runtime)?.label ?? runtime;
+  const setRunnerState = (state: RunnerState, runtime: RuntimeId) => {
+    root.dataset.runnerState = state;
+    root.dataset.runnerRuntime = runtime;
+    hostEl.setAttribute('aria-busy', String(state === 'loading'));
+    if (!status) return;
+    const stateLabel = root.dataset[`status${state[0].toUpperCase()}${state.slice(1)}`];
+    status.textContent = `${runtimeLabel(runtime)} · ${stateLabel ?? state}`;
+  };
+  const waitForMountPaint = () =>
+    new Promise<void>((resolve) => {
+      const view = hostEl.ownerDocument.defaultView;
+      if (view?.requestAnimationFrame) view.requestAnimationFrame(() => resolve());
+      else queueMicrotask(resolve);
+    });
 
   async function renderCurrent(
     runtime: RuntimeId,
@@ -125,17 +172,19 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
     const currentVersion = ++version;
     setSiteSelectDisabled(runtimeSelectEl, true);
     setSiteSelectDisabled(demoSelectEl, true);
+    setRunnerState('loading', runtime);
 
     try {
-      if (active) {
-        await active.destroy();
-        active = null;
-      }
-
       const demo = await loadDemo(demoId);
       const ids = new Set<string>();
       collectPrototypeIds(demo.root, ids);
       await loadPrototypes(Array.from(ids));
+      await prepareDemoRuntime(runtime);
+
+      if (destroyed || currentVersion !== version) return;
+
+      const previous = takeActive();
+      if (previous) await previous.destroy();
 
       if (destroyed || currentVersion !== version) return;
 
@@ -146,10 +195,18 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
         isCurrent: () => !destroyed && currentVersion === version,
       });
 
-      if (destroyed || currentVersion !== version) return;
+      if (destroyed || currentVersion !== version) {
+        await destroy();
+        return;
+      }
 
       active = { runtime, demoId, destroy };
+      await waitForMountPaint();
+      if (!destroyed && currentVersion === version) setRunnerState('ready', runtime);
     } catch (error) {
+      if (destroyed || currentVersion !== version) return;
+      const failedActive = takeActive();
+      if (failedActive) await failedActive.destroy();
       if (destroyed || currentVersion !== version) return;
       hostEl.innerHTML = '';
       const pre = document.createElement('pre');
@@ -159,6 +216,7 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
       pre.style.whiteSpace = 'pre-wrap';
       pre.style.color = 'crimson';
       hostEl.appendChild(pre);
+      setRunnerState('error', runtime);
       console.error(error);
     } finally {
       if (!destroyed && currentVersion === version) {
@@ -203,11 +261,13 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
     const value = typeof detail?.value === 'string' ? detail.value : selectValue(changed);
     const previousValue = changed === runtimeSelectEl ? lastRuntimeValue : lastDemoValue;
     if (previousValue === value) return;
+    const nextRuntime = changed === runtimeSelectEl ? value : selectValue(runtimeSelectEl);
+    if (!isRuntimeId(nextRuntime)) return;
     if (changed === runtimeSelectEl) lastRuntimeValue = value;
     else lastDemoValue = value;
     setSelectValue(changed, value);
     renderCurrent(
-      (changed === runtimeSelectEl ? value : selectValue(runtimeSelectEl)) as RuntimeId,
+      nextRuntime,
       changed === demoSelectEl ? value : selectValue(demoSelectEl),
       focusTarget
     );
@@ -218,7 +278,7 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
   const onRuntimeChange = (event: Event) => {
     const detail = (event as CustomEvent<{ value?: unknown }>).detail;
     const value = typeof detail?.value === 'string' ? detail.value : selectValue(runtimeSelectEl);
-    if (!runtimeOptions.some((option) => option.id === value)) return;
+    if (!isRuntimeId(value) || !runtimeOptions.some((option) => option.id === value)) return;
     const focusTarget = runtimeSelectEl.querySelector<HTMLElement>('wc-shadcn-select-trigger');
     if (lastRuntimeValue === value) return;
     try {
@@ -236,17 +296,12 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
   const onAdapterChange = (event: Event) => {
     const detail = (event as CustomEvent<AdapterPreferenceDetail>).detail;
     const adapter = detail?.adapter;
-    if (typeof adapter !== 'string' || !runtimeOptions.some((option) => option.id === adapter))
-      return;
+    if (!isRuntimeId(adapter) || !runtimeOptions.some((option) => option.id === adapter)) return;
     if (detail?.source === runtimeSelectEl) return;
     if (lastRuntimeValue === adapter) return;
     lastRuntimeValue = adapter;
     setSelectValue(runtimeSelectEl, adapter);
-    void renderCurrent(
-      adapter as RuntimeId,
-      selectValue(demoSelectEl),
-      detail?.focusTarget ?? null
-    );
+    void renderCurrent(adapter, selectValue(demoSelectEl), detail?.focusTarget ?? null);
   };
   demoSelectEl.addEventListener('valueChange', onDemoChange);
   runtimeSelectEl.addEventListener('valueChange', onRuntimeChange);
@@ -258,8 +313,8 @@ export function initHomeDemoPreviewer(root: HTMLElement) {
     if (!document.body.contains(root)) {
       destroyed = true;
       version += 1;
-      Promise.resolve(active?.destroy?.()).finally(() => {
-        active = null;
+      const detachedActive = takeActive();
+      Promise.resolve(detachedActive?.destroy?.()).finally(() => {
         demoSelectEl.removeEventListener('valueChange', onDemoChange);
         runtimeSelectEl.removeEventListener('valueChange', onRuntimeChange);
         runtimeSelectEl.ownerDocument.removeEventListener(PREFERRED_ADAPTER_EVENT, onAdapterChange);

--- a/apps/www/src/components/PrototypePreviewer/runtimes/registry.test.ts
+++ b/apps/www/src/components/PrototypePreviewer/runtimes/registry.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
-import { AdapterIds, InternalAdapterIds, selectRuntimeIds } from './registry';
+import { AdapterIds, InternalAdapterIds, isRuntimeId, selectRuntimeIds } from './registry';
 
 describe('runtime registry', () => {
   it('presents Vue 2 as an official public adapter', () => {
     expect(AdapterIds).toEqual(['wc', 'react', 'vue', 'vue2']);
     expect(InternalAdapterIds).toEqual(['wc', 'react', 'vue', 'vue2']);
+  });
+
+  it('rejects research runner ids at the executable runtime boundary', () => {
+    expect(isRuntimeId('react')).toBe(true);
+    expect(isRuntimeId('gpui-wasm')).toBe(false);
+    expect(isRuntimeId(undefined)).toBe(false);
   });
 
   it('uses defaults only for omitted runtime input and fails closed for explicit unsupported input', () => {

--- a/apps/www/src/components/PrototypePreviewer/runtimes/registry.ts
+++ b/apps/www/src/components/PrototypePreviewer/runtimes/registry.ts
@@ -7,6 +7,10 @@ export type PublicRuntimeId = (typeof AdapterIds)[number];
 /** Kept as a compatibility alias for internal validation surfaces. */
 export const InternalAdapterIds = [...AdapterIds] as const satisfies readonly RuntimeId[];
 
+export function isRuntimeId(value: unknown): value is RuntimeId {
+  return typeof value === 'string' && (AdapterIds as readonly string[]).includes(value);
+}
+
 export function selectRuntimeIds(
   requested: readonly RuntimeId[] | undefined,
   permitted: readonly RuntimeId[] = AdapterIds

--- a/apps/www/src/content/docs/zh-cn/home-demo-runtime.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/home-demo-runtime.browser.test.ts
@@ -15,6 +15,8 @@ async function waitForHomeRuntime(page: Page, runtime: string): Promise<void> {
       const host = root?.querySelector<HTMLElement>('[data-home-demo-host]');
       return (
         select?.dataset.value === selectedRuntime &&
+        root?.dataset.runnerState === 'ready' &&
+        host?.getAttribute('aria-busy') === 'false' &&
         (host?.querySelector('[data-pui-root]') != null ||
           host?.textContent?.includes('[Home Demo Error]') === true)
       );
@@ -89,6 +91,245 @@ describe.sequential('Homepage Runtime demobox browser smoke', () => {
       expect(await home.locator('[data-home-demo-runtime]').getAttribute('data-value')).toBe('vue');
     } finally {
       await context.close();
+    }
+  }, 180_000);
+
+  it('reveals React only after complete dark-mode style projection', async () => {
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 900 },
+      colorScheme: 'dark',
+    });
+    const page = await context.newPage();
+    await page.goto(`${baseUrl}${HOME_ROUTE}`, { waitUntil: 'networkidle' });
+    const home = page.locator(HOME_SELECTOR);
+
+    try {
+      await waitForHomeRuntime(page, 'wc');
+      await page.evaluate((homeSelector) => {
+        const root = document.querySelector<HTMLElement>(homeSelector);
+        const host = root?.querySelector<HTMLElement>('[data-home-demo-host]');
+        if (!host) throw new Error('Homepage demo host is required.');
+        const samples: Array<{
+          revealing: boolean;
+          style: string;
+          transitionDuration: string;
+          visibilityTransitions: string[];
+          visibility: string;
+        }> = [];
+        const guardReleaseSamples: Array<{
+          visibility: string;
+          visibilityTransitions: string[];
+        }> = [];
+        (window as typeof window & { __homeMountSamples?: typeof samples }).__homeMountSamples =
+          samples;
+        (
+          window as typeof window & {
+            __homeRevealGuardReleaseSamples?: typeof guardReleaseSamples;
+          }
+        ).__homeRevealGuardReleaseSamples = guardReleaseSamples;
+        const removeAttribute = Element.prototype.removeAttribute;
+        Element.prototype.removeAttribute = function (name) {
+          const samplesReveal =
+            name === 'data-pui-view-pending' &&
+            this instanceof HTMLElement &&
+            this.hasAttribute(name) &&
+            this.hasAttribute('data-pui-root') &&
+            host.contains(this);
+          const samplesGuardRelease =
+            name === 'data-pui-view-revealing' &&
+            this instanceof HTMLElement &&
+            this.hasAttribute(name) &&
+            this.hasAttribute('data-home-react-reveal-sample') &&
+            !this.hasAttribute('data-pui-view-pending') &&
+            host.contains(this);
+          const result = removeAttribute.call(this, name);
+          if (samplesReveal) {
+            this.setAttribute('data-home-react-reveal-sample', '');
+            const style = getComputedStyle(this);
+            samples.push({
+              revealing: this.hasAttribute('data-pui-view-revealing'),
+              style: this.getAttribute('data-pui-style') ?? '',
+              transitionDuration: style.transitionDuration,
+              visibilityTransitions: this.getAnimations()
+                .filter((animation) => 'transitionProperty' in animation)
+                .map((animation) => (animation as CSSTransition).transitionProperty),
+              visibility: style.visibility,
+            });
+          }
+          if (samplesGuardRelease) {
+            guardReleaseSamples.push({
+              visibility: getComputedStyle(this).visibility,
+              visibilityTransitions: this.getAnimations()
+                .filter((animation) => 'transitionProperty' in animation)
+                .map((animation) => (animation as CSSTransition).transitionProperty),
+            });
+          }
+          return result;
+        };
+      }, HOME_SELECTOR);
+
+      await chooseRuntime(page, home, 'react');
+      const samples = await page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              __homeMountSamples?: Array<{
+                revealing: boolean;
+                style: string;
+                transitionDuration: string;
+                visibilityTransitions: string[];
+                visibility: string;
+              }>;
+            }
+          ).__homeMountSamples ?? []
+      );
+      expect(samples).toHaveLength(6);
+      for (const sample of samples) {
+        expect(sample.revealing).toBe(true);
+        expect(sample.visibility).toBe('visible');
+        expect(sample.transitionDuration).toBe('0s');
+        expect(sample.visibilityTransitions).not.toContain('visibility');
+        const tokens = sample.style.split(/\s+/);
+        expect(tokens).toContain('transition-all');
+        expect(
+          tokens.some((token) =>
+            ['border-transparent', 'border-border', 'border-input'].includes(token)
+          )
+        ).toBe(true);
+        expect(tokens.some((token) => ['h-8', 'size-8'].includes(token))).toBe(true);
+      }
+
+      await page.waitForFunction(
+        (homeSelector) =>
+          !document
+            .querySelector<HTMLElement>(homeSelector)
+            ?.querySelector('[data-pui-view-revealing]'),
+        HOME_SELECTOR,
+        { timeout: 10_000 }
+      );
+      const guardReleaseSamples = await page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              __homeRevealGuardReleaseSamples?: Array<{
+                visibility: string;
+                visibilityTransitions: string[];
+              }>;
+            }
+          ).__homeRevealGuardReleaseSamples ?? []
+      );
+      expect(guardReleaseSamples).toHaveLength(6);
+      for (const sample of guardReleaseSamples) {
+        expect(sample.visibility).toBe('visible');
+        expect(sample.visibilityTransitions).not.toContain('visibility');
+      }
+      const revealedRoots = await home
+        .locator('[data-home-react-reveal-sample]')
+        .evaluateAll((roots) =>
+          roots.map((root) => ({
+            revealing: root.hasAttribute('data-pui-view-revealing'),
+            visibility: getComputedStyle(root).visibility,
+            visibilityTransitions: root
+              .getAnimations()
+              .filter((animation) => 'transitionProperty' in animation)
+              .map((animation) => (animation as CSSTransition).transitionProperty),
+          }))
+        );
+      expect(revealedRoots).toHaveLength(6);
+      for (const root of revealedRoots) {
+        expect(root.revealing).toBe(false);
+        expect(root.visibility).toBe('visible');
+        expect(root.visibilityTransitions).not.toContain('visibility');
+      }
+    } finally {
+      await context.close();
+    }
+  }, 90_000);
+
+  it('uses compact Shadcn geometry, press feedback, and a separate WASM research lane', async () => {
+    for (const colorScheme of ['light', 'dark'] as const) {
+      const context = await browser.newContext({
+        viewport: { width: 1440, height: 900 },
+        colorScheme,
+      });
+      const page = await context.newPage();
+      await page.goto(`${baseUrl}${HOME_ROUTE}`, { waitUntil: 'networkidle' });
+      const home = page.locator(HOME_SELECTOR);
+
+      const readGeometry = () =>
+        home.evaluate((root) => {
+          const panel = root.querySelector<HTMLElement>('.home-demo-previewer__panel');
+          const host = root.querySelector<HTMLElement>('[data-home-demo-host]');
+          const trigger = root.querySelector<HTMLElement>(
+            '[data-home-demo-runtime] wc-shadcn-select-trigger'
+          );
+          if (!panel || !host || !trigger) throw new Error('Runtime Box geometry is incomplete.');
+          const panelStyle = getComputedStyle(panel);
+          const hostStyle = getComputedStyle(host);
+          const triggerStyle = getComputedStyle(trigger);
+          const rect = root.getBoundingClientRect();
+          return {
+            panelRadius: panelStyle.borderRadius,
+            hostRadius: hostStyle.borderRadius,
+            hostBorder: hostStyle.borderWidth,
+            hostShadow: hostStyle.boxShadow,
+            triggerRadius: triggerStyle.borderRadius,
+            triggerHeight: trigger.getBoundingClientRect().height,
+            fitsViewport:
+              rect.left >= 0 && rect.right <= innerWidth && root.scrollWidth <= root.clientWidth,
+          };
+        });
+
+      try {
+        await waitForHomeRuntime(page, 'wc');
+        for (const width of [1440, 390, 320]) {
+          await page.setViewportSize({ width, height: 900 });
+          const geometry = await readGeometry();
+          expect(geometry.panelRadius, `${colorScheme} ${width}px panel`).toBe('14px');
+          expect(geometry.hostRadius, `${colorScheme} ${width}px host radius`).toBe('0px');
+          expect(geometry.hostBorder, `${colorScheme} ${width}px host border`).toBe('0px');
+          expect(geometry.hostShadow, `${colorScheme} ${width}px host shadow`).toBe('none');
+          expect(geometry.triggerRadius, `${colorScheme} ${width}px trigger`).toBe('8px');
+          expect(geometry.triggerHeight, `${colorScheme} ${width}px trigger height`).toBe(36);
+          expect(geometry.fitsViewport, `${colorScheme} ${width}px overflow`).toBe(true);
+        }
+
+        const researchIds = await home
+          .locator('[data-browser-runner-research-id]')
+          .evaluateAll((items) =>
+            items.map((item) => item.getAttribute('data-browser-runner-research-id'))
+          );
+        expect(researchIds).toEqual(['flutter-wasm', 'qt-wasm', 'gpui-wasm']);
+        const executableIds = await home
+          .locator('[data-home-demo-runtime] wc-shadcn-select-item')
+          .evaluateAll((items) => items.map((item) => item.getAttribute('data-value')));
+        expect(executableIds).toEqual([...RUNTIMES]);
+
+        await page.setViewportSize({ width: 1440, height: 900 });
+        for (const selector of ['[data-home-demo-picker]', '[data-home-demo-runtime]']) {
+          const trigger = home.locator(`${selector} wc-shadcn-select-trigger`);
+          const before = await trigger.boundingBox();
+          if (!before) throw new Error(`${selector} trigger must have geometry.`);
+          await page.mouse.move(before.x + before.width / 2, before.y + before.height / 2);
+          await page.mouse.down();
+          await expect
+            .poll(() => trigger.evaluate((element) => element.hasAttribute('data-pressed')))
+            .toBe(true);
+          const pressed = await trigger.boundingBox();
+          expect(pressed?.y).toBeCloseTo(before.y + 1, 1);
+          await page.mouse.up();
+          await expect
+            .poll(() => trigger.evaluate((element) => element.hasAttribute('data-pressed')))
+            .toBe(false);
+          await page.keyboard.press('Escape');
+        }
+
+        expect(await home.locator('[data-home-demo-runtime]').getAttribute('data-value')).toBe(
+          'wc'
+        );
+      } finally {
+        await context.close();
+      }
     }
   }, 180_000);
 });

--- a/internal/records/2026-08-31-runtime-box-react-reveal-and-browser-runner-readiness.zh-CN.md
+++ b/internal/records/2026-08-31-runtime-box-react-reveal-and-browser-runner-readiness.zh-CN.md
@@ -1,0 +1,39 @@
+# Runtime Box、React reveal 与 browser runner readiness
+
+日期：2026-08-31
+
+本文延续 `2026-08-29-shadcn-demobox-dogfood-followup.zh-CN.md`，记录首页 Runtime Box 的一次实现修复与短期展示边界。它不改变 `spec/**` 的规范语义，也不构成 Flutter、Qt 或 GPUI Adapter admission、实现或一致性声明。
+
+## Context
+
+生产首页从其他 Runtime 首次切换到 React 时，新 host root 会在 rule-driven style token 完整提交前解除 `data-pui-view-pending`。组件因此短暂暴露 base-only presentation；已有 transition 会把这次 token 补齐表现为从中心展开，暗色模式下还会闪过非终态边框。
+
+同一页面的 Runtime Box 使用多层大圆角、重复边框与阴影，弱化了控制器和预览 surface 的层级。两个 Select trigger 也缺少按压位移反馈。页面还没有一个诚实表达 future browser-WASM runner 方向、但又与当前可执行 Adapter 列表严格隔离的区域。
+
+## Current implementation direction
+
+- React Adapter 在首次 host commit 后完成 `CommitSignal.done()`，跟踪 EffectsPort 推送的最新 style revision，并保持新 root pending，直到该 revision 已进入后续 React DOM commit。
+- `data-pui-view-pending` 与短暂的 `data-pui-view-revealing` Web guard 同时压制 transition 与 animation；pending 移除后至少经过一个绘制机会才撤掉 revealing guard，且每次 reveal 使用独立 generation，旧 epoch 的延迟回调不能提前撤掉新 guard，避免 `transition-all` 为 visibility reveal 创建新的 CSS transition。
+- 首页 renderer 在卸载当前 demo 前先加载目标 demo、Prototype 与 framework runtime；active cleanup 在任何 `await` 前原子取走，旧 generation 的 teardown 或 render completion 不得覆盖或泄漏较新的 mount。Runtime Box 公开 `loading`、`ready`、`error` 状态，但不把 loader 或 host object 提升为 Proto UI portable contract。
+- Runtime Box 使用单一 Shadcn Card-like outer surface、紧凑 token radius、扁平 preview stage 与 1px Select press feedback，移除 preview host 上重复的大圆角、边框和阴影。
+- Flutter、Qt 与 GPUI 只出现在独立的 `Browser WASM lane` research presentation 中。该列表不可交互，不进入 `RuntimeId`、Adapter preference、`renderDemo()` 或任何 cataloged Adapter profile。
+
+## Boundary and non-goals
+
+当前可执行 Runtime 仍只有 Web Components、React、Vue 3 与 Vue 2。本轮不增加 WIT/schema、WASM loader、Flutter/Qt artifact、Rust host、GPUI fixture、native surface bridge、Adapter identity 或 conformance evidence。
+
+历史 GPUI architecture exploration 仍由 Issue #466 与 draft PR #467 提供上下文；本轮只在二者留下带明确非支持边界的 cross-reference：
+
+- https://github.com/Proto-UI/Proto-UI/issues/466#issuecomment-5467648505
+- https://github.com/Proto-UI/Proto-UI/pull/467#issuecomment-5467649178
+
+真实 GPUI/browser-WASM admission 仍需要基于当前 `main` 的独立架构决策、Host Capability 映射、Adapter profile、fixture 与端到端证据。
+
+## Evidence and follow-up
+
+- `packages/adapters/react/test/view-reveal-style.integration.test.ts` 直接采样 pending attribute 被移除时的完整 style tokens。
+- `apps/www/src/components/PrototypePreviewer/home-demo-client.test.ts` 通过 deferred teardown 与 deferred render result 覆盖 double-destroy、newer-active clobber 和 stale cleanup。
+- `apps/www/src/content/docs/zh-cn/home-demo-runtime.browser.test.ts` 覆盖四个现有 Runtime、暗色 React reveal、Light/Dark 响应式几何、Select press feedback 与 research/executable 分离。
+- Issue #568 继续作为站点控件、Runtime demobox 与 dogfood matrix 的聚合 owner；本次修复由 bounded child Issue #575 跟踪，并通过独立 PR 交付。
+
+后续若加入真实 browser-WASM runner，必须先把 research label 转化为受治理的 architecture slice；不得从本记录或当前页面文案推断支持已经存在。

--- a/packages/adapters/base/src/host/view-visibility.ts
+++ b/packages/adapters/base/src/host/view-visibility.ts
@@ -1,4 +1,5 @@
 export const PUI_VIEW_PENDING_ATTR = 'data-pui-view-pending';
+export const PUI_VIEW_REVEALING_ATTR = 'data-pui-view-revealing';
 export const PUI_VIEW_DETACHED_ATTR = 'data-pui-view-detached';
 
 const VIEW_VISIBILITY_STYLE_ID = 'proto-ui-view-visibility';
@@ -14,6 +15,6 @@ export function installViewVisibilityRule(doc: Document): void {
     (doc.head ?? doc.documentElement).appendChild(styleEl);
   }
 
-  styleEl.textContent = `${styleEl.textContent ?? ''}\n:where([${PUI_VIEW_PENDING_ATTR}]) { visibility: hidden !important; }\n:where([${PUI_VIEW_DETACHED_ATTR}]) { display: none !important; }\n`;
+  styleEl.textContent = `${styleEl.textContent ?? ''}\n:where([${PUI_VIEW_PENDING_ATTR}]) { visibility: hidden !important; }\n:where([${PUI_VIEW_PENDING_ATTR}], [${PUI_VIEW_REVEALING_ATTR}]) { transition: none !important; animation: none !important; }\n:where([${PUI_VIEW_DETACHED_ATTR}]) { display: none !important; }\n`;
   RULES_BY_DOCUMENT.set(doc, true);
 }

--- a/packages/adapters/base/test/view-visibility.test.ts
+++ b/packages/adapters/base/test/view-visibility.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { installViewVisibilityRule, PUI_VIEW_DETACHED_ATTR, PUI_VIEW_PENDING_ATTR } from '../src';
+import {
+  installViewVisibilityRule,
+  PUI_VIEW_DETACHED_ATTR,
+  PUI_VIEW_PENDING_ATTR,
+  PUI_VIEW_REVEALING_ATTR,
+} from '../src';
 
 describe('adapter-base: view visibility', () => {
   afterEach(() => {
@@ -9,14 +14,25 @@ describe('adapter-base: view visibility', () => {
   it('keeps a pending host root hidden until the adapter reveals it', () => {
     const root = document.createElement('div');
     root.setAttribute(PUI_VIEW_PENDING_ATTR, '');
+    root.style.transition = 'all 5s ease';
+    root.style.animation = 'pulse 5s linear';
     document.body.appendChild(root);
 
     installViewVisibilityRule(document);
 
     expect(getComputedStyle(root).visibility).toBe('hidden');
+    expect(getComputedStyle(root).transition).toBe('none');
+    expect(getComputedStyle(root).animation).toBe('none');
 
+    root.setAttribute(PUI_VIEW_REVEALING_ATTR, '');
     root.removeAttribute(PUI_VIEW_PENDING_ATTR);
     expect(getComputedStyle(root).visibility).not.toBe('hidden');
+    expect(getComputedStyle(root).transition).toBe('none');
+    expect(getComputedStyle(root).animation).toBe('none');
+
+    root.removeAttribute(PUI_VIEW_REVEALING_ATTR);
+    expect(getComputedStyle(root).transition).not.toBe('none');
+    expect(getComputedStyle(root).animation).not.toBe('none');
   });
 
   it('takes a detached host root and its subtree out of paint', () => {

--- a/packages/adapters/react/src/adapt.ts
+++ b/packages/adapters/react/src/adapt.ts
@@ -18,6 +18,7 @@ import {
   installViewVisibilityRule,
   PUI_VIEW_DETACHED_ATTR,
   PUI_VIEW_PENDING_ATTR,
+  PUI_VIEW_REVEALING_ATTR,
   type ProtoAdapterProps,
   scheduleAfterWebLayout,
 } from '@proto.ui/adapter-base';
@@ -202,8 +203,17 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
         bindLogicalParent(instanceTokenRef.current, parentToken);
       }
       const [renderChildren, setRenderChildren] = runtime.useState<any>(null);
-      const [hostTokens, setHostTokens] = runtime.useState<string[]>([]);
+      const hostTokenRevisionRef = runtime.useRef(0);
+      const [hostStyle, setHostStyle] = runtime.useState<{ tokens: string[]; revision: number }>({
+        tokens: [],
+        revision: 0,
+      });
+      const setHostTokens = (tokens: string[]) => {
+        const revision = ++hostTokenRevisionRef.current;
+        setHostStyle({ tokens, revision });
+      };
       const [shouldExist, setShouldExist] = runtime.useState(!supportsOwnerContext);
+      const viewEffectsTargetReadyRef = runtime.useRef(false);
       const viewReadyRef = runtime.useRef(false);
       const focusTargetReadyListenersRef = runtime.useRef<Set<() => void>>(new Set());
       const focusTargetRetryScheduledRef = runtime.useRef(false);
@@ -236,6 +246,8 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
       const pendingSignalRef = runtime.useRef<CommitSignal | null>(null);
       const commitVersionRef = runtime.useRef(0);
       const [commitVersion, setCommitVersion] = runtime.useState(0);
+      const pendingRevealStyleRevisionRef = runtime.useRef<number | null>(null);
+      const revealGenerationRef = runtime.useRef(0);
       const hostSessionRef = runtime.useRef<ReturnType<
         typeof createReactHostSession<Props>
       > | null>(null);
@@ -362,9 +374,14 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
         if (!shouldExist) {
           const detachedEl = rootRef.current;
           if (detachedEl) installViewVisibilityRule(detachedEl.ownerDocument);
+          detachedEl?.setAttribute(PUI_VIEW_PENDING_ATTR, '');
+          revealGenerationRef.current += 1;
+          detachedEl?.removeAttribute(PUI_VIEW_REVEALING_ATTR);
           eventGateRef.current?.disable?.();
           if (ownerRef.current?.hasView) void ownerRef.current.detachView();
           setHostTokens([]);
+          pendingRevealStyleRevisionRef.current = null;
+          viewEffectsTargetReadyRef.current = false;
           viewReadyRef.current = false;
           focusTargetRetryCountRef.current = 0;
           return;
@@ -433,7 +450,8 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
           // A child of a detached ancestor still mounts and attaches its own
           // view, so readiness has to consult the subtree, not just this host.
           isViewReady: () =>
-            viewReadyRef.current && !rootRef.current?.closest(`[${PUI_VIEW_DETACHED_ATTR}]`),
+            viewEffectsTargetReadyRef.current &&
+            !rootRef.current?.closest(`[${PUI_VIEW_DETACHED_ATTR}]`),
           getCurrentElement: () => rootRef.current,
           subscribeTargetReady: (listener) => {
             focusTargetReadyListenersRef.current.add(listener);
@@ -482,25 +500,78 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
       runtime.useLayoutEffect(() => {
         ownerDisposalRef.current?.retain();
         return () => {
+          pendingRevealStyleRevisionRef.current = null;
+          viewEffectsTargetReadyRef.current = false;
           viewReadyRef.current = false;
           focusTargetRetryCountRef.current = 0;
-          rootRef.current?.setAttribute(PUI_VIEW_PENDING_ATTR, '');
+          const cleanupRoot = rootRef.current;
+          cleanupRoot?.setAttribute(PUI_VIEW_PENDING_ATTR, '');
+          revealGenerationRef.current += 1;
+          cleanupRoot?.removeAttribute(PUI_VIEW_REVEALING_ATTR);
           void ownerRef.current?.detachView();
           ownerDisposalRef.current?.release();
         };
       }, []);
 
       runtime.useLayoutEffect(() => {
-        if (!pendingCommitRef.current) return;
-        pendingCommitRef.current = false;
+        if (pendingCommitRef.current) {
+          pendingCommitRef.current = false;
+          const wasReady = viewReadyRef.current;
+          const signal = pendingSignalRef.current;
+          pendingSignalRef.current = null;
+          viewEffectsTargetReadyRef.current = true;
+
+          // Runtime finalizes rule-driven view effects from CommitSignal.done().
+          // Keep a newly attached root pending until that flush has reached a
+          // later React DOM commit; otherwise the base style becomes visible
+          // before its variant, size, and state tokens.
+          signal?.done?.();
+
+          if (wasReady) {
+            if (!pendingCommitRef.current) {
+              eventGateRef.current?.enable();
+              notifyFocusTargetReady();
+            }
+            return;
+          }
+
+          pendingRevealStyleRevisionRef.current = hostTokenRevisionRef.current;
+        }
+
+        const requiredStyleRevision = pendingRevealStyleRevisionRef.current;
+        if (requiredStyleRevision === null) return;
+        if (
+          hostStyle.revision < requiredStyleRevision ||
+          hostStyle.revision !== hostTokenRevisionRef.current
+        ) {
+          return;
+        }
+
+        pendingRevealStyleRevisionRef.current = null;
         viewReadyRef.current = true;
         focusTargetRetryCountRef.current = 0;
-        rootRef.current?.removeAttribute(PUI_VIEW_PENDING_ATTR);
+        const revealedRoot = rootRef.current;
+        const revealGeneration = ++revealGenerationRef.current;
+        revealedRoot?.setAttribute(PUI_VIEW_REVEALING_ATTR, '');
+        revealedRoot?.removeAttribute(PUI_VIEW_PENDING_ATTR);
+        if (revealedRoot) {
+          scheduleAfterWebLayout(
+            revealedRoot,
+            () => {
+              if (
+                revealGenerationRef.current === revealGeneration &&
+                rootRef.current === revealedRoot &&
+                !revealedRoot.hasAttribute(PUI_VIEW_PENDING_ATTR)
+              ) {
+                revealedRoot.removeAttribute(PUI_VIEW_REVEALING_ATTR);
+              }
+            },
+            schedule
+          );
+        }
         eventGateRef.current?.enable();
         notifyFocusTargetReady();
-        pendingSignalRef.current?.done?.();
-        pendingSignalRef.current = null;
-      }, [commitVersion]);
+      }, [commitVersion, hostStyle.revision]);
 
       // A renderer can replace the host element after the Proto commit that
       // first announced readiness. Re-advertise the current ref after every
@@ -554,7 +625,7 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
                 'data-pui-root': '',
                 [PUI_VIEW_DETACHED_ATTR]: detached ? '' : undefined,
                 [PUI_VIEW_PENDING_ATTR]: viewReadyRef.current ? undefined : '',
-                'data-pui-style': serializeStyleTokens(hostTokens),
+                'data-pui-style': serializeStyleTokens(hostStyle.tokens),
                 'data-demo-ref': props['data-demo-ref' as keyof typeof props] as string | undefined,
               },
               // Without a view there is no template to place the slot into, so the

--- a/packages/adapters/react/test/view-reveal-style.integration.test.ts
+++ b/packages/adapters/react/test/view-reveal-style.integration.test.ts
@@ -1,0 +1,165 @@
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { definePrototype, tw } from '@proto.ui/core';
+import { PUI_VIEW_PENDING_ATTR, PUI_VIEW_REVEALING_ATTR } from '@proto.ui/adapter-base';
+
+import { createReactAdapter } from '../src';
+import { createMountedReactAdapter } from './utils/fake-react';
+
+const mountedRoots: Array<{ unmount(): void }> = [];
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const root of mountedRoots.splice(0)) {
+    await act(async () => root.unmount());
+  }
+  document.body.replaceChildren();
+});
+
+describe('adapter-react: first-view reveal coherence', () => {
+  it('projects rule-complete style tokens before revealing a newly attached root', async () => {
+    const proto = definePrototype<{ active?: boolean }>({
+      name: 'react-view-reveal-style',
+      setup(def) {
+        def.props.define({
+          active: { type: 'boolean', default: false },
+        });
+        def.feedback.style.use(tw('rounded-lg border transition-all'));
+        def.rule({
+          when: (when) => when.meta('colorScheme').eq('dark'),
+          intent: (intent) => intent.feedback.style.use(tw('bg-input/30')),
+        });
+        def.rule({
+          when: (when) => when.prop('active').eq(true),
+          intent: (intent) =>
+            intent.feedback.style.use(tw('border-transparent bg-primary h-8 px-2.5')),
+        });
+        return (renderer) => renderer.el('span', 'ready');
+      },
+    });
+
+    const revealSamples: Array<{
+      animation: string;
+      revealing: boolean;
+      style: string | null;
+      transition: string;
+      visibility: string;
+    }> = [];
+    const removeAttribute = Element.prototype.removeAttribute;
+    vi.spyOn(Element.prototype, 'removeAttribute').mockImplementation(function (
+      this: Element,
+      name
+    ) {
+      const samplesReveal =
+        name === PUI_VIEW_PENDING_ATTR &&
+        this instanceof HTMLElement &&
+        this.hasAttribute('data-pui-root') &&
+        this.hasAttribute(PUI_VIEW_PENDING_ATTR);
+      const result = removeAttribute.call(this, name);
+      if (samplesReveal) {
+        const computedStyle = getComputedStyle(this);
+        revealSamples.push({
+          animation: computedStyle.animation,
+          revealing: this.hasAttribute(PUI_VIEW_REVEALING_ATTR),
+          style: this.getAttribute('data-pui-style'),
+          transition: computedStyle.transition,
+          visibility: computedStyle.visibility,
+        });
+      }
+      return result;
+    });
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    mountedRoots.push(root);
+    const Component = createReactAdapter(React)(proto, {
+      getMeta: (key) => (key === 'colorScheme' ? 'dark' : undefined),
+    });
+
+    await act(async () => {
+      root.render(React.createElement(Component, { active: true }));
+      await Promise.resolve();
+    });
+
+    expect(revealSamples).toHaveLength(1);
+    expect(revealSamples[0]).toMatchObject({
+      animation: 'none',
+      revealing: true,
+      transition: 'none',
+    });
+    expect(revealSamples[0]?.visibility).not.toBe('hidden');
+    expect(revealSamples[0]?.style?.split(/\s+/)).toEqual([
+      'rounded-lg',
+      'border',
+      'transition-all',
+      'dark:bg-input/30',
+      'border-transparent',
+      'bg-primary',
+      'h-8',
+      'px-2.5',
+    ]);
+    expect(host.querySelector('[data-pui-root]')?.hasAttribute(PUI_VIEW_PENDING_ATTR)).toBe(false);
+  });
+
+  it('does not let an older layout replay clear the current reveal guard', async () => {
+    const originalRaf = globalThis.requestAnimationFrame;
+    const originalCancelRaf = globalThis.cancelAnimationFrame;
+    let frameId = 0;
+    const frames = new Map<number, FrameRequestCallback>();
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      const id = ++frameId;
+      frames.set(id, callback);
+      return id;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number) =>
+      frames.delete(id)) as typeof cancelAnimationFrame;
+    const runNextFrame = () => {
+      const next = frames.entries().next().value as [number, FrameRequestCallback] | undefined;
+      expect(next).toBeDefined();
+      frames.delete(next![0]);
+      next![1](frameId * 16.7);
+    };
+
+    const proto = definePrototype({
+      name: 'react-view-reveal-generation',
+      setup(def) {
+        def.feedback.style.use(tw('transition-all'));
+        return (renderer) => renderer.el('span', 'ready');
+      },
+    });
+    const mounted = createMountedReactAdapter(proto);
+
+    try {
+      const root = mounted.root;
+      expect(root?.hasAttribute(PUI_VIEW_REVEALING_ATTR)).toBe(true);
+      expect(frames.size).toBe(1);
+
+      runNextFrame();
+      mounted.replayLayoutEffects();
+      await Promise.resolve();
+      mounted.update();
+
+      expect(mounted.root).toBe(root);
+      expect(root?.hasAttribute(PUI_VIEW_PENDING_ATTR)).toBe(false);
+      expect(root?.hasAttribute(PUI_VIEW_REVEALING_ATTR)).toBe(true);
+      expect(frames.size).toBe(2);
+
+      runNextFrame();
+      expect(root?.hasAttribute(PUI_VIEW_REVEALING_ATTR)).toBe(true);
+
+      runNextFrame();
+      expect(root?.hasAttribute(PUI_VIEW_REVEALING_ATTR)).toBe(true);
+      runNextFrame();
+      expect(root?.hasAttribute(PUI_VIEW_REVEALING_ATTR)).toBe(false);
+    } finally {
+      mounted.unmount();
+      globalThis.requestAnimationFrame = originalRaf;
+      globalThis.cancelAnimationFrame = originalCancelRaf;
+    }
+  });
+});

--- a/spec/adapters/A-REACT-18-19-0001.yaml
+++ b/spec/adapters/A-REACT-18-19-0001.yaml
@@ -139,6 +139,7 @@ sources:
   - path: packages/adapters/react/test/lifecycle-repeatable-mount.test.ts
   - path: packages/adapters/react/test/lifecycle-strict-replay.test.ts
   - path: packages/adapters/react/test/lifecycle-view-intent.test.ts
+  - path: packages/adapters/react/test/view-reveal-style.integration.test.ts
   - path: packages/adapters/react/test/contract/state-runtime.v0.contract.test.ts
   - path: packages/adapters/base/src/host/exposes.ts
   - path: packages/adapters/react/test/expose.test.ts

--- a/spec/tests/T-LIFECYCLE-0006.yaml
+++ b/spec/tests/T-LIFECYCLE-0006.yaml
@@ -101,6 +101,17 @@ implementations:
       - T-LIFECYCLE-0006-CASE-REPEATABLE-DETACH
       - T-LIFECYCLE-0006-CASE-LATEST-INTENT
       - T-LIFECYCLE-0006-CASE-REVEAL-BARRIER
+  - id: adapter-react-view-reveal-style-coherence
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/react/test/view-reveal-style.integration.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0006-CASE-REVEAL-BARRIER
+    exercises:
+      - A-REACT-18-19-0001
+    notes:
+      - Asserts that a new React host keeps data-pui-view-pending until rule-complete style tokens have reached a later DOM commit.
   - id: adapter-vue-initial-view-intent
     kind: adapter-test
     status: passing
@@ -150,6 +161,9 @@ verifies:
       anchors:
         - A-WEB-COMPONENT-0001-I
 revisions:
+  - version: 0.3.0-alpha.0
+    change: strengthened
+    summary: Added direct React DOM evidence that the reveal barrier includes the rule-complete style projection commit.
   - version: 0.3.0-alpha.0
     change: strengthened
     summary: Added Vue 2 latest-intent and repeatable-detach journey evidence.


### PR DESCRIPTION
## Summary

- Hold newly attached React roots behind a generation-scoped reveal barrier until rule-driven style projection reaches the React DOM commit; suppress transition/animation through the reveal frame so Dark mode cannot flash an outline or animate from partial geometry.
- Make the homepage runner generation-safe across dependency preload, teardown, stale completion, error state, and active cleanup ownership.
- Replace the nested oversized Runtime Box treatment with one compact Shadcn-aligned surface, add 1px `data-pressed` Select feedback, and keep Flutter/Qt/GPUI in a separate non-interactive Browser WASM research lane.

Closes #575.

Parent: #568.

## Related context

- Issue: #575
- Applicable spec entities and lifecycle: active `C-LIFECYCLE-0008-J`, active `A-REACT-18-19-0001-I`, active `T-LIFECYCLE-0006-CASE-REVEAL-BARRIER`, active `D-ADAPTER-PROFILE-0001`
- Criteria / test anchors: `A-REACT-18-19-0001-I`, `T-LIFECYCLE-0006-CASE-REVEAL-BARRIER`, `packages/adapters/react/test/view-reveal-style.integration.test.ts`, `apps/www/src/content/docs/zh-cn/home-demo-runtime.browser.test.ts`
- Related upstream: #466 and historical draft PR #467 contain the evidence-backed GPUI/browser-WASM boundary cross-references; style independence is separately tracked by #573 / #574.

## Scope boundary

- The issue already decided that this is drift repair against the active reveal-coherence guarantee, that executable runtimes remain exactly WC/React/Vue 3/Vue 2, and that future hosts cannot imply Adapter support.
- This pull request chooses a generation-scoped reveal guard, generation-safe runner cleanup, and a compact Shadcn Card-like homepage shell with local press feedback.
- Real Flutter/Qt/GPUI execution, Adapter identities, WASM loaders/protocols, conformance claims, Prototype semantic changes, and the separate style-independence work in #574 remain out of scope.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs.
- [x] Normative behavior changes include coherent P/C/T criteria, revisions, executable evidence, and affected projections.
- [x] This change does not create an empty catalog identity or silently widen a draft/active public guarantee.

## Contribution provenance

Select every applicable item. Original, third-party, AI-assisted, and employer or client considerations may coexist.

- [x] This contribution was created by me and I have the right to submit it.
- [ ] This contribution adapts or derives from third-party material.
- [x] This contribution includes material AI-assisted generation or transformation.
- [ ] This contribution may be subject to employer or client ownership, and I have confirmed that I may submit it.
- [x] No third-party source disclosure is required.

### Third-party or upstream sources

| Source | Version / commit | License | Material used | Required attribution |
| ------ | ---------------- | ------- | ------------- | -------------------- |
| None | — | — | — | — |

### AI assistance

OpenAI Codex assisted with diagnosis, implementation, regression tests, validation, and PR drafting using the repository, the user-provided reproduction, and public GitHub context. An independent Codex review found no blocker at exact head `0efcecbe`; human maintainer review is still required before merge. No private or undisclosed third-party source material was provided.

## DCO

Every human-authored commit in this PR must have a valid DCO sign-off. Prefer a `Signed-off-by` trailer on the commit itself; an unsigned published commit may instead be covered by an individual remediation commit from its original author.

This checkbox is only a reminder; it does not replace commit sign-off.

- [x] I have checked the DCO status of this PR.

## Prototype website preview

- [ ] This pull request adds or changes public Prototype behavior and includes the required reachable website page or page update.
- [x] A new or updated website page is not applicable because: this changes the existing homepage runner and React Adapter reveal lifecycle, not a Prototype identity, anatomy, or semantic contract.

- Public docs route: `/en/` and `/zh-cn/`
- Local preview URL or route: `http://127.0.0.1:<port>/en/` and `/zh-cn/`
- Applicable runtimes reviewed: automated Chromium coverage for Web Component / React / Vue 3 / Vue 2
- [x] The demo consumes the real public package export and prefers the Prototype's own anatomy, triggers, state, events, and defaults.
- [x] The Demo Matrix, when used, is supplementary evidence rather than a replacement for the website page.
- External demo orchestration: none
- Consumer-owned orchestration that is not installed with the package: `apps/www/src/components/PrototypePreviewer/home-demo-client.ts`

## Validation

Environment: Node.js `22.22.1`, pnpm `10.32.1`, Windows, exact head `0efcecbe3bc152fe3bf83984060346a478e1d20c`.

- Focused tests:
  - `corepack pnpm@10.32.1 exec vitest run packages/adapters/base/test packages/adapters/react/test` — 57 files / 176 tests passed.
  - `corepack pnpm@10.32.1 exec vitest run apps/www/src/components/PrototypePreviewer/home-demo-client.test.ts apps/www/src/components/PrototypePreviewer/runtimes/registry.test.ts` — 2 files / 10 tests passed.
  - `corepack pnpm@10.32.1 exec vitest run packages/spec/fixtures/test packages/spec/graph/test` — 19 files / 38 tests passed.
- Catalog / generated checks:
  - `corepack pnpm@10.32.1 check:prototype-catalog` — passed.
  - `corepack pnpm@10.32.1 spec:docs:agent` followed by `corepack pnpm@10.32.1 check:agent-doc` — passed; the generated local projection was removed.
- Types / repository tests:
  - `corepack pnpm@10.32.1 check:types` — passed; Astro checked 178 files with 0 errors, warnings, or hints.
  - `corepack pnpm@10.32.1 install --frozen-lockfile --offline` then `corepack pnpm@10.32.1 build:packages` — passed, 43/43 public packages.
  - `git diff --check origin/main...HEAD` — passed.
- Docs build / preview:
  - `corepack pnpm@10.32.1 --dir apps/www run build` — passed; 228 pages built and sitemap cleanup completed.
- Manual or browser evidence:
  - `node scripts/test/run-runtime-tests.mjs -- apps/www/src/content/docs/zh-cn/home-demo-runtime.browser.test.ts --no-file-parallelism` — Chromium 1 file / 3 tests passed, covering all active runtimes, Dark React reveal coherence, compact responsive geometry, Select press feedback, and research/executable separation.
  - No separate human visual sign-off is claimed.
- Not run or not applicable, with reason:
  - The umbrella `corepack pnpm@10.32.1 test` was not rerun as one aggregate command; the affected Adapter, website runner, spec, catalog, types, package, docs, and Chromium boundaries were run directly.
  - Deployment, publication, release, approval, and merge are out of scope.