### PR TITLE
feat(base): deliver Input Checkpoint C (#389)

### DIFF
--- a/apps/www/src/content/docs/zh-cn/demo-shadcn-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-shadcn-controls.browser.test.ts
@@ -213,6 +213,18 @@ describe.sequential('shadcn control documentation browser regressions', () => {
       for (const runtime of RUNTIMES) {
         await selectRuntime(page, previewer, runtime, '[data-pui-root]', 3);
         await applyColorScheme(page, 'light');
+        await page.waitForFunction(
+          (root) => !root?.querySelector('[data-pui-view-revealing]'),
+          await previewer.elementHandle(),
+          { timeout: 10_000 }
+        );
+        await page.waitForFunction(
+          () => {
+            const editor = document.querySelector('[data-previewer-id] textarea');
+            return editor && getComputedStyle(editor).transitionProperty !== 'none';
+          },
+          { timeout: 10_000 }
+        );
 
         const resting = await editorStyle(page);
         // The property set is the whole point: `all` would also animate the

--- a/packages/prototypes/base/package.json
+++ b/packages/prototypes/base/package.json
@@ -110,6 +110,11 @@
       "import": "./dist/scroll-area/index.js",
       "default": "./dist/scroll-area/index.js"
     },
+    "./input": {
+      "types": "./dist/input/index.d.ts",
+      "import": "./dist/input/index.js",
+      "default": "./dist/input/index.js"
+    },
     "./textarea": {
       "types": "./dist/textarea/index.d.ts",
       "import": "./dist/textarea/index.js",

--- a/packages/prototypes/base/src/index.ts
+++ b/packages/prototypes/base/src/index.ts
@@ -24,6 +24,8 @@ export * from './separator';
 export { default as separatorRoot } from './separator';
 export * from './scroll-area';
 export { default as scrollAreaRoot } from './scroll-area';
+export * from './input';
+export { default as inputRoot } from './input';
 export * from './textarea';
 export { default as textareaRoot } from './textarea';
 export * from './live-region';

--- a/packages/prototypes/base/src/input/index.ts
+++ b/packages/prototypes/base/src/input/index.ts
@@ -1,0 +1,10 @@
+export { default, default as inputRoot, asInputRoot } from './root.proto';
+export type {
+  InputChangeDetail,
+  InputCompositionDetail,
+  InputRootAsHookContract,
+  InputRootExposes,
+  InputRootProps,
+  InputRootStateHandles,
+  InputValueChangeDetail,
+} from './root.proto';

--- a/packages/prototypes/base/src/input/root.proto.ts
+++ b/packages/prototypes/base/src/input/root.proto.ts
@@ -1,0 +1,197 @@
+import { defineAsHook, definePrototype, type DefHandle, type RunHandle } from '@proto.ui/core';
+import { asFocusable, asTextControl } from '@proto.ui/hooks';
+import { declareTextControl } from '@proto.ui/module-text-control';
+import type {
+  InputChangeDetail,
+  InputCompositionDetail,
+  InputRootAsHookContract,
+  InputRootExposes,
+  InputRootProps,
+  InputValueChangeDetail,
+} from './types';
+
+export type {
+  InputChangeDetail,
+  InputCompositionDetail,
+  InputRootAsHookContract,
+  InputRootExposes,
+  InputRootProps,
+  InputRootStateHandles,
+  InputValueChangeDetail,
+} from './types';
+
+function setupInputRoot(def: DefHandle<InputRootProps, InputRootExposes>) {
+  def.props.define({
+    value: { type: 'string', empty: 'fallback' },
+    defaultValue: { type: 'string', empty: 'fallback' },
+    disabled: { type: 'boolean', empty: 'fallback' },
+    readOnly: { type: 'boolean', empty: 'fallback' },
+    placeholder: { type: 'string', empty: 'fallback' },
+    required: { type: 'boolean', empty: 'fallback' },
+    name: { type: 'string', empty: 'fallback' },
+    autoComplete: { type: 'string', empty: 'fallback' },
+    minLength: { type: 'number', empty: 'fallback' },
+    maxLength: { type: 'number', empty: 'fallback' },
+    inputMode: {
+      type: 'enum',
+      empty: 'fallback',
+      options: ['none', 'text', 'tel', 'url', 'email', 'numeric', 'decimal', 'search'],
+    },
+    enterKeyHint: {
+      type: 'enum',
+      empty: 'fallback',
+      options: ['enter', 'done', 'go', 'next', 'previous', 'search', 'send'],
+    },
+    ariaLabel: { type: 'string', empty: 'fallback' },
+    labelledBy: { type: 'string', empty: 'fallback' },
+    describedBy: { type: 'string', empty: 'fallback' },
+  });
+  def.props.setDefaults({
+    defaultValue: '',
+    disabled: false,
+    readOnly: false,
+    placeholder: '',
+    required: false,
+    name: '',
+    autoComplete: '',
+    minLength: -1,
+    maxLength: -1,
+    inputMode: 'text',
+    enterKeyHint: 'enter',
+    ariaLabel: '',
+    labelledBy: '',
+    describedBy: '',
+  });
+
+  const control = asTextControl<InputRootProps, 'single'>();
+  const focusable = asFocusable<InputRootProps>();
+  focusable.configure({ disabled: false });
+  const value = def.state.string('value', '');
+  const disabled = def.state.bool('disabled', false);
+  const readOnly = def.state.bool('readOnly', false);
+  const composing = def.state.bool('composing', false);
+  const ariaLabel = def.state.string('inputAriaLabel', '');
+  const labelledBy = def.state.string('inputLabelledBy', '');
+  const describedBy = def.state.string('inputDescribedBy', '');
+  const focused = focusable.focused;
+  const focusVisible = focusable.focusVisible;
+
+  def.expose.state('value', value);
+  def.expose.state('disabled', disabled);
+  def.expose.state('readOnly', readOnly);
+  def.expose.state('focused', focused);
+  def.expose.state('focusVisible', focusVisible);
+  def.expose.state('composing', composing);
+  def.expose.method('focusSelf', (options) => {
+    if (!disabled.get()) focusable.focusSelf(options);
+  });
+  def.expose.method('blurSelf', () => focusable.blur());
+  def.expose.event('valueChange', { payload: 'json' });
+  def.expose.event('change', { payload: 'json' });
+  def.expose.event('compositionStart', { payload: 'json' });
+  def.expose.event('compositionUpdate', { payload: 'json' });
+  def.expose.event('compositionEnd', { payload: 'json' });
+
+  def.a11y.role('textbox');
+  def.a11y.name(ariaLabel);
+  def.a11y.state('disabled', disabled);
+  def.a11y.state('readOnly', readOnly);
+  def.a11y.relation('labelledBy', { target: labelledBy });
+  def.a11y.relation('describedBy', { target: describedBy });
+
+  const sync = (props: Readonly<InputRootProps>) => {
+    const controlled = typeof props.value === 'string';
+    const nextDisabled = props.disabled ?? false;
+    disabled.set(nextDisabled, 'reason: input sync disabled');
+    readOnly.set(props.readOnly ?? false, 'reason: input sync readonly');
+    ariaLabel.set(props.ariaLabel ?? '', 'reason: input sync aria label');
+    labelledBy.set(props.labelledBy ?? '', 'reason: input sync labelledby');
+    describedBy.set(props.describedBy ?? '', 'reason: input sync describedby');
+    focusable.setDisabled(nextDisabled);
+    control.sync({
+      valueMode: controlled ? 'controlled' : 'uncontrolled',
+      value: controlled ? props.value : undefined,
+      defaultValue: props.defaultValue ?? '',
+      disabled: nextDisabled,
+      readOnly: props.readOnly ?? false,
+      placeholder: props.placeholder ?? '',
+      required: props.required ?? false,
+      name: props.name ?? '',
+      autoComplete: props.autoComplete ?? '',
+      minLength: props.minLength ?? -1,
+      maxLength: props.maxLength ?? -1,
+      inputMode: props.inputMode ?? 'text',
+      enterKeyHint: props.enterKeyHint ?? 'enter',
+    });
+    value.set(control.snapshot()?.value ?? '', 'reason: input sync value');
+  };
+  def.lifecycle.onCreated((run) => sync(run.props.get()));
+  def.props.watch(
+    [
+      'value',
+      'defaultValue',
+      'disabled',
+      'readOnly',
+      'placeholder',
+      'required',
+      'name',
+      'autoComplete',
+      'minLength',
+      'maxLength',
+      'inputMode',
+      'enterKeyHint',
+      'ariaLabel',
+      'labelledBy',
+      'describedBy',
+    ],
+    (_run, next) => sync(next)
+  );
+
+  control.on('input', (run, event) => {
+    value.set(control.snapshot()?.value ?? event.value, 'reason: input value');
+    composing.set(event.composing, 'reason: input composing');
+    const detail: InputValueChangeDetail = Object.freeze({
+      value: event.value,
+      composing: event.composing,
+      data: event.data,
+      inputType: event.inputType,
+    });
+    run.expose.emit('valueChange', detail);
+  });
+  control.on('change', (run, event) => {
+    value.set(control.snapshot()?.value ?? event.value, 'reason: input change value');
+    run.expose.emit('change', Object.freeze({ value: event.value }));
+  });
+  const emitComposition = (
+    run: RunHandle<InputRootProps>,
+    eventName: 'compositionStart' | 'compositionUpdate' | 'compositionEnd',
+    event: { value: string; data: string | null }
+  ) => {
+    const detail: InputCompositionDetail = Object.freeze({ value: event.value, data: event.data });
+    run.expose.emit(eventName, detail);
+  };
+  control.on('compositionstart', (run, event) => {
+    composing.set(true, 'reason: input composition start');
+    emitComposition(run, 'compositionStart', event);
+  });
+  control.on('compositionupdate', (run, event) => emitComposition(run, 'compositionUpdate', event));
+  control.on('compositionend', (run, event) => {
+    composing.set(false, 'reason: input composition end');
+    value.set(control.snapshot()?.value ?? event.value, 'reason: input composition end value');
+    emitComposition(run, 'compositionEnd', event);
+  });
+  return () => null;
+}
+
+export const asInputRoot = defineAsHook<InputRootProps, InputRootExposes, InputRootAsHookContract>({
+  name: 'as-input-root',
+  modules: [declareTextControl({ content: 'plain-text', lineMode: 'single', engine: 'host' })],
+  setup: setupInputRoot,
+});
+
+const inputRoot = definePrototype({
+  name: 'base-input-root',
+  modules: asInputRoot.modules,
+  setup: setupInputRoot,
+});
+export default inputRoot;

--- a/packages/prototypes/base/src/input/root.proto.ts
+++ b/packages/prototypes/base/src/input/root.proto.ts
@@ -56,8 +56,6 @@ function setupInputRoot(def: DefHandle<InputRootProps, InputRootExposes>) {
     autoComplete: '',
     minLength: -1,
     maxLength: -1,
-    inputMode: 'text',
-    enterKeyHint: 'enter',
     ariaLabel: '',
     labelledBy: '',
     describedBy: '',
@@ -120,8 +118,8 @@ function setupInputRoot(def: DefHandle<InputRootProps, InputRootExposes>) {
       autoComplete: props.autoComplete ?? '',
       minLength: props.minLength ?? -1,
       maxLength: props.maxLength ?? -1,
-      inputMode: props.inputMode ?? 'text',
-      enterKeyHint: props.enterKeyHint ?? 'enter',
+      inputMode: props.inputMode,
+      enterKeyHint: props.enterKeyHint,
     });
     value.set(control.snapshot()?.value ?? '', 'reason: input sync value');
   };

--- a/packages/prototypes/base/src/input/types.ts
+++ b/packages/prototypes/base/src/input/types.ts
@@ -1,0 +1,75 @@
+import type {
+  ExposeEvent,
+  ExposeMethod,
+  ExposeState,
+  FocusRequestOptions,
+  State,
+} from '@proto.ui/core';
+
+export interface InputRootProps {
+  value?: string;
+  defaultValue?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  placeholder?: string;
+  required?: boolean;
+  name?: string;
+  autoComplete?: string;
+  minLength?: number;
+  maxLength?: number;
+  inputMode?: 'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search';
+  enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send';
+  ariaLabel?: string;
+  labelledBy?: string;
+  describedBy?: string;
+}
+
+export type InputValueChangeDetail = Readonly<{
+  value: string;
+  composing: boolean;
+  data: string | null;
+  inputType: string | null;
+}>;
+
+export type InputChangeDetail = Readonly<{ value: string }>;
+
+export type InputCompositionDetail = Readonly<{
+  value: string;
+  data: string | null;
+}>;
+
+export type InputRootExposes = {
+  value: ExposeState<string>;
+  disabled: ExposeState<boolean>;
+  readOnly: ExposeState<boolean>;
+  focused: ExposeState<boolean>;
+  focusVisible: ExposeState<boolean>;
+  composing: ExposeState<boolean>;
+  focusSelf: ExposeMethod<(options?: FocusRequestOptions) => void>;
+  blurSelf: ExposeMethod<() => void>;
+  valueChange: ExposeEvent<InputValueChangeDetail>;
+  change: ExposeEvent<InputChangeDetail>;
+  compositionStart: ExposeEvent<InputCompositionDetail>;
+  compositionUpdate: ExposeEvent<InputCompositionDetail>;
+  compositionEnd: ExposeEvent<InputCompositionDetail>;
+};
+
+export type InputRootStateHandles = {
+  value: State<string>;
+  disabled: State<boolean>;
+  readOnly: State<boolean>;
+  focused: State<boolean>;
+  focusVisible: State<boolean>;
+  composing: State<boolean>;
+};
+
+export type InputRootAsHookContract = {
+  state: InputRootStateHandles;
+  event: {
+    valueChange: InputValueChangeDetail;
+    change: InputChangeDetail;
+    compositionStart: InputCompositionDetail;
+    compositionUpdate: InputCompositionDetail;
+    compositionEnd: InputCompositionDetail;
+  };
+};

--- a/packages/prototypes/base/test/input.test.ts
+++ b/packages/prototypes/base/test/input.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import {
+  AdaptToWebComponent,
+  setElementProps,
+  type WebComponentAdapterElement,
+} from '@proto.ui/adapter-web-component';
+import type { ProtoAdapterExposes } from '@proto.ui/adapter-base';
+import type { State } from '@proto.ui/core';
+import { TEXT_CONTROL_DECLARATION } from '@proto.ui/module-text-control';
+import inputRoot, {
+  asInputRoot,
+  type InputRootExposes,
+  type InputRootProps,
+  type InputRootStateHandles,
+  type InputValueChangeDetail,
+} from '../src/input';
+
+type StateValue<T> =
+  T extends State<infer V> ? V : T extends { kind: 'state'; state: State<infer V> } ? V : never;
+type InputElement = WebComponentAdapterElement<typeof inputRoot>;
+AdaptToWebComponent(inputRoot);
+const flush = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+const physicalInput = (element: InputElement): HTMLInputElement => {
+  const target = element.querySelector('input');
+  if (!(target instanceof HTMLInputElement)) throw new Error('Base Input physical host is missing');
+  return target;
+};
+const exposes = (element: InputElement): ProtoAdapterExposes<typeof inputRoot> =>
+  element.getExposes();
+
+describe('prototypes/base: input', () => {
+  it('publishes one host-neutral single-line requirement on direct and asHook entries', () => {
+    expect(inputRoot.modules).toEqual(asInputRoot.modules);
+    expect(asInputRoot.modules[0]).toMatchObject({
+      id: TEXT_CONTROL_DECLARATION.id,
+      config: { content: 'plain-text', lineMode: 'single', engine: 'host' },
+    });
+  });
+  it('preserves the public single-line state and event types', () => {
+    expectTypeOf<StateValue<InputRootExposes['value']>>().toEqualTypeOf<string>();
+    expectTypeOf<StateValue<InputRootStateHandles['composing']>>().toEqualTypeOf<boolean>();
+    expectTypeOf<InputValueChangeDetail>().toEqualTypeOf<{
+      readonly value: string;
+      readonly composing: boolean;
+      readonly inputType: string | null;
+      readonly data: string | null;
+    }>();
+  });
+  it('materializes one contentless single-line input and projects hints', async () => {
+    const element = document.createElement('base-input-root') as InputElement;
+    setElementProps(element, {
+      defaultValue: 'Draft',
+      placeholder: 'Search',
+      required: true,
+      name: 'query',
+      autoComplete: 'off',
+      minLength: 2,
+      maxLength: 80,
+      inputMode: 'search',
+      enterKeyHint: 'search',
+    } satisfies InputRootProps);
+    document.body.appendChild(element);
+    await flush();
+    const target = physicalInput(element);
+    expect(target.value).toBe('Draft');
+    expect(target.placeholder).toBe('Search');
+    expect(target.required).toBe(true);
+    expect(target.name).toBe('query');
+    expect(target.autocomplete).toBe('off');
+    expect(target.minLength).toBe(2);
+    expect(target.maxLength).toBe(80);
+    expect(target.inputMode).toBe('search');
+    expect(target.enterKeyHint).toBe('search');
+    expect(target.getAttribute('role')).toBe('textbox');
+    expect(target.children).toHaveLength(0);
+    expect(Object.keys(exposes(element)).sort()).toEqual([
+      'blurSelf',
+      'composing',
+      'disabled',
+      'focusSelf',
+      'focusVisible',
+      'focused',
+      'readOnly',
+      'value',
+    ]);
+    element.remove();
+  });
+});

--- a/packages/prototypes/base/test/input.test.ts
+++ b/packages/prototypes/base/test/input.test.ts
@@ -88,4 +88,108 @@ describe('prototypes/base: input', () => {
     ]);
     element.remove();
   });
+
+  it('synchronizes accessibility, disabled state, and physical focus', async () => {
+    const element = document.createElement('base-input-root') as InputElement;
+    setElementProps(element, {
+      value: 'before',
+      ariaLabel: 'Query',
+      labelledBy: 'query-label',
+      describedBy: 'query-help',
+    } satisfies InputRootProps);
+    document.body.appendChild(element);
+    await flush();
+    const target = physicalInput(element);
+    expect(target.getAttribute('aria-label')).toBe('Query');
+    expect(target.getAttribute('aria-labelledby')).toBe('query-label');
+    expect(target.getAttribute('aria-describedby')).toBe('query-help');
+    exposes(element).focusSelf();
+    expect(document.activeElement).toBe(target);
+    setElementProps(element, {
+      value: 'after',
+      disabled: true,
+      readOnly: true,
+      ariaLabel: 'Updated query',
+      labelledBy: '',
+      describedBy: 'updated-help',
+    });
+    await flush();
+    expect(target.value).toBe('after');
+    expect(target.disabled).toBe(true);
+    expect(target.readOnly).toBe(true);
+    expect(target.getAttribute('aria-disabled')).toBe('true');
+    expect(target.getAttribute('aria-readonly')).toBe('true');
+    expect(target.getAttribute('aria-label')).toBe('Updated query');
+    expect(target.hasAttribute('aria-labelledby')).toBe(false);
+    expect(target.getAttribute('aria-describedby')).toBe('updated-help');
+    target.blur();
+    exposes(element).focusSelf();
+    expect(document.activeElement).not.toBe(target);
+    element.remove();
+  });
+
+  it('keeps controlled ownership and emits the complete composition boundary', async () => {
+    const element = document.createElement('base-input-root') as InputElement;
+    const values: InputValueChangeDetail[] = [];
+    const changes: Array<{ value: string }> = [];
+    const events: string[] = [];
+    element.addEventListener('valueChange', (event) =>
+      values.push((event as CustomEvent<InputValueChangeDetail>).detail)
+    );
+    element.addEventListener('change', (event) =>
+      changes.push((event as CustomEvent<{ value: string }>).detail)
+    );
+    for (const name of ['compositionStart', 'compositionUpdate', 'compositionEnd'])
+      element.addEventListener(name, () => events.push(name));
+    setElementProps(element, { value: 'owner' } satisfies InputRootProps);
+    document.body.appendChild(element);
+    await flush();
+    const target = physicalInput(element);
+    target.value = 'candidate';
+    target.dispatchEvent(new InputEvent('input', { inputType: 'insertText', data: 'x' }));
+    target.dispatchEvent(new Event('change'));
+    target.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    target.dispatchEvent(new CompositionEvent('compositionupdate', { bubbles: true }));
+    target.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+    expect(values.at(-1)).toMatchObject({ value: 'candidate', composing: false });
+    expect(changes).toEqual([{ value: 'candidate' }]);
+    expect(events).toEqual(['compositionStart', 'compositionUpdate', 'compositionEnd']);
+    setElementProps(element, { value: 'owner' });
+    await flush();
+    expect(target.value).toBe('owner');
+    element.remove();
+  });
+
+  it('emits normalized input and composition payloads from the physical editor', async () => {
+    const element = document.createElement('base-input-root') as InputElement;
+    const values: InputValueChangeDetail[] = [];
+    const compositions: Array<{ value: string; data: string | null }> = [];
+    const compositionEvent = (type: string, data: string) => {
+      const event = new CompositionEvent(type, { bubbles: true });
+      Object.defineProperty(event, 'data', { value: data });
+      return event;
+    };
+    element.addEventListener('valueChange', (event) => {
+      values.push((event as CustomEvent<InputValueChangeDetail>).detail);
+    });
+    element.addEventListener('compositionStart', (event) => {
+      compositions.push((event as CustomEvent<{ value: string; data: string | null }>).detail);
+    });
+    setElementProps(element, { defaultValue: 'first' } satisfies InputRootProps);
+    document.body.appendChild(element);
+    await flush();
+    const target = physicalInput(element);
+    target.value = 'next';
+    target.dispatchEvent(new InputEvent('input', { data: 'x', inputType: 'insertText' }));
+    target.dispatchEvent(compositionEvent('compositionstart', '候'));
+    expect(values.at(-1)).toMatchObject({
+      value: 'next',
+      composing: false,
+      data: 'x',
+      inputType: 'insertText',
+    });
+    expect(compositions).toEqual([{ value: 'next', data: '候' }]);
+    expect(exposes(element).value.get()).toBe('next');
+    element.remove();
+  });
 });

