### PR TITLE
fix(preview): probe explicit Pages index asset

### DIFF
--- a/integrations/proto-ui-preview/scripts/pages-worker.test.mjs
+++ b/integrations/proto-ui-preview/scripts/pages-worker.test.mjs
@@ -155,6 +155,7 @@ test("authorized Astro routes fall back to their explicit directory index", asyn
   }
 });
 
+// Keep this contract explicit: Advanced Mode must probe the emitted file, not the directory root.
 test("the public readiness probe checks the emitted index without exposing it", async () => {
   const paths = [];
   const result = await worker.fetch(

--- a/integrations/proto-ui-preview/scripts/pages-worker.test.mjs
+++ b/integrations/proto-ui-preview/scripts/pages-worker.test.mjs
@@ -155,21 +155,21 @@ test("authorized Astro routes fall back to their explicit directory index", asyn
   }
 });
 
-test("the public readiness probe follows Pages' canonical root route without exposing it", async () => {
+test("the public readiness probe checks the emitted index without exposing it", async () => {
   const paths = [];
   const result = await worker.fetch(
     new Request("https://poppy-proto-ui-pr-462.pages.dev/__poppy/assets-ready"),
     { ASSETS: { fetch(request) {
       const pathname = new URL(request.url).pathname;
       paths.push(pathname);
-      return pathname === "/"
+      return pathname === "/index.html"
         ? new Response("private html")
-        : new Response(null, { status: 308, headers: { Location: "/" } });
+        : new Response("missing", { status: 404 });
     } } },
   );
   assert.equal(result.status, 204);
   assert.equal(await result.text(), "");
-  assert.deepEqual(paths, ["/"]);
+  assert.deepEqual(paths, ["/index.html"]);
 });
 
 test("a transient control-plane failure does not clear the session or loop OAuth", async () => {

--- a/integrations/proto-ui-preview/templates/pages-worker.js
+++ b/integrations/proto-ui-preview/templates/pages-worker.js
@@ -195,9 +195,20 @@ async function fetchAsset(env, request) {
   return env.ASSETS.fetch(new Request(url, request));
 }
 
-async function assetHealth(env) {
-  const probe = await env.ASSETS.fetch(new Request(`${CANONICAL_ORIGIN}/`));
-  return response(null, { status: probe.ok ? 204 : 503 });
+async function assetHealth(request, env) {
+  // Keep the original Pages Request context and probe the emitted file
+  // explicitly. Advanced Mode does not guarantee directory-index routing for
+  // ASSETS.fetch(new Request(CANONICAL_ORIGIN + "/")).
+  const probeURL = new URL(request.url);
+  probeURL.pathname = "/index.html";
+  probeURL.search = "";
+  probeURL.hash = "";
+  try {
+    const probe = await env.ASSETS.fetch(new Request(probeURL, request));
+    return response(null, { status: probe.ok ? 204 : 503 });
+  } catch {
+    return response(null, { status: 503, headers: { "Retry-After": "5" } });
+  }
 }
 
 export default {
@@ -206,7 +217,7 @@ export default {
     if (url.origin !== CANONICAL_ORIGIN) {
       return redirect(`${CANONICAL_ORIGIN}${url.pathname}${url.search}`, 308);
     }
-    if (url.pathname === "/__poppy/assets-ready") return assetHealth(env);
+    if (url.pathname === "/__poppy/assets-ready") return assetHealth(request, env);
     if (url.pathname === "/__poppy/session") return exchangeTicket(request, env);
     return serveAuthorized(request, env);
   },


### PR DESCRIPTION
The Advanced Mode readiness probe queried /, which can be a 404 through the Pages ASSETS binding because directory-index routing is not guaranteed. Probe /index.html with the original Request context and cover the path in the Worker test. This fixes the deployed preview readiness gate without changing authorization boundaries.