### PR TITLE
chore(governance): reconcile npm bootstrap latest retention

### DIFF
--- a/internal/governance/ci-cd.md
+++ b/internal/governance/ci-cd.md
@@ -72,7 +72,7 @@ The workflow does not accept ad hoc `version`, `tag`, or `only` inputs. Version 
 - `publish-all` is allowed only on `main`.
 - `publish-all` requires the `workspace` profile; `launch` is for product-scope audit and rehearsal only.
 - Real publication selects the GitHub `npm` environment and uses npm Trusted Publishing through OIDC. Environment reviewers, branch restrictions, and administrator bypass are external configuration; verify them immediately before a release instead of inferring protection from the workflow file.
-- `stage` and `publish-all` fail before package staging unless every public package identity is already readable from the npm registry. The check cannot inspect private Trusted Publisher settings, which remain a maintainer responsibility.
+- `stage` and `publish-all` fail before package staging unless every public package identity is readable and its bootstrap dist-tags/deprecation state meets the release gate. The check cannot inspect private Trusted Publisher settings, which remain a maintainer responsibility.
 - Concurrency prevents overlapping release runs for the same ref.
 - The workflow creates `v<version>` only after every public package publishes successfully.
 

--- a/internal/governance/ci-cd.zh-CN.md
+++ b/internal/governance/ci-cd.zh-CN.md
@@ -72,7 +72,7 @@ CI 在 pull request、`main` push 和手动触发时运行。除常规类型与�
 - `publish-all` 仅允许在 `main` 上运行。
 - `publish-all` 必须使用 `workspace` profile；`launch` 只用于产品范围审计和彩排。
 - 真实发布会选择 GitHub `npm` environment，并使用 npm Trusted Publishing OIDC。Environment reviewer、分支限制和管理员 bypass 均属于外部配置；发布前必须现场核验，不能仅凭 workflow 文件推断这些保护存在。
-- `stage` 与 `publish-all` 在 package 暂存前检查全部公开 package identity 均已可从 npm registry 读取；该检查无法读取私有的 Trusted Publisher 设置，后者仍由维护者负责核对。
+- `stage` 与 `publish-all` 在 package 暂存前检查全部公开 package identity 均已可从 npm registry 读取，且其 bootstrap dist-tag/deprecation 状态满足发布门禁；该检查无法读取私有的 Trusted Publisher 设置，后者仍由维护者负责核对。
 - 同一 ref 上启用并发互斥，避免重叠发布任务。
 - 全部公开 package 发布成功后才创建 `v<version>` tag。
 

--- a/internal/governance/release-workflow.md
+++ b/internal/governance/release-workflow.md
@@ -64,13 +64,13 @@ Package-local fixes do not use `publish-single`; they enter the next global rele
 
 Each release train owns `internal/releases/<version>/release-notes.md`, its Chinese projection, and a deterministic `package-bom.json`. `pnpm release:bom` regenerates the BOM from the public workspace package graph and launch-governance roles; `pnpm release:assets:check` fails when the reviewed BOM drifts or either release note is absent. The English note becomes the GitHub Release body, while the BOM, Chinese note, spec snapshot, and checksum are attached as release evidence.
 
-npm Trusted Publisher configuration is package-scoped and therefore cannot be attached before a package identity exists. Every newly named public package must be created before the release train with a clearly non-release bootstrap version, configured for the reviewed release workflow, and kept out of `latest` and release-channel dist-tags. `pnpm release:registry:check` proves that every identity is publicly readable; it does not claim to inspect the private Trusted Publisher configuration.
+npm Trusted Publisher configuration is package-scoped and therefore cannot be attached before a package identity exists. Every newly named public package must be created before the release train with a clearly non-release bootstrap version and configured for the reviewed release workflow. Bootstrap must not receive a release-channel dist-tag and its `bootstrap` tag must be removed after identity setup. npm may refuse to remove `latest` when it points at the package's sole bootstrap version; that `latest` may remain only if the sole version is deprecated, `next` does not point to that bootstrap version, and no release-train or stable version is published merely to cover it. `pnpm release:registry:check` verifies these public identity, dist-tag, and deprecation conditions; it does not claim to inspect the private Trusted Publisher configuration.
 
 ## 4. Publication
 
 Real publication is manually triggered from `main` and protected by the GitHub `npm` environment approval.
 