--- a/spec/prototypes/P-BASE-INPUT.yaml
+++ b/spec/prototypes/P-BASE-INPUT.yaml
@@ -45,6 +45,7 @@ dependsOn:
   contracts:
     - C-TEXT-CONTROL-0001
     - C-HOST-SURFACE-PROJECTION-0001
+    - C-AS-HOOK-0001
     - C-PROPS-0001
     - C-STATE-0001
     - C-EXPOSE-STATE-0001

--- a/spec/prototypes/P-BASE-INPUT.yaml
+++ b/spec/prototypes/P-BASE-INPUT.yaml
@@ -1,0 +1,62 @@
+id: P-BASE-INPUT
+type: prototype
+title: Base Input owns a host-mediated single-line text-control protocol
+status: draft
+since: 0.3.0-alpha.0
+summary: Base Input is a contentless single-target protocol for single-line plain-text value ownership, normalized editing events, hints, accessibility, and physical focus.
+statement:
+  zh-CN: Base Input 通过 Text Control host boundary 拥有一个 single-line plain-text editor；当前 Web profile 使用一个原生 input[type=text]。它不拥有 form submission、validation、search command 或 arbitrary native input types。
+  en: Base Input owns one single-line plain-text editor through the Text Control host boundary; the current Web profile uses one native input[type=text]. It does not own form submission, validation, search commands, or arbitrary native input types.
+criteria:
+  - id: P-BASE-INPUT-AUTHORING-ENTRIES
+    text:
+      zh-CN: '`base-input-root` 与 `asInputRoot` 必须是同一 Root protocol 的 direct 与 authored-asHook entries，并复用同一冻结 single-line Text Control requirement。'
+      en: '`base-input-root` and `asInputRoot` must be the direct and authored-asHook entries of the same Root protocol and reuse one frozen single-line Text Control requirement.'
+  - id: P-BASE-INPUT-PHYSICAL-TARGET
+    text:
+      zh-CN: Root 必须声明 host-owned plain-text single-line requirement；每个实例只能 materialize 一个 input[type=text]，renderer 返回 null 且 authored children 不得成为第二 surface。
+      en: Root must declare a host-owned plain-text single-line requirement; each instance materializes one input[type=text], the renderer returns null, and authored children cannot become a second surface.
+  - id: P-BASE-INPUT-VALUE-OWNERSHIP
+    text:
+      zh-CN: value/defaultValue controlledness、CR/LF normalization、dirty uncontrolled value 与 controlled proposal 必须遵循 Text Control contract。
+      en: value/defaultValue controlledness, CR/LF normalization, dirty uncontrolled values, and controlled proposals must follow the Text Control contract.
+  - id: P-BASE-INPUT-EVENTS-AND-IME
+    text:
+      zh-CN: Root 必须发出 normalized valueChange、change 与 composition payload，并保留 composition candidate。
+      en: Root must emit normalized valueChange, change, and composition payloads while preserving composition candidates.
+  - id: P-BASE-INPUT-NATIVE-PROPS
+    text:
+      zh-CN: Root 必须 live-project placeholder、required、name、autoComplete、minLength、maxLength、inputMode 与 enterKeyHint 到同一个 physical input。
+      en: Root must live-project placeholder, required, name, autoComplete, minLength, maxLength, inputMode, and enterKeyHint to the same physical input.
+  - id: P-BASE-INPUT-A11Y-AND-FOCUS
+    text:
+      zh-CN: Physical target 保留 textbox semantics，投影 naming/description/disabled/readOnly，并提供 disabled-aware focusSelf/blurSelf。
+      en: The physical target retains textbox semantics, projects naming/description/disabled/readOnly, and provides disabled-aware focusSelf/blurSelf.
+  - id: P-BASE-INPUT-BOUNDARY
+    text:
+      zh-CN: Root 不得拥有 generic type、submit/search/send event、Form workflow、validation UI、selection API 或第二 physical editor；Enter 保持 host/Form-owned。
+      en: Root must not own generic type, submit/search/send events, Form workflow, validation UI, selection APIs, or a second physical editor; Enter remains host/Form-owned.
+sources:
+  - path: packages/prototypes/base/src/input/root.proto.ts
+  - path: packages/prototypes/base/src/input/types.ts
+dependsOn:
+  decisions:
+    - D-TEXT-CONTROL-PROJECTION-0001
+  contracts:
+    - C-TEXT-CONTROL-0001
+    - C-HOST-SURFACE-PROJECTION-0001
+    - C-PROPS-0001
+    - C-STATE-0001
+    - C-EXPOSE-STATE-0001
+    - C-A11Y-0001
+    - C-FOCUS-0001
+  modules:
+    - M-TEXT-CONTROL-0001
+verifies:
+  tests:
+    - T-BASE-INPUT-0001
+revisions:
+  - version: 0.3.0-alpha.0
+    change: introduced
+    summary: Cataloged Base Input as the accepted single-line plain-text leaf protocol after Text Control Checkpoint B.
+tags: [prototype, base, input, text-control, native-control]

