### PR TITLE
fix(agent): collect review checks from exact head commit

### DIFF
--- a/scripts/agent-operations/collect-live-review-input.mjs
+++ b/scripts/agent-operations/collect-live-review-input.mjs
@@ -32,31 +32,10 @@ query($owner: String!, $name: String!, $number: Int!) {
       headRefOid
       author { login }
       commits(first: 100) {
-        nodes { commit { oid messageHeadline } }
-        pageInfo { hasNextPage }
-      }
-      reviews(first: 100) {
-        nodes { id author { login } state commit { oid } submittedAt body }
-        pageInfo { hasNextPage }
-      }
-      comments(first: 100) {
-        nodes { id author { login } body updatedAt }
-        pageInfo { hasNextPage }
-      }
-      reviewThreads(first: 100) {
         nodes {
-          id
-          isResolved
-          comments(first: 100) {
-            nodes { databaseId author { login } body updatedAt }
-            pageInfo { hasNextPage }
-          }
-        }
-        pageInfo { hasNextPage }
-      }
-      headRef {
-        target {
-          ... on Commit {
+          commit {
+            oid
+            messageHeadline
             statusCheckRollup {
               contexts(first: 100) {
                 nodes {
@@ -83,6 +62,26 @@ query($owner: String!, $name: String!, $number: Int!) {
             }
           }
         }
+        pageInfo { hasNextPage }
+      }
+      reviews(first: 100) {
+        nodes { id author { login } state commit { oid } submittedAt body }
+        pageInfo { hasNextPage }
+      }
+      comments(first: 100) {
+        nodes { id author { login } body updatedAt }
+        pageInfo { hasNextPage }
+      }
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 100) {
+            nodes { databaseId author { login } body updatedAt }
+            pageInfo { hasNextPage }
+          }
+        }
+        pageInfo { hasNextPage }
       }
     }
   }
@@ -254,7 +253,11 @@ export function buildLiveReviewInput(
     }
   }
 
-  const checkContexts = pullRequestPayload.headRef?.target?.statusCheckRollup?.contexts;
+  const headCommit = pullRequestPayload.commits.nodes.at(-1)?.commit;
+  if (!headCommit || headCommit.oid !== pullRequestPayload.headRefOid) {
+    throw new Error('live head commit collection does not match the pull-request head');
+  }
+  const checkContexts = headCommit.statusCheckRollup?.contexts;
   assertNoTruncation(checkContexts?.nodes, checkContexts?.pageInfo, 'check contexts');
   const checks = (checkContexts?.nodes ?? []).map(normalizeCheck);
 