-Both `stage` and `publish-all` run the registry-identity preflight before any package is staged or published. A missing identity aborts the run with the complete missing-package list, preventing an avoidable partial publication.
+Both `stage` and `publish-all` run the public registry preflight before any package is staged or published. A missing identity or non-compliant bootstrap state aborts the run, preventing an avoidable partial publication.
 
 The workflow:
 

--- a/internal/governance/release-workflow.zh-CN.md
+++ b/internal/governance/release-workflow.zh-CN.md
@@ -64,13 +64,13 @@ Prerelease suffix 用来表达稳定化阶段，而不是泛化的内部构建�
 
 每条 release train 在 `internal/releases/<version>/` 下维护 `release-notes.md`、对应中文投射与确定性的 `package-bom.json`。`pnpm release:bom` 根据公开 workspace package 图和 launch governance 角色重新生成 BOM；`pnpm release:assets:check` 会在已评审 BOM 漂移或任一 release note 缺失时失败。英文说明作为 GitHub Release 正文，BOM、中文说明、spec snapshot 与 checksum 作为 release evidence 附件。
 
-npm Trusted Publisher 是 package 级配置，因此 package identity 不存在时无法预先绑定。每个首次出现的公开 package 都必须在 release train 前使用明确不属于正式发行的 bootstrap 版本完成创建，绑定到已评审的发布 workflow，并且不得占据 `latest` 或发行 channel dist-tag。`pnpm release:registry:check` 只证明所有 identity 已可公开读取，不宣称能够检查私有的 Trusted Publisher 配置。
+npm Trusted Publisher 是 package 级配置，因此 package identity 不存在时无法预先绑定。每个首次出现的公开 package 都必须在 release train 前使用明确不属于正式发行的 bootstrap 版本完成创建，并绑定到已评审的发布 workflow。bootstrap 不得占用发行 channel dist-tag，且 identity setup 后必须移除其 `bootstrap` tag。若 npm 拒绝移除指向 package 唯一 bootstrap 版本的 `latest`，则仅当该唯一版本已 deprecated、`next` 不指向该 bootstrap 版本，且没有为了覆盖它而发布 release-train 或 stable 版本时，允许该 `latest` 暂留。`pnpm release:registry:check` 会核验这些公开 identity、dist-tag 与 deprecation 条件；它不宣称能够检查私有的 Trusted Publisher 配置。
 
 ## 4. 发布流程
 
 真实发布只允许从 `main` 手动触发，并由 GitHub `npm` environment 审批保护。
 
-`stage` 与 `publish-all` 都会在任何 package 暂存或发布前运行 registry identity preflight。任一 identity 缺失都会一次性列出全部缺口并中止，避免形成可预防的部分发布。
+`stage` 与 `publish-all` 都会在任何 package 暂存或发布前运行公开 registry preflight。任一 identity 缺失或 bootstrap 状态不合规都会中止，避免形成可预防的部分发布。
 
 发布 workflow：
 

--- a/internal/records/2026-09-01-npm-bootstrap-latest-reconciliation.zh-CN.md
+++ b/internal/records/2026-09-01-npm-bootstrap-latest-reconciliation.zh-CN.md
@@ -1,0 +1,27 @@
+# npm bootstrap `latest` 规则协调
+
+## Context
+
+`0.3.0-alpha.0` 的新公开 package identity 需要先发布一个明确不属于正式 release 的 bootstrap 版本，才能为该 package 绑定 npm Trusted Publisher。`V-PROTO-UI-0009-NEW-PACKAGE` 与 release workflow 投射原先要求 bootstrap 不占用 `latest` 或 `next`。
+
+## Observed facts
+
+- npm 首次发布 scoped bootstrap package 时，即使使用 `--tag bootstrap`，registry 仍会创建 `latest`。
+- 当该 package 只有这一个版本时，移除 `latest` 返回 npm registry `400 Bad Request`。
+- 已验证的 bootstrap package 可以移除 `bootstrap` tag，保留 deprecated 的唯一 bootstrap 版本，并且不占用 `next`。
+- `pnpm release:registry:check` 只证明公开 identity 可读取；Trusted Publisher 仍须以 `npm trust list <package>` 核对，正式 OIDC publication 仍须由受保护 GitHub workflow 实证。
+
+## Decision
+
+将 bootstrap 的禁止条件收窄为：不得占用 `next` 或保留 `bootstrap` tag。若 npm 拒绝删除唯一、明确不属于正式发行且已 deprecated 的 bootstrap 版本上的 `latest`，允许该 `latest` 暂留。
+
+此例外不允许发布虚假的 stable 或 release-train 版本来覆盖 `latest`，不改变 prerelease 发布到 `next` 的规则，也不提前激活 V 实体或绕过受保护的 `release-packages.yml`。
+
+## Rationale
+
+该限制来自 npm registry 对唯一已发布版本的行为，而不是 Proto UI 希望把 bootstrap 暴露为默认安装目标。deprecation、移除 `bootstrap` tag、禁止 `next`，以及正式发布仍需通过受保护 workflow，共同保留了对误安装与越权直接发布的防护。
+
+## Follow-up
+
+- 在每次真实发布后审计该 package 的 dist-tag、integrity、Git tag、GitHub prerelease 与 spec snapshot evidence。
+- 若 npm 后续允许移除唯一 bootstrap 版本的 `latest`，可在保持同一保护边界的前提下清理该 tag，并重新评估此例外是否仍有必要。