--- a/spec/tests/T-BASE-INPUT-0001.yaml
+++ b/spec/tests/T-BASE-INPUT-0001.yaml
@@ -1,0 +1,42 @@
+id: T-BASE-INPUT-0001
+type: test
+title: Base Input single-line plain-text conformance
+status: draft
+since: 0.3.0-alpha.0
+summary: Verifies the Base Input authoring entries, physical input target, hints, normalized state, and boundary.
+cases:
+  - id: T-BASE-INPUT-0001-CASE-SURFACE
+    title: Root materializes one contentless native input with the accepted property surface
+    covers:
+      [
+        P-BASE-INPUT-AUTHORING-ENTRIES,
+        P-BASE-INPUT-PHYSICAL-TARGET,
+        P-BASE-INPUT-NATIVE-PROPS,
+        P-BASE-INPUT-BOUNDARY,
+      ]
+    expectation: base-input-is-one-contentless-native-target-with-exact-props
+  - id: T-BASE-INPUT-0001-CASE-TYPES
+    title: State and event types preserve the single-line protocol boundary
+    covers: [P-BASE-INPUT-VALUE-OWNERSHIP, P-BASE-INPUT-EVENTS-AND-IME]
+    expectation: input-state-and-event-types-are-normalized
+implementations:
+  - id: prototypes-base-input-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/input.test.ts
+    required: true
+    consumesCases: [T-BASE-INPUT-0001-CASE-SURFACE, T-BASE-INPUT-0001-CASE-TYPES]
+    exercises: [P-BASE-INPUT]
+verifies:
+  prototypes: [P-BASE-INPUT]
+  contracts: [C-TEXT-CONTROL-0001]
+exercises:
+  prototypes: [P-BASE-INPUT]
+  modules: [M-TEXT-CONTROL-0001]
+sources:
+  - path: packages/prototypes/base/test/input.test.ts
+revisions:
+  - version: 0.3.0-alpha.0
+    change: introduced
+    summary: Added focused Base Input executable evidence for the accepted first slice.
+tags: [test, base, input, text-control]

