### PR TITLE
fix(positioning): synchronize dropdown during pointer drag

### DIFF
--- a/internal/records/2026-09-02-dropdown-active-pointer-positioning.zh-CN.md
+++ b/internal/records/2026-09-02-dropdown-active-pointer-positioning.zh-CN.md
@@ -1,0 +1,45 @@
+# Dropdown active-pointer positioning 同步记录
+
+日期：2026-09-02 关联 Issue：#587
+
+本文记录一次实现回归修复及其 authority gap。它不是 Proto UI 规范，不修改 `spec/**`，也不为 drag cadence、placement 动画或 touch dismissal 创建新的公开保证。
+
+## Context
+
+Issue #587 观察到：mobile viewport 中 Dropdown 保持打开时，Trigger 在 pointer drag 期间发生 rendered-geometry 位移，Content 的 positioning 更新与视觉位移不同步；接近 viewport 底部时，collision placement 从 bottom 翻为 top。
+
+## Applicable authority
+
+- `C-ANCHORED-POSITIONING-0001-E` 要求自动更新只存在于 active-view lease 生命周期，idle 默认不得启用逐帧 `animationFrame` polling，并在 detach/dispose 时撤销 observer。
+- `C-ANCHORED-POSITIONING-0001-G` 要求默认按 anchor 的实际 rendered geometry 定位；只有显式 `excludeAnchorTranslation` 才排除 anchor 自身 translation。
+- `HC-ANCHORED-POSITION-0001` 把测量、collision resolution、坐标写入与相关 geometry observation 归给 host capability。
+- `P-BASE-DROPDOWN-MENU-CONTENT-POSITION` 要求 `excludeAnchorTranslation=false` 时使用 Trigger 的实际 rendered geometry。
+- `P-BASE-DROPDOWN-MENU-TRIGGER-*` 与 Root request channel 继续拥有 open/close interaction；Positioning host 不拥有 dismissal。
+
+当前没有 `C-*` criterion 规定 active pointer session 必须达到何种逐帧 cadence，也没有实体授权对 collision flip 的 `left/top` 变化做动画。因此本轮不新增 `T-ANCHORED-POSITIONING-0001` case，避免用 Test entity 反向发明规范语义。
+
+## Bounded implementation decision
+
+Web Floating UI host 保持 idle `animationFrame:false`。仅当 active positioning lease 的 anchor 收到 `pointerdown` 时，暂时重启同一 `autoUpdate` lease 为 `animationFrame:true`；在匹配的 `pointerup`、`pointercancel`、window `blur`、target replacement 或 dispose 时恢复 idle policy 并撤销监听。
+
+这只是 host implementation 对实际 rendered geometry 的同步修复：
+
+- 不新增 portable prop、Module API 或 Host Capability identity；
+- 不改变 Trigger/Root 的 open、toggle、outside-dismiss 或 focus 语义；
+- 不对 placement flip 增加 transition；Positioning 继续直接写 `left/top`，Transition 不取得几何所有权；
+- 用 request generation 丢弃重叠 `computePosition()` 的 stale result，避免较旧计算覆盖较新 frame。
+
+## Evidence
+
+实现级单测 `packages/modules/positioning/test/floating-ui-host.test.ts` 覆盖：idle 无 frame loop、pointerdown 启动 tracking、rendered rect 变化驱动 Content 坐标、pointerup/pointercancel/blur 停止、anchor replacement 解绑旧 target 并绑定新 target、active dispose 清理 frame 与监听。
+
+真实 mobile journey 在 390×844 Shadcn Dropdown 页面验证：
+
+- drag session 中菜单保持 open；
+- Trigger 每 20px 下移时 Content 每次保持 4px anchor gap；
+- offset 320 时 collision placement 从 `bottom` 翻为 `top`，翻转后继续保持 4px gap；
+- 未添加 placement animation；outside press dismissal 保持原路径。
+
+## Follow-up
+
+若维护者要把 active-pointer cadence 或 placement-change motion 提升为跨 host 保证，应先单独决定：可移植输入事实、host availability/fallback、性能预算、multi-pointer 规则、placement transition ownership 与对应 `C-*` criterion，再添加 `T-*` mapping。#587 本轮不代替该决定。