--- a/scripts/release/check-registry-readiness.mjs
+++ b/scripts/release/check-registry-readiness.mjs
@@ -6,6 +6,39 @@ import { resolve } from 'node:path';
 import { findProtoPackages } from './version-utils.mjs';
 
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
+const BOOTSTRAP_VERSION = /^0\.0\.0-bootstrap(?:[.-]|$)/;
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function bootstrapReadinessViolation(metadata) {
+  if (!isRecord(metadata) || !isRecord(metadata['dist-tags']) || !isRecord(metadata.versions)) {
+    return 'registry metadata is missing dist-tags or versions';
+  }
+
+  const distTags = metadata['dist-tags'];
+  const versions = metadata.versions;
+  if (typeof distTags.bootstrap === 'string') return 'bootstrap dist-tag must be removed';
+
+  if (typeof distTags.next === 'string' && BOOTSTRAP_VERSION.test(distTags.next)) {
+    return `next must not point to bootstrap version ${distTags.next}`;
+  }
+
+  if (typeof distTags.latest === 'string' && BOOTSTRAP_VERSION.test(distTags.latest)) {
+    const latestMetadata = versions[distTags.latest];
+    const isSoleVersion = Object.keys(versions).length === 1;
+    const isDeprecated =
+      isRecord(latestMetadata) &&
+      typeof latestMetadata.deprecated === 'string' &&
+      latestMetadata.deprecated.trim().length > 0;
+    if (!isSoleVersion || !isDeprecated) {
+      return 'latest may retain bootstrap version only when it is the sole deprecated version';
+    }
+  }
+
+  return null;
+}
 
 export async function checkRegistryReadiness(
   packageNames,
@@ -26,7 +59,21 @@ export async function checkRegistryReadiness(
           headers: { accept: 'application/json' },
           signal: timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined,
         });
-        if (response.status === 200) return { name, state: 'ready' };
+        if (response.status === 200) {
+          let metadata;
+          try {
+            metadata = await response.json();
+          } catch (error) {
+            return {
+              name,
+              state: 'error',
+              detail: `invalid registry metadata: ${error instanceof Error ? error.message : String(error)}`,
+            };
+          }
+          const violation = bootstrapReadinessViolation(metadata);
+          if (violation) return { name, state: 'error', detail: violation };
+          return { name, state: 'ready' };
+        }
         if (response.status === 404) return { name, state: 'missing' };
 
         const detail = (await response.text()).trim().replace(/\s+/g, ' ').slice(0, 240);

--- a/scripts/release/test/check-registry-readiness.test.mjs
+++ b/scripts/release/test/check-registry-readiness.test.mjs
@@ -13,7 +13,7 @@ test('registry readiness reports public package identities and encodes scoped na
     timeoutMs: 1_000,
     fetchImpl: async (url) => {
       requested.push(url.href);
-      return response(200);
+      return response(200, '', publishedReleaseMetadata());
     },
   });
 
@@ -28,13 +28,112 @@ test('registry readiness reports public package identities and encodes scoped na
   ]);
 });
 