--- a/scripts/agent-operations/test/collect-live-review-input.test.mjs
+++ b/scripts/agent-operations/test/collect-live-review-input.test.mjs
@@ -33,7 +33,7 @@ const changedFiles = [
 ];
 
 function payload(overrides = {}) {
-  return {
+  const result = {
     data: {
       viewer: { login: 'reviewer' },
       repository: {
@@ -136,6 +136,9 @@ function payload(overrides = {}) {
     },
     ...overrides,
   };
+  result.data.repository.pullRequest.commits.nodes[0].commit.statusCheckRollup =
+    result.data.repository.pullRequest.headRef.target.statusCheckRollup;
+  return result;
 }
 
 test('live collector builds a complete canonical input from the GraphQL payload', () => {
@@ -246,7 +249,7 @@ test('live collector fails closed on pagination truncation for every connection'
     [
       'check contexts',
       (p) => {
-        p.data.repository.pullRequest.headRef.target.statusCheckRollup.contexts.pageInfo.hasNextPage = true;
+        p.data.repository.pullRequest.commits.nodes[0].commit.statusCheckRollup.contexts.pageInfo.hasNextPage = true;
       },
     ],
   ]) {
@@ -422,23 +425,24 @@ test('live collector passes external evidence through verbatim and validates its
 
 test('live collector accepts nullable check links without treating them as trusted CI evidence', () => {
   const nullableUrls = payload();
-  nullableUrls.data.repository.pullRequest.headRef.target.statusCheckRollup.contexts.nodes = [
-    {
-      __typename: 'CheckRun',
-      name: 'test',
-      status: 'COMPLETED',
-      conclusion: 'SUCCESS',
-      completedAt: '2026-08-23T06:00:00Z',
-      detailsUrl: null,
-    },
-    {
-      __typename: 'StatusContext',
-      context: 'legacy-ci',
-      state: 'SUCCESS',
-      targetUrl: null,
-      createdAt: '2026-08-23T06:00:00Z',
-    },
-  ];
+  nullableUrls.data.repository.pullRequest.commits.nodes[0].commit.statusCheckRollup.contexts.nodes =
+    [
+      {
+        __typename: 'CheckRun',
+        name: 'test',
+        status: 'COMPLETED',
+        conclusion: 'SUCCESS',
+        completedAt: '2026-08-23T06:00:00Z',
+        detailsUrl: null,
+      },
+      {
+        __typename: 'StatusContext',
+        context: 'legacy-ci',
+        state: 'SUCCESS',
+        targetUrl: null,
+        createdAt: '2026-08-23T06:00:00Z',
+      },
+    ];
   const result = buildLiveReviewInput(
     nullableUrls,
     'github.com:Proto-UI/Proto-UI',
@@ -450,6 +454,23 @@ test('live collector accepts nullable check links without treating them as trust
   assert.equal(result.input.checks[0].detailsUrl, null);
   assert.equal(result.input.checks[1].detailsUrl, null);
   assert.equal(summarizeLiveChecks(result.input.checks), 'unknown');
+});
+
+test('live collector reads checks from the exact head commit when headRef target rollup is absent', () => {
+  const forkPullRequest = payload();
+  forkPullRequest.data.repository.pullRequest.headRef.target.statusCheckRollup = null;
+  const result = buildLiveReviewInput(forkPullRequest, repositoryId, 487, [], changedFiles);
+  assert.equal(result.input.headSha, sha('b'));
+  assert.equal(result.input.checks.length, 2);
+});
+
+test('live collector fails closed when the collected final commit is not the pull-request head', () => {
+  const mismatched = payload();
+  mismatched.data.repository.pullRequest.commits.nodes[0].commit.oid = sha('c');
+  assert.throws(
+    () => buildLiveReviewInput(mismatched, repositoryId, 487, [], changedFiles),
+    /head commit collection does not match/
+  );
 });
 
 test('check context normalization matches both connection node kinds', () => {


### PR DESCRIPTION
## Summary

Restore canonical review-input collection for pull requests whose `headRef.target.statusCheckRollup` is absent by reading checks from the final commit in the complete PR commit connection.

The collector still fails closed: it verifies that the final collected commit OID equals `headRefOid`, preserves check pagination rejection, and leaves canonical digest, permission, self-review, CI, spec, and exact-head submission gates unchanged.

## Related context

- Reproduction: PR #585 returned a null `headRef.target.statusCheckRollup` while the exact head commit exposed all 12 check contexts.
- Applicable spec entities and lifecycle: none; this is Agent operations infrastructure.
- Criteria / test anchors: canonical exact-head review input and live submission-boundary revalidation in `internal/agent-operations/contributor-agents.md`.

## Scope boundary

- Fix the GraphQL collection path and add focused positive/negative regressions.
- Do not activate scheduled review authorization, relax approval rules, change review packet semantics, or merge/review any other PR.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs; no product entity applies.
- [x] This change preserves the existing governed Agent review boundary.
- [x] This change does not create or widen a product guarantee.

## Contribution provenance

- [x] This contribution was created by me and I have the right to submit it.
- [x] This contribution includes AI-assisted implementation and review under the active maintainer loop.
- [x] No third-party source disclosure is required.

### AI assistance

Codex traced the live GraphQL failure, implemented the bounded collector fix, added regression tests, and ran validation. The current maintainer explicitly requested this repair and PR.

## DCO

- [x] The commit carries a `Signed-off-by` trailer.

## Prototype website preview

- [x] A new or updated website page is not applicable because this changes only Agent review-input collection.

## Validation

- Focused: `corepack pnpm@10.32.1 exec node --test scripts/agent-operations/test/collect-live-review-input.test.mjs` — 13/13 passed.
- Agent operations: `corepack pnpm@10.32.1 check:agent-operations` — 58/58 passed; skill checks passed.
- Agent docs: `corepack pnpm@10.32.1 check:agent-doc` — passed.
- Formatting: `git diff --check` and focused Prettier check — passed.
- Live boundary: `corepack pnpm@10.32.1 agent:review:smoke -- github.com:Proto-UI/Proto-UI 585` — collected the current exact head, 12 checks, viewer permission, reviews, comments, replies, and threads; correctly classified failing CI as `failure`.