--- a/packages/modules/positioning/src/web/floating-ui-host.ts
+++ b/packages/modules/positioning/src/web/floating-ui-host.ts
@@ -11,7 +11,6 @@ import {
 import type {
   AnchoredPositionAlign,
   AnchoredPositionConfig,
-  AnchoredPositionConnection,
   AnchoredPositionSide,
 } from '@proto.ui/core';
 import type { AnchoredPositionHost, AnchoredPositionHostLease } from '../caps';
@@ -106,9 +105,15 @@ export function createFloatingUiAnchoredPositionHost(): AnchoredPositionHost {
     attach(initial): AnchoredPositionHostLease {
       let connection = initial;
       let disposed = false;
-      let cleanup: (() => void) | null = null;
+      let positionCleanup: (() => void) | null = null;
+      let anchorCleanup: (() => void) | null = null;
+      let pointerEndCleanup: (() => void) | null = null;
+      let pointerTracking = false;
+      let activePointerId: number | null = null;
+      let positionRequest = 0;
 
       const position = async () => {
+        const request = ++positionRequest;
         const { anchor, floating, config } = connection;
         if (disposed || !isElement(anchor) || !isElement(floating)) return;
         const result = await computePosition(positionReference(anchor, config), floating, {
@@ -116,7 +121,7 @@ export function createFloatingUiAnchoredPositionHost(): AnchoredPositionHost {
           strategy: config.strategy,
           middleware: middlewareFor(config),
         });
-        if (disposed) return;
+        if (disposed || request !== positionRequest) return;
         Object.assign(floating.style, {
           position: result.strategy,
           left: `${result.x}px`,
@@ -128,12 +133,62 @@ export function createFloatingUiAnchoredPositionHost(): AnchoredPositionHost {
         connection.onResolved?.({ ...resolved, strategy: result.strategy });
       };
 
-      const restart = () => {
-        cleanup?.();
-        cleanup = null;
+      const restartPositioning = () => {
+        positionCleanup?.();
+        positionCleanup = null;
         const { anchor, floating } = connection;
         if (!isElement(anchor) || !isElement(floating)) return;
-        cleanup = autoUpdate(anchor, floating, position, { animationFrame: false });
+        positionCleanup = autoUpdate(anchor, floating, position, {
+          animationFrame: pointerTracking,
+        });
+      };
+
+      const stopPointerTracking = (event?: Event) => {
+        if (!pointerTracking) return;
+        const pointerId =
+          event && 'pointerId' in event && typeof event.pointerId === 'number'
+            ? event.pointerId
+            : null;
+        if (pointerId !== null && activePointerId !== null && pointerId !== activePointerId) return;
+        pointerTracking = false;
+        activePointerId = null;
+        pointerEndCleanup?.();
+        pointerEndCleanup = null;
+        restartPositioning();
+      };
+
+      const bindAnchor = () => {
+        anchorCleanup?.();
+        anchorCleanup = null;
+        const { anchor } = connection;
+        if (!isElement(anchor)) return;
+        const ownerWindow = anchor.ownerDocument.defaultView;
+        const startPointerTracking = (event: Event) => {
+          if (disposed || pointerTracking || !ownerWindow) return;
+          pointerTracking = true;
+          activePointerId =
+            'pointerId' in event && typeof event.pointerId === 'number' ? event.pointerId : null;
+          ownerWindow.addEventListener('pointerup', stopPointerTracking, true);
+          ownerWindow.addEventListener('pointercancel', stopPointerTracking, true);
+          ownerWindow.addEventListener('blur', stopPointerTracking);
+          pointerEndCleanup = () => {
+            ownerWindow.removeEventListener('pointerup', stopPointerTracking, true);
+            ownerWindow.removeEventListener('pointercancel', stopPointerTracking, true);
+            ownerWindow.removeEventListener('blur', stopPointerTracking);
+          };
+          restartPositioning();
+        };
+        anchor.addEventListener('pointerdown', startPointerTracking);
+        anchorCleanup = () => anchor.removeEventListener('pointerdown', startPointerTracking);
+      };
+
+      const restart = () => {
+        pointerEndCleanup?.();
+        pointerEndCleanup = null;
+        pointerTracking = false;
+        activePointerId = null;
+        bindAnchor();
+        restartPositioning();
       };
 
       restart();
@@ -152,8 +207,14 @@ export function createFloatingUiAnchoredPositionHost(): AnchoredPositionHost {
         },
         dispose() {
           disposed = true;
-          cleanup?.();
-          cleanup = null;
+          activePointerId = null;
+          positionRequest += 1;
+          pointerEndCleanup?.();
+          pointerEndCleanup = null;
+          anchorCleanup?.();
+          anchorCleanup = null;
+          positionCleanup?.();
+          positionCleanup = null;
         },
       };
     },

--- a/packages/modules/positioning/test/floating-ui-host.test.ts
+++ b/packages/modules/positioning/test/floating-ui-host.test.ts
@@ -42,7 +42,10 @@ async function flush(): Promise<void> {
   await Promise.resolve();
 }
 
-afterEach(() => document.body.replaceChildren());
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.unstubAllGlobals();
+});
 
 describe('module-positioning: Floating UI host', () => {
   it('applies side, alignment, offsets, categorical data, and non-transform coordinates', async () => {
@@ -145,6 +148,85 @@ describe('module-positioning: Floating UI host', () => {
     expect(floating.style.top).toBe('126px');
     transformSpy.mockRestore();
     lease.dispose();
+  });
+
+  it('tracks rendered anchor movement each frame only during an active pointer drag', async () => {
+    const anchor = document.createElement('button');
+    const floating = document.createElement('div');
+    document.body.append(anchor, floating);
+    setRect(anchor, rect(100, 100, 50, 20));
+    setRect(floating, rect(0, 0, 40, 10));
+
+    vi.stubGlobal('ResizeObserver', undefined);
+    vi.stubGlobal('IntersectionObserver', undefined);
+    const frames = new Map<number, FrameRequestCallback>();
+    let frameId = 0;
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        frameId += 1;
+        frames.set(frameId, callback);
+        return frameId;
+      })
+    );
+    vi.stubGlobal(
+      'cancelAnimationFrame',
+      vi.fn((id: number) => {
+        frames.delete(id);
+      })
+    );
+
+    const lease = createFloatingUiAnchoredPositionHost().attach({
+      anchor,
+      floating,
+      config: baseConfig,
+    });
+    await flush();
+    expect(floating.style.left).toBe('100px');
+    expect(frames).toHaveLength(0);
+
+    anchor.dispatchEvent(new Event('pointerdown'));
+    expect(frames).toHaveLength(1);
+    setRect(anchor, rect(140, 100, 50, 20));
+    const activeFrame = frames.entries().next().value as [number, FrameRequestCallback] | undefined;
+    if (!activeFrame) throw new Error('Active pointer tracking did not schedule a frame.');
+    frames.delete(activeFrame[0]);
+    activeFrame[1](16);
+    await flush();
+    expect(floating.style.left).toBe('140px');
+
+    window.dispatchEvent(new Event('pointerup'));
+    expect(frames).toHaveLength(0);
+    await flush();
+    expect(floating.style.left).toBe('140px');
+    setRect(anchor, rect(180, 100, 50, 20));
+    await flush();
+    expect(floating.style.left).toBe('140px');
+    anchor.dispatchEvent(new Event('pointerdown'));
+    expect(frames).toHaveLength(1);
+    window.dispatchEvent(new Event('pointercancel'));
+    expect(frames).toHaveLength(0);
+
+    anchor.dispatchEvent(new Event('pointerdown'));
+    expect(frames).toHaveLength(1);
+    window.dispatchEvent(new Event('blur'));
+    expect(frames).toHaveLength(0);
+
+    anchor.dispatchEvent(new Event('pointerdown'));
+    expect(frames).toHaveLength(1);
+    const replacementAnchor = document.createElement('button');
+    document.body.appendChild(replacementAnchor);
+    setRect(replacementAnchor, rect(200, 100, 50, 20));
+    lease.update({ anchor: replacementAnchor, floating, config: baseConfig });
+    expect(frames).toHaveLength(0);
+    anchor.dispatchEvent(new Event('pointerdown'));
+    expect(frames).toHaveLength(0);
+    replacementAnchor.dispatchEvent(new Event('pointerdown'));
+    expect(frames).toHaveLength(1);
+    lease.dispose();
+    expect(frames).toHaveLength(0);
+    window.dispatchEvent(new Event('pointerup'));
+    expect(frames).toHaveLength(0);
   });
 
   it('reports collision-resolved side and alignment against the viewport', async () => {


### PR DESCRIPTION
## Summary

Fixes active Dropdown anchor tracking during a mobile pointer drag without enabling idle frame polling.

- keeps the existing Floating UI `autoUpdate(..., { animationFrame: false })` policy while idle;
- temporarily enables frame tracking only from anchor `pointerdown` until matching `pointerup` / `pointercancel`, window blur, target replacement, or disposal;
- ignores stale overlapping `computePosition()` results;
- adds focused cleanup/cadence regression coverage;
- records the current authority gap without adding a normative T-* drag-cadence case.

Fixes #587.

## Related context

- Issue: #587
- Applicable spec entities and lifecycle: `C-ANCHORED-POSITIONING-0001` (draft), `M-POSITIONING-0001` (draft), `HC-ANCHORED-POSITION-0001` (draft), `P-BASE-DROPDOWN-MENU-CONTENT` (draft)
- Criteria / test anchors: `C-ANCHORED-POSITIONING-0001-E`, `C-ANCHORED-POSITIONING-0001-G`; implementation evidence in `packages/modules/positioning/test/floating-ui-host.test.ts`
- Related upstream: existing `@floating-ui/dom` `autoUpdate` animation-frame option; no copied source

## Scope boundary

- Already decided: idle positioning must not poll every frame; default positioning uses actual rendered anchor geometry; host owns geometry/collision updates; Trigger/Root retain open and dismissal semantics.
- This PR decides only a Web-host implementation detail: active-pointer sessions temporarily use per-frame anchor measurement and cleanly return to idle observation.
- Out of scope: placement animation, new portable props or Host Capability identities, changing drag-vs-dismiss behavior, or defining cross-host drag cadence. The authority gap is recorded in `internal/records/2026-09-02-dropdown-active-pointer-positioning.zh-CN.md`.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs.
- [x] Normative behavior changes include coherent P/C/T criteria, revisions, executable evidence, and affected projections. (No normative behavior was added; the T entity is intentionally unchanged.)
- [x] This change does not create an empty catalog identity or silently widen a draft/active public guarantee.

## Contribution provenance

- [x] This contribution was created by me and I have the right to submit it.
- [ ] This contribution adapts or derives from third-party material.
- [x] This contribution includes material AI-assisted generation or transformation.
- [ ] This contribution may be subject to employer or client ownership, and I have confirmed that I may submit it.
- [x] No third-party source disclosure is required.

### Third-party or upstream sources

| Source | Version / commit | License | Material used | Required attribution |
| ------ | ---------------- | ------- | ------------- | -------------------- |
| Existing `@floating-ui/dom` dependency | repository lockfile | MIT | Existing `autoUpdate` public API only; no copied source | Existing dependency notices |

### AI assistance

OMP coding agents traced the governed positioning boundary, produced a red-first host regression, implemented the bounded host fix, and performed independent read-only review. The current user directed the scope; repository tests, type checks, and a real browser journey were reviewed before submission. No private or third-party source material was provided.

## DCO

- [x] I have checked the DCO status of this PR.

## Prototype website preview

- [ ] This pull request adds or changes public Prototype behavior and includes the required reachable website page or page update.
- [x] A new or updated website page is not applicable because: the change repairs the existing Web Positioning host cadence and changes no Prototype API or documented guarantee.

- Public docs route: `/en/ui-libraries/shadcn/dropdown-menu/`
- Local preview URL or route: `http://127.0.0.1:4325/en/ui-libraries/shadcn/dropdown-menu/`
- Applicable runtimes manually reviewed: Web Component
- [x] The demo consumes the real public package export and prefers the Prototype's own anatomy, triggers, state, events, and defaults.
- [x] The Demo Matrix, when used, is supplementary evidence rather than a replacement for the website page.
- External demo orchestration: test-only transform updates during the pointer session to measure host tracking cadence
- Consumer-owned orchestration that is not installed with the package: none

## Validation

- Focused tests: `corepack pnpm@10.32.1 exec vitest run packages/modules/positioning/test/floating-ui-host.test.ts` — 5/5 passed.
- Catalog / generated checks: not applicable; no spec entity or generated projection changed.
- Types / repository tests: `corepack pnpm@10.32.1 check:types:workspace` — passed.
- Docs build / preview: local Astro dev server used for manual browser evidence; full docs build not run.
- Manual or browser evidence: 390×844 Shadcn Dropdown. During an active pointer session, Trigger moved in 20px increments and Content retained a 4px gap each sample; collision placement flipped bottom→top at offset 320 and retained the 4px gap. Outside press changed `aria-expanded` true→false and visible menu count 1→0.
- Not run or not applicable, with reason: full repository suite deferred to CI; no placement animation or touch-dismiss semantic change was made.