+test('registry readiness permits a sole deprecated bootstrap version to retain latest', async () => {
+  const report = await checkRegistryReadiness(['@proto.ui/bootstrap'], {
+    timeoutMs: 1_000,
+    fetchImpl: async () =>
+      response(200, '', {
+        'dist-tags': { latest: '0.0.0-bootstrap.0' },
+        versions: {
+          '0.0.0-bootstrap.0': {
+            deprecated:
+              'Registry identity bootstrap only; use a published Proto UI release version.',
+          },
+        },
+      }),
+  });
+
+  assert.deepEqual(report, {
+    ready: ['@proto.ui/bootstrap'],
+    missing: [],
+    errors: [],
+  });
+});
+
+test('registry readiness rejects forbidden bootstrap registry states', async () => {
+  const cases = [
+    {
+      name: '@proto.ui/bootstrap-tag',
+      metadata: {
+        'dist-tags': { bootstrap: '0.0.0-bootstrap.0' },
+        versions: { '0.0.0-bootstrap.0': { deprecated: 'bootstrap only' } },
+      },
+      detail: 'bootstrap dist-tag must be removed',
+    },
+    {
+      name: '@proto.ui/bootstrap-next',
+      metadata: {
+        'dist-tags': { next: '0.0.0-bootstrap.0' },
+        versions: { '0.0.0-bootstrap.0': { deprecated: 'bootstrap only' } },
+      },
+      detail: 'next must not point to bootstrap version 0.0.0-bootstrap.0',
+    },
+    {
+      name: '@proto.ui/bootstrap-latest-not-deprecated',
+      metadata: {
+        'dist-tags': { latest: '0.0.0-bootstrap.0' },
+        versions: { '0.0.0-bootstrap.0': {} },
+      },
+      detail: 'latest may retain bootstrap version only when it is the sole deprecated version',
+    },
+    {
+      name: '@proto.ui/bootstrap-latest-not-sole',
+      metadata: {
+        'dist-tags': { latest: '0.0.0-bootstrap.0' },
+        versions: {
+          '0.0.0-bootstrap.0': { deprecated: 'bootstrap only' },
+          '0.3.0-alpha.0': {},
+        },
+      },
+      detail: 'latest may retain bootstrap version only when it is the sole deprecated version',
+    },
+  ];
+
+  const report = await checkRegistryReadiness(
+    cases.map(({ name }) => name),
+    {
+      timeoutMs: 1_000,
+      fetchImpl: async (url) => {
+        const current = cases.find(({ name }) => url.href.endsWith(encodeURIComponent(name)));
+        return response(200, '', current.metadata);
+      },
+    }
+  );
+
+  assert.deepEqual(report, {
+    ready: [],
+    missing: [],
+    errors: [...cases]
+      .sort(({ name: left }, { name: right }) => left.localeCompare(right))
+      .map(({ name, detail }) => ({ name, detail })),
+  });
+});
+
+test('registry readiness fails closed when public registry metadata cannot establish tag state', async () => {
+  const report = await checkRegistryReadiness(['@proto.ui/incomplete'], {
+    timeoutMs: 1_000,
+    fetchImpl: async () => response(200, '', {}),
+  });
+
+  assert.deepEqual(report, {
+    ready: [],
+    missing: [],
+    errors: [
+      {
+        name: '@proto.ui/incomplete',
+        detail: 'registry metadata is missing dist-tags or versions',
+      },
+    ],
+  });
+});
+
 test('registry readiness distinguishes missing identities from registry failures', async () => {
   const report = await checkRegistryReadiness(
     ['@proto.ui/ready', '@proto.ui/missing', '@proto.ui/unavailable'],
     {
       timeoutMs: 1_000,
       fetchImpl: async (url) => {
-        if (url.href.endsWith('%2Fready')) return response(200);
+        if (url.href.endsWith('%2Fready')) return response(200, '', publishedReleaseMetadata());
         if (url.href.endsWith('%2Fmissing')) return response(404);
         return response(503, 'Service Unavailable', 'retry later');
       },
@@ -84,6 +183,14 @@ function response(status, statusText = '', body = '') {
   return {
     status,
     statusText,
-    text: async () => body,
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  };
+}
+
+function publishedReleaseMetadata() {
+  return {
+    'dist-tags': { latest: '0.3.0-alpha.0' },
+    versions: { '0.3.0-alpha.0': {} },
   };
 }

--- a/spec/versions/V-PROTO-UI-0009.yaml
+++ b/spec/versions/V-PROTO-UI-0009.yaml
@@ -33,8 +33,8 @@ criteria:
       zh-CN: 本 release train 可以承载经过评审的架构、顶层 API 与新 Prototype 变化，因此必须以 alpha 呈现，不能被描述为 release candidate 或 stable compatibility 承诺。
   - id: V-PROTO-UI-0009-NEW-PACKAGE
     text:
-      en: Publication remains blocked until the new @proto.ui/module-expose-event, @proto.ui/adapter-vue2, and @proto.ui/module-image-view npm identities exist, are configured for the protected release workflow, and pass registry readiness without receiving latest or next during bootstrap.
-      zh-CN: 在新的 @proto.ui/module-expose-event、@proto.ui/adapter-vue2 与 @proto.ui/module-image-view npm identity 已建立、已配置受保护 release workflow，且 bootstrap 未占用 latest 或 next 并通过 registry readiness 前，真实发布保持 blocked。
+      en: Publication remains blocked until the new @proto.ui/module-expose-event, @proto.ui/adapter-vue2, and @proto.ui/module-image-view npm identities exist, are configured for the protected release workflow, and pass registry readiness. Bootstrap must not receive next or retain its bootstrap dist-tag. If npm refuses to remove latest from the sole clearly non-release bootstrap version, latest may remain only when that version is deprecated and no release-train or stable version is published merely to replace it.
+      zh-CN: 在新的 @proto.ui/module-expose-event、@proto.ui/adapter-vue2 与 @proto.ui/module-image-view npm identity 已建立、已配置受保护 release workflow，且通过 registry readiness 前，真实发布保持 blocked。bootstrap 不得占用 next，也不得保留 bootstrap dist-tag；若 npm 拒绝移除唯一明确属于非正式发行的 bootstrap 版本上的 latest，则仅当该版本已 deprecated，且没有仅为替换它而发布 release-train 或 stable 版本时，允许 latest 暂留。
   - id: V-PROTO-UI-0009-PUBLICATION
     text:
       en: The entity may become active only after all packages in its reviewed release BOM exist at 0.3.0-alpha.0, their next tags point to it, the v0.3.0-alpha.0 tag resolves to the publication commit, and immutable snapshot evidence exists.
@@ -46,8 +46,12 @@ sources:
   - path: internal/records/2026-08-16-0.3.0-alpha.0-release-train.zh-CN.md
   - path: internal/records/2026-08-16-expose-event-package-extraction.zh-CN.md
   - path: internal/records/2026-08-16-expose-event-npm-identity-bootstrap.zh-CN.md
+  - path: internal/records/2026-09-01-npm-bootstrap-latest-reconciliation.zh-CN.md
 openQuestions: []
 revisions:
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Reconciled the new-package bootstrap gate with npm retaining latest on a sole deprecated bootstrap version while preserving the next-channel and protected-publication requirements.
   - version: 0.3.0-alpha.0
     change: revised
     summary: Expanded the reviewed draft train to 43 public packages by admitting the public Image View Module and its pending npm identity bootstrap gate.


### PR DESCRIPTION
## Summary

Reconcile the npm bootstrap `latest` exception with `V-PROTO-UI-0009`.

npm may retain `latest` on a package's sole deprecated bootstrap version.
This PR permits that narrow case, while keeping `next` off bootstrap
versions and preserving the protected release workflow.

## Related context

- Applicable spec entities and lifecycle: `V-PROTO-UI-0009` (`draft`)
- Criteria / test anchors: `V-PROTO-UI-0009-NEW-PACKAGE`
- Related upstream: npm returns `400` when removing `latest` from the sole bootstrap version.

## Scope boundary

- In scope: V criterion, bilingual release workflow guidance, reconciliation record.
- Out of scope: version changes, npm publication, tags, GitHub Release, and V activation.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities.
- [x] This change updates the governing V criterion and its projections.
- [x] This change does not widen a public runtime guarantee.

## Contribution provenance

- [ ] This contribution was created by me and I have the right to submit it.
- [x] This contribution includes material AI-assisted generation or transformation.

## DCO

- [ ] I have checked the DCO status of this PR.

## Prototype website preview

- [x] A new or updated website page is not applicable because this is a release-governance-only change.

## Validation

- `git diff --check` — passed
- `corepack pnpm@10.32.1 check:prototype-catalog` — passed
- `corepack pnpm@10.32.1 release:assets:check` — passed
- `corepack pnpm@10.32.1 check:types` — passed