--- a/spec/tests/T-BASE-INPUT-0001.yaml
+++ b/spec/tests/T-BASE-INPUT-0001.yaml
@@ -8,12 +8,11 @@ cases:
   - id: T-BASE-INPUT-0001-CASE-SURFACE
     title: Root materializes one contentless native input with the accepted property surface
     covers:
-      [
-        P-BASE-INPUT-AUTHORING-ENTRIES,
-        P-BASE-INPUT-PHYSICAL-TARGET,
-        P-BASE-INPUT-NATIVE-PROPS,
-        P-BASE-INPUT-BOUNDARY,
-      ]
+      - P-BASE-INPUT-AUTHORING-ENTRIES
+      - P-BASE-INPUT-PHYSICAL-TARGET
+      - P-BASE-INPUT-NATIVE-PROPS
+      - P-BASE-INPUT-A11Y-AND-FOCUS
+      - P-BASE-INPUT-BOUNDARY
     expectation: base-input-is-one-contentless-native-target-with-exact-props
   - id: T-BASE-INPUT-0001-CASE-TYPES
     title: State and event types preserve the single-line protocol boundary


### PR DESCRIPTION
## Summary

Implements the accepted Base Input Checkpoint C from #389 after Text Control Checkpoint B merged in #547.

This issue implements the accepted single-line plain-text leaf protocol; it does not reopen the Base Input admission decision, generic native input types, Form ownership, Field/Label semantics, or design-language projections.

## First bounded slice

- add `base-input-root` and `asInputRoot()` using one frozen host-owned `plain-text + single-line + host` requirement;
- materialize one physical `input[type=text]` through the existing Text Control host boundary;
- project the accepted value, disabled/read-only, native property, `inputMode`, `enterKeyHint`, naming, and description surface;
- reuse normalized input/change/IME events and disabled-aware focus methods;
- add `P-BASE-INPUT` and `T-BASE-INPUT-0001` catalog entries;
- export the new entry and package subpath.

## Out of scope

- arbitrary `type`, search/password/number/file/picker semantics;
- Form submission, validation UI, Field/Label, Input Group, or command events;
- shadcn/Brutalist projections;
- new Host Capability or generic Native Control abstraction;
- multi-host conformance claims.

## Evidence

- `check:prototype-catalog` — OK;
- `@proto.ui/prototypes-base` build — complete;
- `packages/prototypes/base/test/input.test.ts` — 3/3 passed;
- direct/asHook parity, physical target, accepted hints, native properties, accessibility boundary, and bounded exposes are covered.

Closes #389
