### PR TITLE
test(www): wait for Shadcn transition projection readiness

### DIFF
--- a/apps/www/src/content/docs/zh-cn/demo-shadcn-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-shadcn-controls.browser.test.ts
@@ -130,6 +130,27 @@ async function editorStyle(page: Page): Promise<EditorStyle> {
   });
 }
 
+async function waitForTransitionStyle(page: Page): Promise<void> {
+  await page.waitForFunction(
+    ({ property, duration, timing }) => {
+      const editor = document.querySelector('[data-previewer-id] textarea');
+      if (!editor) return false;
+      const style = getComputedStyle(editor);
+      return (
+        style.transitionProperty === property &&
+        style.transitionDuration === duration &&
+        style.transitionTimingFunction === timing
+      );
+    },
+    {
+      property: TRANSITION_PROPERTY,
+      duration: TRANSITION_DURATION,
+      timing: TRANSITION_TIMING,
+    },
+    { timeout: 10_000 }
+  );
+}
+
 async function focusEditorWithRealTab(page: Page): Promise<void> {
   const prepared = await page.evaluate(() => {
     const editor = document.querySelector<HTMLTextAreaElement>('[data-previewer-id] textarea');
@@ -213,6 +234,7 @@ describe.sequential('shadcn control documentation browser regressions', () => {
       for (const runtime of RUNTIMES) {
         await selectRuntime(page, previewer, runtime, '[data-pui-root]', 3);
         await applyColorScheme(page, 'light');
+        await waitForTransitionStyle(page);
 
         const resting = await editorStyle(page);
         // The property set is the whole point: `all` would also animate the


### PR DESCRIPTION
Fixes #594.

## Scope
The existing Shadcn Textarea browser assertion reads computed transition styles immediately after runtime-root readiness. React can expose the mounted root before the projected style is observable, producing `transitionProperty: none` and blocking unrelated PRs.

This change adds a bounded wait for the exact computed `transitionProperty`, duration, and timing function before the existing assertions. It does not weaken or change expected upstream values, runtime behavior, CSS tokens, or Textarea semantics.

## Evidence
- Before: focused suite failed at `demo-shadcn-controls.browser.test.ts:220` with React/property `none`.
- After: `vitest run apps/www/src/content/docs/zh-cn/demo-shadcn-controls.browser.test.ts` — 5 passed.
- Prettier check and `git diff --check` passed.