### PR TITLE
fix(cli): lower rules on exposed prototype-owned state

### DIFF
--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -310,16 +310,22 @@ export function scanRuleStateReads(
     return found.flatMap((edge) => aliasRoots(edge.target, chain, edge.at, next));
   };
 
+  // An exposure names a binding, and a binding lives in one scope. Writing it
+  // across the whole chain would let a sibling prototype reusing the same local
+  // name inherit an exposure its own runtime never registers.
+  const declaringScope = (name: string, chain: ts.Node[]): ts.Node | undefined =>
+    chain.find((candidate) => declaredIn.get(candidate)?.has(name)) ?? chain[chain.length - 1];
+
   for (const { handle, key, chain, at } of rawExposures) {
     // A key the scanner cannot read still means the state is exposed, and the
     // attribute comes from the declared name anyway.
     const text = ts.isStringLiteralLike(key) ? key.text : '';
     for (const name of new Set([handle, ...aliasRoots(handle, chain, at)])) {
-      for (const owner of chain) {
-        const scoped = exposedKeys.get(owner) ?? new Map<string, string>();
-        if (!scoped.has(name)) scoped.set(name, text);
-        exposedKeys.set(owner, scoped);
-      }
+      const owner = declaringScope(name, chain);
+      if (!owner) continue;
+      const scoped = exposedKeys.get(owner) ?? new Map<string, string>();
+      if (!scoped.has(name)) scoped.set(name, text);
+      exposedKeys.set(owner, scoped);
     }
   }
 

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -216,24 +216,28 @@ export function scanRuleStateReads(
   const aliasRoot = (name: string, chain: ts.Node[], at: number): string => {
     const seen = new Set<string>();
     let current = name;
+    // Each hop resolves where that edge was created, not where the exposure was
+    // written, so a later redeclaration of an intermediate name cannot retarget
+    // an alias that had already captured its value.
+    let cursor = at;
     for (;;) {
       if (seen.has(current)) return current;
       seen.add(current);
-      // The edge in effect where the exposure was written, nearest scope first.
-      let next: string | undefined;
+      let found: AliasEdge | null = null;
       for (const owner of chain) {
         let best: AliasEdge | null = null;
         for (const edge of aliasEdges) {
-          if (edge.owner !== owner || edge.name !== current || edge.at > at) continue;
+          if (edge.owner !== owner || edge.name !== current || edge.at > cursor) continue;
           if (!best || edge.at > best.at) best = edge;
         }
         if (best) {
-          next = best.target;
+          found = best;
           break;
         }
       }
-      if (next === undefined) return current;
-      current = next;
+      if (!found) return current;
+      current = found.target;
+      cursor = found.at;
     }
   };
 

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -153,6 +153,7 @@ export function scanRuleStateReads(
   const exposedKeys = new Map<ts.Node, Map<string, string>>();
   type AliasEdge = { owner: ts.Node; name: string; target: string; at: number };
   const aliasEdges: AliasEdge[] = [];
+  const declaredIn = new Map<ts.Node, Set<string>>();
   const rawExposures: Array<{
     handle: string;
     key: ts.Expression;
@@ -179,15 +180,21 @@ export function scanRuleStateReads(
 
   const collectExposedKeys = (node: ts.Node, chain: ts.Node[]): void => {
     const nextChain = introducesScope(node) ? [node, ...chain] : chain;
-    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
-      const initializer = unwrap(node.initializer);
-      if (ts.isIdentifier(initializer)) {
-        aliasEdges.push({
-          owner: nextChain[0] ?? source,
-          name: node.name.text,
-          target: initializer.text,
-          at: node.getStart(),
-        });
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+      const owner = nextChain[0] ?? source;
+      const names = declaredIn.get(owner) ?? new Set<string>();
+      names.add(node.name.text);
+      declaredIn.set(owner, names);
+      if (node.initializer) {
+        const initializer = unwrap(node.initializer);
+        if (ts.isIdentifier(initializer)) {
+          aliasEdges.push({
+            owner,
+            name: node.name.text,
+            target: initializer.text,
+            at: node.getStart(),
+          });
+        }
       }
     }
     // A plain reassignment moves the handle just as a declaration does.
@@ -198,12 +205,15 @@ export function scanRuleStateReads(
     ) {
       const value = unwrap(node.right);
       if (ts.isIdentifier(value)) {
-        aliasEdges.push({
-          owner: nextChain[0] ?? source,
-          name: node.left.text,
-          target: value.text,
-          at: node.getStart(),
-        });
+        // An assignment does not declare, so it belongs to whichever scope owns
+        // the binding; otherwise a reassignment inside a nested block would be
+        // invisible to an exposure written outside it.
+        const left = node.left.text;
+        const owner =
+          [...nextChain, source].find((candidate) => declaredIn.get(candidate)?.has(left)) ??
+          nextChain[0] ??
+          source;
+        aliasEdges.push({ owner, name: left, target: value.text, at: node.getStart() });
       }
     }
     if (ts.isCallExpression(node)) {

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -154,6 +154,32 @@ export function scanRuleStateReads(
   type AliasEdge = { owner: ts.Node; name: string; target: string; at: number };
   const aliasEdges: AliasEdge[] = [];
   const declaredIn = new Map<ts.Node, Set<string>>();
+  const objectMembers = new Map<string, Map<string, string>>();
+
+  /** Every handle an initializer may name; a conditional contributes both. */
+  const aliasTargets = (node: ts.Node): string[] => {
+    const value = unwrap(node);
+    if (ts.isIdentifier(value)) return [value.text];
+    if (ts.isConditionalExpression(value)) {
+      return [...aliasTargets(value.whenTrue), ...aliasTargets(value.whenFalse)];
+    }
+    return [];
+  };
+
+  const resolveHandleIdentifier = (node: ts.Node): string | null => {
+    const value = unwrap(node);
+    if (ts.isIdentifier(value)) return value.text;
+    const owner = ownerOf(value);
+    if (!owner) return null;
+    const base = unwrap(owner);
+    if (!ts.isIdentifier(base)) return null;
+    const members = objectMembers.get(base.text);
+    if (!members) return null;
+    for (const [key, target] of members) {
+      if (memberNamed(value, key)) return target;
+    }
+    return null;
+  };
   const rawExposures: Array<{
     handle: string;
     key: ts.Expression;
@@ -181,19 +207,41 @@ export function scanRuleStateReads(
   const collectExposedKeys = (node: ts.Node, chain: ts.Node[]): void => {
     const nextChain = introducesScope(node) ? [node, ...chain] : chain;
     if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
-      const owner = nextChain[0] ?? source;
+      // `var` binds to the enclosing function however deeply it is nested.
+      const isVar =
+        ts.isVariableDeclarationList(node.parent) &&
+        !(node.parent.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const));
+      const enclosingFunction = isVar
+        ? ts.findAncestor(node, (candidate): candidate is ts.FunctionLikeDeclaration =>
+            ts.isFunctionLike(candidate)
+          )
+        : undefined;
+      const enclosingBody = enclosingFunction?.body;
+      const owner =
+        (enclosingBody && nextChain.includes(enclosingBody) ? enclosingBody : nextChain[0]) ??
+        source;
       const names = declaredIn.get(owner) ?? new Set<string>();
       names.add(node.name.text);
       declaredIn.set(owner, names);
       if (node.initializer) {
-        const initializer = unwrap(node.initializer);
-        if (ts.isIdentifier(initializer)) {
-          aliasEdges.push({
-            owner,
-            name: node.name.text,
-            target: initializer.text,
-            at: node.getStart(),
-          });
+        const literal = unwrap(node.initializer);
+        if (ts.isObjectLiteralExpression(literal)) {
+          const members = new Map<string, string>();
+          for (const property of literal.properties) {
+            if (ts.isShorthandPropertyAssignment(property)) {
+              members.set(property.name.text, property.name.text);
+            } else if (
+              ts.isPropertyAssignment(property) &&
+              (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name))
+            ) {
+              const value = unwrap(property.initializer);
+              if (ts.isIdentifier(value)) members.set(property.name.text, value.text);
+            }
+          }
+          objectMembers.set(node.name.text, members);
+        }
+        for (const target of aliasTargets(node.initializer)) {
+          aliasEdges.push({ owner, name: node.name.text, target, at: node.getStart() });
         }
       }
     }
@@ -203,17 +251,16 @@ export function scanRuleStateReads(
       node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
       ts.isIdentifier(node.left)
     ) {
-      const value = unwrap(node.right);
-      if (ts.isIdentifier(value)) {
-        // An assignment does not declare, so it belongs to whichever scope owns
-        // the binding; otherwise a reassignment inside a nested block would be
-        // invisible to an exposure written outside it.
-        const left = node.left.text;
-        const owner =
-          [...nextChain, source].find((candidate) => declaredIn.get(candidate)?.has(left)) ??
-          nextChain[0] ??
-          source;
-        aliasEdges.push({ owner, name: left, target: value.text, at: node.getStart() });
+      // An assignment does not declare, so it belongs to whichever scope owns
+      // the binding; otherwise a reassignment inside a nested block would be
+      // invisible to an exposure written outside it.
+      const left = node.left.text;
+      const assignOwner =
+        [...nextChain, source].find((candidate) => declaredIn.get(candidate)?.has(left)) ??
+        nextChain[0] ??
+        source;
+      for (const target of aliasTargets(node.right)) {
+        aliasEdges.push({ owner: assignOwner, name: left, target, at: node.getStart() });
       }
     }
     if (ts.isCallExpression(node)) {
@@ -224,10 +271,10 @@ export function scanRuleStateReads(
       const exposesDirectly = memberNamed(callee, 'expose');
       if (exposesState || exposesDirectly) {
         const [nameArg, handleArg] = node.arguments;
-        const handle = handleArg && unwrap(handleArg);
-        if (nameArg && handle && ts.isIdentifier(handle)) {
+        const handle = handleArg && resolveHandleIdentifier(handleArg);
+        if (nameArg && handle) {
           rawExposures.push({
-            handle: handle.text,
+            handle,
             key: nameArg,
             chain: [...nextChain, source],
             at: node.getStart(),
@@ -239,39 +286,35 @@ export function scanRuleStateReads(
   };
   collectExposedKeys(source, []);
 
-  const aliasRoot = (name: string, chain: ts.Node[], at: number): string => {
-    const seen = new Set<string>();
-    let current = name;
-    // Each hop resolves where that edge was created, not where the exposure was
-    // written, so a later redeclaration of an intermediate name cannot retarget
-    // an alias that had already captured its value.
-    let cursor = at;
-    for (;;) {
-      if (seen.has(current)) return current;
-      seen.add(current);
-      let found: AliasEdge | null = null;
-      for (const owner of chain) {
-        let best: AliasEdge | null = null;
-        for (const edge of aliasEdges) {
-          if (edge.owner !== owner || edge.name !== current || edge.at > cursor) continue;
-          if (!best || edge.at > best.at) best = edge;
-        }
-        if (best) {
-          found = best;
-          break;
-        }
-      }
-      if (!found) return current;
-      current = found.target;
-      cursor = found.at;
+  // Fans out rather than picking one edge, so a conditional alias gives every
+  // candidate handle its variant.
+  const aliasRoots = (
+    name: string,
+    chain: ts.Node[],
+    at: number,
+    seen = new Set<string>()
+  ): string[] => {
+    if (seen.has(name)) return [name];
+    let found: AliasEdge[] = [];
+    for (const owner of chain) {
+      const candidates = aliasEdges.filter(
+        (edge) => edge.owner === owner && edge.name === name && edge.at <= at
+      );
+      if (candidates.length === 0) continue;
+      const latest = Math.max(...candidates.map((edge) => edge.at));
+      found = candidates.filter((edge) => edge.at === latest);
+      break;
     }
+    if (found.length === 0) return [name];
+    const next = new Set([...seen, name]);
+    return found.flatMap((edge) => aliasRoots(edge.target, chain, edge.at, next));
   };
 
   for (const { handle, key, chain, at } of rawExposures) {
     // A key the scanner cannot read still means the state is exposed, and the
     // attribute comes from the declared name anyway.
     const text = ts.isStringLiteralLike(key) ? key.text : '';
-    for (const name of new Set([handle, aliasRoot(handle, chain, at)])) {
+    for (const name of new Set([handle, ...aliasRoots(handle, chain, at)])) {
       for (const owner of chain) {
         const scoped = exposedKeys.get(owner) ?? new Map<string, string>();
         if (!scoped.has(name)) scoped.set(name, text);

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -102,6 +102,18 @@ function lookup(scope: Scope | null, name: string): Binding | null {
   return null;
 }
 
+function isLoopStatement(node: ts.Node): boolean {
+  return ts.isForStatement(node) || ts.isForOfStatement(node) || ts.isForInStatement(node);
+}
+
+/** The scope a name is already bound in, so an assignment does not shadow it. */
+function scopeBinding(scope: Scope, name: string): Scope | null {
+  for (let current: Scope | null = scope; current; current = current.parent) {
+    if (current.bindings.has(name)) return current;
+  }
+  return null;
+}
+
 function introducesScope(node: ts.Node): boolean {
   return (
     ts.isSourceFile(node) ||
@@ -219,6 +231,78 @@ export function scanRuleStateReads(
     return [];
   };
 
+  /** The identifier member `key` of an initializer names, if it names one. */
+  const memberTargetName = (
+    initializer: ts.Node,
+    key: string,
+    chain: ts.Node[],
+    at: number
+  ): string | null => {
+    const value = unwrap(initializer);
+    if (ts.isObjectLiteralExpression(value)) {
+      for (const property of value.properties) {
+        if (ts.isShorthandPropertyAssignment(property) && property.name.text === key) return key;
+        if (
+          ts.isPropertyAssignment(property) &&
+          (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name)) &&
+          property.name.text === key
+        ) {
+          const assigned = unwrap(property.initializer);
+          return ts.isIdentifier(assigned) ? assigned.text : null;
+        }
+      }
+      return null;
+    }
+    if (!ts.isIdentifier(value)) return null;
+    for (const scope of chain) {
+      const members = objectMembers.get(scope)?.get(value.text);
+      if (!members) continue;
+      const edges = members.get(key);
+      if (!edges) return null;
+      const visible = edges.filter((edge) => edge.at <= at);
+      if (visible.length === 0) return null;
+      return visible.reduce((latest, edge) => (edge.at > latest.at ? edge : latest)).target;
+    }
+    return null;
+  };
+
+  /**
+   * The handle each name in a binding pattern ends up on. A pattern aliases the
+   * same state object a plain `const publicFlag = flag` does.
+   */
+  const patternTargets = (
+    name: ts.BindingName,
+    initializer: ts.Node,
+    chain: ts.Node[],
+    at: number
+  ): Array<{ name: string; target: string }> => {
+    const out: Array<{ name: string; target: string }> = [];
+    if (ts.isObjectBindingPattern(name)) {
+      for (const element of name.elements) {
+        if (!ts.isIdentifier(element.name) || element.dotDotDotToken) continue;
+        const property = element.propertyName ?? element.name;
+        const key =
+          ts.isIdentifier(property) || ts.isStringLiteralLike(property) ? property.text : null;
+        if (!key) continue;
+        const target = memberTargetName(initializer, key, chain, at);
+        if (target) out.push({ name: element.name.text, target });
+      }
+      return out;
+    }
+    if (!ts.isArrayBindingPattern(name)) return out;
+    const values = unwrap(initializer);
+    if (!ts.isArrayLiteralExpression(values)) return out;
+    name.elements.forEach((element, index) => {
+      if (ts.isOmittedExpression(element)) return;
+      if (!ts.isIdentifier(element.name) || element.dotDotDotToken) return;
+      const value = values.elements[index] && unwrap(values.elements[index]);
+      if (value && ts.isIdentifier(value)) {
+        out.push({ name: element.name.text, target: value.text });
+      }
+    });
+    return out;
+  };
+
   const resolveHandleIdentifier = (node: ts.Node, chain: ts.Node[], at: number): string | null => {
     const value = unwrap(node);
     if (ts.isIdentifier(value)) return value.text;
@@ -314,6 +398,21 @@ export function scanRuleStateReads(
         for (const target of aliasTargets(node.initializer)) {
           aliasEdges.push({ owner, name: node.name.text, target, at: node.getStart() });
         }
+      }
+    }
+    if (
+      ts.isVariableDeclaration(node) &&
+      !ts.isIdentifier(node.name) &&
+      node.initializer &&
+      nextChain.length > 0
+    ) {
+      const patternOwner = nextChain[0] ?? source;
+      const at = node.getStart();
+      for (const alias of patternTargets(node.name, node.initializer, nextChain, at)) {
+        const names = declaredIn.get(patternOwner) ?? new Set<string>();
+        names.add(alias.name);
+        declaredIn.set(patternOwner, names);
+        aliasEdges.push({ owner: patternOwner, name: alias.name, target: alias.target, at });
       }
     }
     // Writing through the container moves the handle the same way, so the
@@ -458,13 +557,23 @@ export function scanRuleStateReads(
     scope.bindings.set(name, binding);
   };
 
-  const declareFromInitializer = (declaration: ts.VariableDeclaration, scope: Scope): void => {
-    if (!declaration.initializer) return;
-    const bag = bagHook(declaration.initializer, scope);
+  /**
+   * Binds `name` to whatever `initializer` names. A declaration and a plain
+   * reassignment reach the same runtime handle, so both come through here; the
+   * assignment declares in the scope that already owns the name while still
+   * resolving its right-hand side where it was written.
+   */
+  const declareValue = (
+    name: ts.BindingName,
+    initializer: ts.Expression,
+    scope: Scope,
+    lookupScope: Scope = scope
+  ): void => {
+    const bag = bagHook(initializer, lookupScope);
 
     if (bag) {
-      if (ts.isObjectBindingPattern(declaration.name)) {
-        for (const element of declaration.name.elements) {
+      if (ts.isObjectBindingPattern(name)) {
+        for (const element of name.elements) {
           const property = element.propertyName ?? element.name;
           if (ts.isIdentifier(element.name) && ts.isIdentifier(property)) {
             declare(scope, element.name.text, {
@@ -474,21 +583,21 @@ export function scanRuleStateReads(
             });
           }
         }
-      } else if (ts.isIdentifier(declaration.name)) {
-        declare(scope, declaration.name.text, { kind: 'handleBag', hook: bag });
+      } else if (ts.isIdentifier(name)) {
+        declare(scope, name.text, { kind: 'handleBag', hook: bag });
       }
       return;
     }
 
     // `const checked = asHook().stateHandles.checked` and `= bag.checked`
-    const initializer = unwrap(declaration.initializer);
-    if (ts.isPropertyAccessExpression(initializer) && ts.isIdentifier(declaration.name)) {
-      const owner = bagHook(initializer.expression, scope);
+    const value = unwrap(initializer);
+    if (ts.isPropertyAccessExpression(value) && ts.isIdentifier(name)) {
+      const owner = bagHook(value.expression, lookupScope);
       if (owner) {
-        declare(scope, declaration.name.text, {
+        declare(scope, name.text, {
           kind: 'handle',
           hook: owner,
-          state: initializer.name.text,
+          state: value.name.text,
         });
         return;
       }
@@ -496,39 +605,52 @@ export function scanRuleStateReads(
 
     // `const hidden = def.state.bool('hidden', true)` — a prototype-owned state.
     if (
-      ts.isCallExpression(initializer) &&
-      ts.isPropertyAccessExpression(initializer.expression) &&
-      ts.isPropertyAccessExpression(initializer.expression.expression) &&
-      initializer.expression.expression.name.text === 'state' &&
-      ts.isIdentifier(declaration.name)
+      ts.isCallExpression(value) &&
+      ts.isPropertyAccessExpression(value.expression) &&
+      ts.isPropertyAccessExpression(value.expression.expression) &&
+      value.expression.expression.name.text === 'state' &&
+      ts.isIdentifier(name)
     ) {
-      const declaredArgument = initializer.arguments[0];
-      declare(scope, declaration.name.text, {
+      const declaredArgument = value.arguments[0];
+      declare(scope, name.text, {
         kind: 'localState',
         // `null` means the declaration exists but its runtime name cannot be
         // read here, which is not the same as having no declaration at all.
         // A constant the extractor resolves has to resolve here too, or the
         // gate reports a blind spot production does not have.
-        declaredAs: declaredArgument ? constantStringValue(declaredArgument, scope) : null,
-        exposedAs: exposureFor(declaration.name.text, scope),
+        declaredAs: declaredArgument ? constantStringValue(declaredArgument, lookupScope) : null,
+        exposedAs: exposureFor(name.text, scope),
       });
       return;
     }
 
-    const hook = hookOfCall(declaration.initializer);
-    if (hook && ts.isIdentifier(declaration.name)) {
-      declare(scope, declaration.name.text, { kind: 'hookResult', hook });
+    const hook = hookOfCall(initializer);
+    if (hook && ts.isIdentifier(name)) {
+      declare(scope, name.text, { kind: 'hookResult', hook });
       return;
+    }
+
+    // `let current = first` names the same handle `first` does, and production
+    // resolves the alias, so a rule reading the alias is not a blind spot.
+    if (ts.isIdentifier(value) && ts.isIdentifier(name)) {
+      const aliased = lookup(lookupScope, value.text);
+      if (aliased && aliased.kind !== 'token' && aliased.kind !== 'tokenImport') {
+        declare(
+          scope,
+          name.text,
+          aliased.kind === 'localState'
+            ? { ...aliased, exposedAs: exposureFor(name.text, scope) ?? aliased.exposedAs }
+            : aliased
+        );
+        return;
+      }
     }
 
     // Anything else a name can hold is a candidate token value. Keeping it in
     // the same scope chain means two blocks may each declare `TOKENS` without
     // either becoming ambiguous, which is what the extractor's scopes do.
-    if (ts.isIdentifier(declaration.name)) {
-      declare(scope, declaration.name.text, {
-        kind: 'token',
-        initializer: declaration.initializer,
-      });
+    if (ts.isIdentifier(name)) {
+      declare(scope, name.text, { kind: 'token', initializer });
     }
   };
 
@@ -1078,9 +1200,6 @@ export function scanRuleStateReads(
       ? { parent: scope, bindings: new Map<string, Binding>(), node }
       : scope;
 
-    // The extractor registers declarations while iterating the variable
-    // statements of a statement-bearing scope, so a loop initializer or a
-    // catch binding never reaches it.
     // A parameter shadows whatever the enclosing scopes bound to that name. Its
     // own origin cannot be recovered from the source, so it resolves to nothing
     // rather than falling through to an outer handle of the same name.
@@ -1091,14 +1210,27 @@ export function scanRuleStateReads(
       }
     }
 
+    // A statement, or a loop initializer, which production registers in the
+    // loop's own scope. A catch binding still reaches neither.
     if (
       ts.isVariableDeclaration(node) &&
       node.parent &&
       ts.isVariableDeclarationList(node.parent) &&
       node.parent.parent &&
-      ts.isVariableStatement(node.parent.parent)
+      (ts.isVariableStatement(node.parent.parent) || isLoopStatement(node.parent.parent))
     ) {
-      declareFromInitializer(node, current);
+      if (node.initializer) declareValue(node.name, node.initializer, current);
+    }
+
+    // A reassignment moves the handle for every read that follows it.
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(node.left)
+    ) {
+      const name = node.left.text;
+      const owner = scopeBinding(current, name) ?? current;
+      declareValue(node.left, node.right, owner, current);
     }
 
     if (

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -86,7 +86,12 @@ type Binding =
       alternatives?: LocalStateBinding[];
     })
   /** A value a `tw(...)` argument may name, resolved where it was declared. */
-  | { kind: 'token'; initializer: ts.Expression }
+  | {
+      kind: 'token';
+      initializer: ts.Expression;
+      /** Members written after the declaration, latest candidates first. */
+      members?: Map<string, ts.Expression[]>;
+    }
   /** A named import; only a relative one is something the extractor follows. */
   | { kind: 'tokenImport'; specifier: string; imported: string; from?: string }
   /** A parameter: it shadows an outer name and its origin is not recoverable. */
@@ -827,8 +832,9 @@ export function scanRuleStateReads(
         });
       }
       for (const { target, key } of bound) {
-        const held = containerMember(initializer, key, lookupScope);
-        if (held) declareValue(target, held, scope, lookupScope);
+        const held = containerMembers(initializer, key, lookupScope);
+        // A pattern binds one name, so several candidates leave it ambiguous.
+        if (held.length === 1) declareValue(target, held[0], scope, lookupScope);
       }
       return;
     }
@@ -956,13 +962,17 @@ export function scanRuleStateReads(
       }
       return null;
     }
-    if (ts.isPropertyAccessExpression(argument)) {
-      const owner = bagHook(argument.expression, scope);
-      if (owner) return [{ hook: owner, state: argument.name.text }];
+    if (ts.isPropertyAccessExpression(argument) || ts.isElementAccessExpression(argument)) {
+      if (ts.isPropertyAccessExpression(argument)) {
+        const owner = bagHook(argument.expression, scope);
+        if (owner) return [{ hook: owner, state: argument.name.text }];
+      }
       // `const controls = { ready: flag }` — production reads the container the
       // same way it reads an `asHook` bag, so this is not a blind spot.
       const held = memberOfHandleObject(argument, scope);
-      if (held) return readState(held, scope);
+      if (held.length === 0) return null;
+      const reads = held.map((expression) => readState(expression, scope));
+      return reads.some((read) => read === null) ? null : (reads.flat() as StateRead[]);
     }
     return null;
   };
@@ -972,47 +982,51 @@ export function scanRuleStateReads(
    * index is its position, which is what a positional pattern binds. Following
    * a name is bounded so a self-referential constant cannot loop.
    */
-  const containerMember = (
+  const containerMembers = (
     node: ts.Node,
     key: string,
     scope: Scope,
     seen = new Set<string>()
-  ): ts.Expression | null => {
+  ): ts.Expression[] => {
     const value = unwrap(node);
     if (ts.isObjectLiteralExpression(value)) {
       for (const property of value.properties) {
         if (ts.isShorthandPropertyAssignment(property) && property.name.text === key) {
-          return property.name;
+          return [property.name];
         }
         if (
           ts.isPropertyAssignment(property) &&
           (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name)) &&
           property.name.text === key
         ) {
-          return property.initializer;
+          return [property.initializer];
         }
       }
-      return null;
+      return [];
     }
     if (ts.isArrayLiteralExpression(value)) {
       const index = Number(key);
-      if (!Number.isInteger(index) || index < 0) return null;
+      if (!Number.isInteger(index) || index < 0) return [];
       const element = value.elements[index];
-      return element && !ts.isOmittedExpression(element) ? element : null;
+      return element && !ts.isOmittedExpression(element) ? [element] : [];
     }
     if (ts.isIdentifier(value) && !seen.has(value.text)) {
       const binding = lookup(scope, value.text);
       if (binding?.kind === 'token') {
-        return containerMember(binding.initializer, key, scope, new Set([...seen, value.text]));
+        // A write through the container replaces what the declaration named.
+        const written = binding.members?.get(key);
+        if (written && written.length > 0) return written;
+        return containerMembers(binding.initializer, key, scope, new Set([...seen, value.text]));
       }
     }
-    return null;
+    return [];
   };
 
-  const memberOfHandleObject = (
-    node: ts.PropertyAccessExpression,
-    scope: Scope
-  ): ts.Expression | null => containerMember(node.expression, node.name.text, scope);
+  const memberOfHandleObject = (node: ts.Node, scope: Scope): ts.Expression[] => {
+    const owner = ownerOf(node);
+    const key = memberNameOf(node);
+    return owner && key !== null ? containerMembers(owner, key, scope) : [];
+  };
 
   /**
    * The extractor's `resolveStateEqVariant` lowers exactly three right-hand
@@ -1536,6 +1550,30 @@ export function scanRuleStateReads(
       // is where production registers it too.
       const owner = isVarList(node.parent) ? functionScope(current) : current;
       if (node.initializer) declareValue(node.name, node.initializer, owner, current);
+    }
+
+    // Writing through the container moves the member for every read after it.
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      (ts.isPropertyAccessExpression(node.left) || ts.isElementAccessExpression(node.left))
+    ) {
+      const base = unwrap(ownerOf(node.left) ?? node.left);
+      const member = memberNameOf(node.left);
+      if (ts.isIdentifier(base) && member !== null) {
+        const owner = scopeBinding(current, base.text) ?? current;
+        const container = owner.bindings.get(base.text);
+        if (container?.kind === 'token') {
+          // Before the first write the member still lives in the declaration.
+          const previous =
+            container.members?.get(member) ??
+            containerMembers(container.initializer, member, current);
+          const kept = isConditionallyReached(node) ? previous : [];
+          const members = new Map(container.members ?? []);
+          members.set(member, [node.right, ...kept]);
+          declare(owner, base.text, { ...container, members });
+        }
+      }
     }
 
     // A reassignment moves the handle for every read that follows it.

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -102,6 +102,100 @@ function lookup(scope: Scope | null, name: string): Binding | null {
   return null;
 }
 
+/**
+ * Whether a write may be skipped at runtime. A branch the source decides
+ * statically executes exactly as written; anything else has to keep whatever
+ * the name held before it.
+ */
+function isConditionallyReached(node: ts.Node): boolean {
+  for (
+    let child: ts.Node = node, parent = node.parent;
+    parent;
+    child = parent, parent = parent.parent
+  ) {
+    if (ts.isFunctionLike(parent)) return false;
+    if (ts.isIfStatement(parent)) {
+      if (child === parent.expression) continue;
+      if (child === parent.thenStatement && parent.expression.kind === ts.SyntaxKind.TrueKeyword) {
+        continue;
+      }
+      if (child === parent.elseStatement && parent.expression.kind === ts.SyntaxKind.FalseKeyword) {
+        continue;
+      }
+      return true;
+    }
+    if (ts.isConditionalExpression(parent)) {
+      if (child !== parent.condition) return true;
+      continue;
+    }
+    if (
+      ts.isSwitchStatement(parent) ||
+      ts.isCaseBlock(parent) ||
+      ts.isCaseClause(parent) ||
+      ts.isDefaultClause(parent) ||
+      ts.isTryStatement(parent) ||
+      ts.isCatchClause(parent)
+    ) {
+      return true;
+    }
+    if (
+      ts.isForStatement(parent) ||
+      ts.isForOfStatement(parent) ||
+      ts.isForInStatement(parent) ||
+      ts.isWhileStatement(parent)
+    ) {
+      if (child === parent.statement) return true;
+      continue;
+    }
+    if (ts.isBinaryExpression(parent)) {
+      const operator = parent.operatorToken.kind;
+      const shortCircuits =
+        operator === ts.SyntaxKind.AmpersandAmpersandToken ||
+        operator === ts.SyntaxKind.BarBarToken ||
+        operator === ts.SyntaxKind.QuestionQuestionToken;
+      if (shortCircuits && child === parent.right) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Every edge at the latest position at or before `at`, plus everything an
+ * earlier position still contributes because the later write may be skipped.
+ */
+function visibleEdges<T extends { at: number; conditional?: boolean }>(
+  edges: T[],
+  at: number
+): T[] {
+  const candidates = edges.filter((edge) => edge.at <= at);
+  if (candidates.length === 0) return [];
+  const positions = [...new Set(candidates.map((edge) => edge.at))].sort((a, b) => b - a);
+  const selected: T[] = [];
+  for (const position of positions) {
+    const group = candidates.filter((edge) => edge.at === position);
+    selected.push(...group);
+    if (!group.every((edge) => edge.conditional)) break;
+  }
+  return selected;
+}
+
+/** `var` binds to the function however deeply the declaration is nested. */
+function functionScope(scope: Scope): Scope {
+  for (let current: Scope | null = scope; current; current = current.parent) {
+    const node = current.node;
+    if (!node || !current.parent) return current;
+    if (ts.isSourceFile(node) || ts.isFunctionLike(node)) return current;
+    if (node.parent && ts.isFunctionLike(node.parent)) return current;
+  }
+  return scope;
+}
+
+function isVarList(list: ts.Node): boolean {
+  return (
+    ts.isVariableDeclarationList(list) && !(list.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const))
+  );
+}
+
 function isLoopStatement(node: ts.Node): boolean {
   return ts.isForStatement(node) || ts.isForOfStatement(node) || ts.isForInStatement(node);
 }
@@ -186,7 +280,13 @@ export function scanRuleStateReads(
       : node;
 
   const exposedKeys = new Map<ts.Node, Map<string, string>>();
-  type AliasEdge = { owner: ts.Node; name: string; target: string; at: number };
+  type AliasEdge = {
+    owner: ts.Node;
+    name: string;
+    target: string;
+    at: number;
+    conditional: boolean;
+  };
   const aliasEdges: AliasEdge[] = [];
   const declaredIn = new Map<ts.Node, Set<string>>();
 
@@ -204,7 +304,7 @@ export function scanRuleStateReads(
   };
   // Members carry positions for the same reason aliases do: a write through the
   // container retargets the member from there on.
-  type MemberEdge = { target: string; at: number };
+  type MemberEdge = { target: string; at: number; conditional: boolean };
   const objectMembers = new Map<ts.Node, Map<string, Map<string, MemberEdge[]>>>();
 
   /** Every member an object literal names, at the position it was written. */
@@ -212,17 +312,18 @@ export function scanRuleStateReads(
     owner: ts.Node,
     base: string,
     literal: ts.ObjectLiteralExpression,
-    at: number
+    at: number,
+    conditional: boolean
   ): void => {
     for (const property of literal.properties) {
       if (ts.isShorthandPropertyAssignment(property)) {
-        recordMember(owner, base, property.name.text, property.name.text, at);
+        recordMember(owner, base, property.name.text, property.name.text, at, conditional);
       } else if (
         ts.isPropertyAssignment(property) &&
         (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name))
       ) {
         for (const target of aliasTargets(property.initializer)) {
-          recordMember(owner, base, property.name.text, target, at);
+          recordMember(owner, base, property.name.text, target, at, conditional);
         }
       }
     }
@@ -233,11 +334,12 @@ export function scanRuleStateReads(
     base: string,
     key: string,
     target: string,
-    at: number
+    at: number,
+    conditional: boolean
   ): void => {
     const scoped = objectMembers.get(owner) ?? new Map<string, Map<string, MemberEdge[]>>();
     const members = scoped.get(base) ?? new Map<string, MemberEdge[]>();
-    members.set(key, [...(members.get(key) ?? []), { target, at }]);
+    members.set(key, [...(members.get(key) ?? []), { target, at, conditional }]);
     scoped.set(base, members);
     objectMembers.set(owner, scoped);
   };
@@ -258,18 +360,20 @@ export function scanRuleStateReads(
     key: string,
     chain: ts.Node[],
     at: number
-  ): string | null => {
+  ): { target: string; at: number } | null => {
     const value = unwrap(initializer);
     if (ts.isObjectLiteralExpression(value)) {
       for (const property of value.properties) {
-        if (ts.isShorthandPropertyAssignment(property) && property.name.text === key) return key;
+        if (ts.isShorthandPropertyAssignment(property) && property.name.text === key) {
+          return { target: key, at };
+        }
         if (
           ts.isPropertyAssignment(property) &&
           (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name)) &&
           property.name.text === key
         ) {
           const assigned = unwrap(property.initializer);
-          return ts.isIdentifier(assigned) ? assigned.text : null;
+          return ts.isIdentifier(assigned) ? { target: assigned.text, at } : null;
         }
       }
       return null;
@@ -280,9 +384,9 @@ export function scanRuleStateReads(
       if (!members) continue;
       const edges = members.get(key);
       if (!edges) return null;
-      const targets = latestTargets(edges, at);
-      // A pattern binds one name, so a conditional member leaves it ambiguous.
-      return targets.length === 1 ? targets[0] : null;
+      const visible = visibleEdges(edges, at);
+      // A pattern binds one name, so several candidates leave it ambiguous.
+      return visible.length === 1 ? { target: visible[0].target, at: visible[0].at } : null;
     }
     return null;
   };
@@ -296,8 +400,8 @@ export function scanRuleStateReads(
     initializer: ts.Node,
     chain: ts.Node[],
     at: number
-  ): Array<{ name: string; target: string }> => {
-    const out: Array<{ name: string; target: string }> = [];
+  ): Array<{ name: string; target: string; at: number }> => {
+    const out: Array<{ name: string; target: string; at: number }> = [];
     if (ts.isObjectBindingPattern(name)) {
       for (const element of name.elements) {
         if (!ts.isIdentifier(element.name) || element.dotDotDotToken) continue;
@@ -305,8 +409,8 @@ export function scanRuleStateReads(
         const key =
           ts.isIdentifier(property) || ts.isStringLiteralLike(property) ? property.text : null;
         if (!key) continue;
-        const target = memberTargetName(initializer, key, chain, at);
-        if (target) out.push({ name: element.name.text, target });
+        const resolved = memberTargetName(initializer, key, chain, at);
+        if (resolved) out.push({ name: element.name.text, ...resolved });
       }
       return out;
     }
@@ -318,24 +422,23 @@ export function scanRuleStateReads(
       if (!ts.isIdentifier(element.name) || element.dotDotDotToken) return;
       const value = values.elements[index] && unwrap(values.elements[index]);
       if (value && ts.isIdentifier(value)) {
-        out.push({ name: element.name.text, target: value.text });
+        out.push({ name: element.name.text, target: value.text, at });
       }
     });
     return out;
   };
 
-  /** Every edge written at the latest position at or before `at`. */
-  const latestTargets = (edges: MemberEdge[], at: number): string[] => {
-    const visible = edges.filter((edge) => edge.at <= at);
-    if (visible.length === 0) return [];
-    const latest = Math.max(...visible.map((edge) => edge.at));
-    return visible.filter((edge) => edge.at === latest).map((edge) => edge.target);
-  };
-
-  /** The handles an expose argument may name; a conditional member gives both. */
-  const resolveHandleNames = (node: ts.Node, chain: ts.Node[], at: number): string[] => {
+  /**
+   * The handles an expose argument may name, each with the position its own
+   * edge was written at: a member captured whatever its target named then.
+   */
+  const resolveHandleNames = (
+    node: ts.Node,
+    chain: ts.Node[],
+    at: number
+  ): Array<{ name: string; at: number }> => {
     const value = unwrap(node);
-    if (ts.isIdentifier(value)) return [value.text];
+    if (ts.isIdentifier(value)) return [{ name: value.text, at }];
     const owner = ownerOf(value);
     if (!owner) return [];
     const base = unwrap(owner);
@@ -345,17 +448,16 @@ export function scanRuleStateReads(
       if (!members) continue;
       for (const [key, edges] of members) {
         if (!memberNamed(value, key)) continue;
-        return latestTargets(edges, at);
+        return visibleEdges(edges, at).map((edge) => ({ name: edge.target, at: edge.at }));
       }
       return [];
     }
     return [];
   };
   const rawExposures: Array<{
-    handles: string[];
+    handles: Array<{ name: string; at: number }>;
     key: ts.Expression;
     chain: ts.Node[];
-    at: number;
   }> = [];
 
   const memberNamed = (node: ts.Node, name: string): boolean => {
@@ -407,11 +509,18 @@ export function scanRuleStateReads(
       declaredIn.set(owner, names);
       if (node.initializer) {
         const literal = unwrap(node.initializer);
+        const conditional = isConditionallyReached(node);
         if (ts.isObjectLiteralExpression(literal)) {
-          recordObjectLiteral(owner, node.name.text, literal, node.getStart());
+          recordObjectLiteral(owner, node.name.text, literal, node.getStart(), conditional);
         }
         for (const target of aliasTargets(node.initializer)) {
-          aliasEdges.push({ owner, name: node.name.text, target, at: node.getStart() });
+          aliasEdges.push({
+            owner,
+            name: node.name.text,
+            target,
+            at: node.getStart(),
+            conditional,
+          });
         }
       }
     }
@@ -423,11 +532,18 @@ export function scanRuleStateReads(
     ) {
       const patternOwner = nextChain[0] ?? source;
       const at = node.getStart();
+      const conditional = isConditionallyReached(node);
       for (const alias of patternTargets(node.name, node.initializer, nextChain, at)) {
         const names = declaredIn.get(patternOwner) ?? new Set<string>();
         names.add(alias.name);
         declaredIn.set(patternOwner, names);
-        aliasEdges.push({ owner: patternOwner, name: alias.name, target: alias.target, at });
+        aliasEdges.push({
+          owner: patternOwner,
+          name: alias.name,
+          target: alias.target,
+          at: alias.at,
+          conditional,
+        });
       }
     }
     // Writing through the container moves the handle the same way, so the
@@ -444,8 +560,9 @@ export function scanRuleStateReads(
           [...nextChain, source].find((candidate) => declaredIn.get(candidate)?.has(base.text)) ??
           nextChain[0] ??
           source;
+        const conditional = isConditionallyReached(node);
         for (const target of aliasTargets(node.right)) {
-          recordMember(memberOwnerScope, base.text, member, target, node.getStart());
+          recordMember(memberOwnerScope, base.text, member, target, node.getStart(), conditional);
         }
       }
     }
@@ -463,12 +580,19 @@ export function scanRuleStateReads(
         [...nextChain, source].find((candidate) => declaredIn.get(candidate)?.has(left)) ??
         nextChain[0] ??
         source;
+      const conditional = isConditionallyReached(node);
       const replacement = unwrap(node.right);
       if (ts.isObjectLiteralExpression(replacement)) {
-        recordObjectLiteral(assignOwner, left, replacement, node.getStart());
+        recordObjectLiteral(assignOwner, left, replacement, node.getStart(), conditional);
       }
       for (const target of aliasTargets(node.right)) {
-        aliasEdges.push({ owner: assignOwner, name: left, target, at: node.getStart() });
+        aliasEdges.push({
+          owner: assignOwner,
+          name: left,
+          target,
+          at: node.getStart(),
+          conditional,
+        });
       }
     }
     if (ts.isCallExpression(node)) {
@@ -483,12 +607,7 @@ export function scanRuleStateReads(
           ? resolveHandleNames(handleArg, [...nextChain, source], node.getStart())
           : [];
         if (nameArg && handles.length > 0) {
-          rawExposures.push({
-            handles,
-            key: nameArg,
-            chain: [...nextChain, source],
-            at: node.getStart(),
-          });
+          rawExposures.push({ handles, key: nameArg, chain: [...nextChain, source] });
         }
       }
     }
@@ -507,12 +626,9 @@ export function scanRuleStateReads(
     if (seen.has(name)) return [name];
     let found: AliasEdge[] = [];
     for (const owner of chain) {
-      const candidates = aliasEdges.filter(
-        (edge) => edge.owner === owner && edge.name === name && edge.at <= at
-      );
+      const candidates = aliasEdges.filter((edge) => edge.owner === owner && edge.name === name);
       if (candidates.length === 0) continue;
-      const latest = Math.max(...candidates.map((edge) => edge.at));
-      found = candidates.filter((edge) => edge.at === latest);
+      found = visibleEdges(candidates, at);
       break;
     }
     if (found.length === 0) return [name];
@@ -526,12 +642,12 @@ export function scanRuleStateReads(
   const declaringScope = (name: string, chain: ts.Node[]): ts.Node | undefined =>
     chain.find((candidate) => declaredIn.get(candidate)?.has(name)) ?? chain[chain.length - 1];
 
-  for (const { handles, key, chain, at } of rawExposures) {
+  for (const { handles, key, chain } of rawExposures) {
     // A key the scanner cannot read still means the state is exposed, and the
     // attribute comes from the declared name anyway.
     const text = ts.isStringLiteralLike(key) ? key.text : '';
     for (const name of new Set(
-      handles.flatMap((handle) => [handle, ...aliasRoots(handle, chain, at)])
+      handles.flatMap((handle) => [handle.name, ...aliasRoots(handle.name, chain, handle.at)])
     )) {
       const owner = declaringScope(name, chain);
       if (!owner) continue;
@@ -627,11 +743,13 @@ export function scanRuleStateReads(
     }
 
     // `const hidden = def.state.bool('hidden', true)` — a prototype-owned state.
+    // Production reads the member name statically, so `def.state['bool'](…)`
+    // reaches the same declaration and must not be reported unresolved.
+    const stateOwner = ts.isCallExpression(value) ? ownerOf(unwrap(value.expression)) : null;
     if (
       ts.isCallExpression(value) &&
-      ts.isPropertyAccessExpression(value.expression) &&
-      ts.isPropertyAccessExpression(value.expression.expression) &&
-      value.expression.expression.name.text === 'state' &&
+      stateOwner &&
+      memberNamed(stateOwner, 'state') &&
       ts.isIdentifier(name)
     ) {
       const declaredArgument = value.arguments[0];
@@ -1242,7 +1360,10 @@ export function scanRuleStateReads(
       node.parent.parent &&
       (ts.isVariableStatement(node.parent.parent) || isLoopStatement(node.parent.parent))
     ) {
-      if (node.initializer) declareValue(node.name, node.initializer, current);
+      // `var` is one function-scoped binding however deeply it is nested, which
+      // is where production registers it too.
+      const owner = isVarList(node.parent) ? functionScope(current) : current;
+      if (node.initializer) declareValue(node.name, node.initializer, owner, current);
     }
 
     // A reassignment moves the handle for every read that follows it.

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -764,6 +764,31 @@ export function scanRuleStateReads(
       return;
     }
 
+    // `const { ready: publicFlag } = { ready: flag }` and `const [publicFlag] =
+    // [flag]` name the same handle a plain alias does.
+    if (ts.isObjectBindingPattern(name) || ts.isArrayBindingPattern(name)) {
+      const bound: Array<{ target: ts.Identifier; key: string }> = [];
+      if (ts.isObjectBindingPattern(name)) {
+        for (const element of name.elements) {
+          if (!ts.isIdentifier(element.name) || element.dotDotDotToken) continue;
+          const property = element.propertyName ?? element.name;
+          if (!ts.isIdentifier(property) && !ts.isStringLiteralLike(property)) continue;
+          bound.push({ target: element.name, key: property.text });
+        }
+      } else {
+        name.elements.forEach((element, index) => {
+          if (ts.isOmittedExpression(element)) return;
+          if (!ts.isIdentifier(element.name) || element.dotDotDotToken) return;
+          bound.push({ target: element.name, key: String(index) });
+        });
+      }
+      for (const { target, key } of bound) {
+        const held = containerMember(initializer, key, lookupScope);
+        if (held) declareValue(target, held, scope, lookupScope);
+      }
+      return;
+    }
+
     // `const checked = asHook().stateHandles.checked` and `= bag.checked`
     const value = unwrap(initializer);
     if (ts.isPropertyAccessExpression(value) && ts.isIdentifier(name)) {
@@ -898,31 +923,52 @@ export function scanRuleStateReads(
     return null;
   };
 
-  /** The expression a plain object member holds, if the object is statically known. */
-  const memberOfHandleObject = (
-    node: ts.PropertyAccessExpression,
-    scope: Scope
+  /**
+   * The expression a statically known container holds under `key`. An array
+   * index is its position, which is what a positional pattern binds. Following
+   * a name is bounded so a self-referential constant cannot loop.
+   */
+  const containerMember = (
+    node: ts.Node,
+    key: string,
+    scope: Scope,
+    seen = new Set<string>()
   ): ts.Expression | null => {
-    const owner = unwrap(node.expression);
-    if (!ts.isIdentifier(owner)) return null;
-    const binding = lookup(scope, owner.text);
-    if (binding?.kind !== 'token') return null;
-    const literal = unwrap(binding.initializer);
-    if (!ts.isObjectLiteralExpression(literal)) return null;
-    for (const property of literal.properties) {
-      if (ts.isShorthandPropertyAssignment(property) && property.name.text === node.name.text) {
-        return property.name;
+    const value = unwrap(node);
+    if (ts.isObjectLiteralExpression(value)) {
+      for (const property of value.properties) {
+        if (ts.isShorthandPropertyAssignment(property) && property.name.text === key) {
+          return property.name;
+        }
+        if (
+          ts.isPropertyAssignment(property) &&
+          (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name)) &&
+          property.name.text === key
+        ) {
+          return property.initializer;
+        }
       }
-      if (
-        ts.isPropertyAssignment(property) &&
-        (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name)) &&
-        property.name.text === node.name.text
-      ) {
-        return property.initializer;
+      return null;
+    }
+    if (ts.isArrayLiteralExpression(value)) {
+      const index = Number(key);
+      if (!Number.isInteger(index) || index < 0) return null;
+      const element = value.elements[index];
+      return element && !ts.isOmittedExpression(element) ? element : null;
+    }
+    if (ts.isIdentifier(value) && !seen.has(value.text)) {
+      const binding = lookup(scope, value.text);
+      if (binding?.kind === 'token') {
+        return containerMember(binding.initializer, key, scope, new Set([...seen, value.text]));
       }
     }
     return null;
   };
+
+  const memberOfHandleObject = (
+    node: ts.PropertyAccessExpression,
+    scope: Scope
+  ): ts.Expression | null => containerMember(node.expression, node.name.text, scope);
 
   /**
    * The extractor's `resolveStateEqVariant` lowers exactly three right-hand

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -74,12 +74,17 @@ export type RuleStateScan = {
   exposedLocals: ExposedLocalUsage[];
 };
 
+type LocalStateBinding = { kind: 'localState'; declaredAs: string | null; exposedAs?: string };
+
 type Binding =
   | { kind: 'hookResult'; hook: string }
   | { kind: 'handleBag'; hook: string }
   | { kind: 'handle'; hook: string; state: string }
   /** `def.state.bool(...)` — owned by the prototype, not borrowed from a hook. */
-  | { kind: 'localState'; declaredAs: string | null; exposedAs?: string }
+  | (LocalStateBinding & {
+      /** Handles the name may still hold because a write may be skipped. */
+      alternatives?: LocalStateBinding[];
+    })
   /** A value a `tw(...)` argument may name, resolved where it was declared. */
   | { kind: 'token'; initializer: ts.Expression }
   /** A named import; only a relative one is something the extractor follows. */
@@ -697,6 +702,37 @@ export function scanRuleStateReads(
   };
 
   /**
+   * A write the source may skip leaves the name on either handle, and the
+   * runtime lowers whichever it holds, so a conditional reassignment keeps the
+   * binding it replaces as an alternative instead of discarding it.
+   */
+  const declareConditionally = (
+    scope: Scope,
+    name: string,
+    node: ts.Node,
+    lookupScope: Scope,
+    initializer: ts.Expression
+  ): void => {
+    const previous = scope.bindings.get(name);
+    declareValue(node as ts.BindingName, initializer, scope, lookupScope);
+    const next = scope.bindings.get(name);
+    if (!isConditionallyReached(initializer.parent) || !previous || !next) return;
+    if (next.kind !== 'localState' || previous.kind !== 'localState') return;
+    // Alternatives are flat: a candidate carries no candidates of its own.
+    const bare = (binding: LocalStateBinding): LocalStateBinding => ({
+      kind: 'localState',
+      declaredAs: binding.declaredAs,
+      exposedAs: binding.exposedAs,
+    });
+    const kept = [bare(previous), ...(previous.alternatives ?? [])].filter(
+      (candidate) => candidate.declaredAs !== next.declaredAs
+    );
+    if (kept.length > 0) {
+      declare(scope, name, { ...next, alternatives: [...(next.alternatives ?? []), ...kept] });
+    }
+  };
+
+  /**
    * Binds `name` to whatever `initializer` names. A declaration and a plain
    * reassignment reach the same runtime handle, so both come through here; the
    * assignment declares in the scope that already owns the name while still
@@ -816,33 +852,74 @@ export function scanRuleStateReads(
    * `'local'` means traced to a prototype-owned state, which needs no hook
    * entry and must not be reported either way.
    */
-  const readState = (
-    node: ts.Node,
-    scope: Scope
-  ): HookStateUsage | { exposedLocal: ExposedLocalUsage } | 'local' | null => {
+  type StateRead = HookStateUsage | { exposedLocal: ExposedLocalUsage } | 'local';
+
+  const localStateRead = (binding: LocalStateBinding, state: string): StateRead | null => {
+    if (binding.exposedAs === undefined) return 'local';
+    // The runtime attribute comes from the declared name. If that name is not
+    // statically readable the extractor emits nothing, so substituting the
+    // expose key here would certify a selector that never exists.
+    if (binding.declaredAs === null) return null;
+    return {
+      exposedLocal: {
+        state,
+        exposedAs: binding.exposedAs,
+        attribute: exposedDataAttributeName(binding.declaredAs),
+      },
+    };
+  };
+
+  /**
+   * Every state a `w.state(...)` read may reach. `null` means untraceable; a
+   * name whose write may be skipped reaches more than one, and production emits
+   * a selector for each.
+   */
+  const readState = (node: ts.Node, scope: Scope): StateRead[] | null => {
     const argument = unwrap(node);
     if (ts.isIdentifier(argument)) {
       const binding = lookup(scope, argument.text);
-      if (binding?.kind === 'handle') return { hook: binding.hook, state: binding.state };
+      if (binding?.kind === 'handle') return [{ hook: binding.hook, state: binding.state }];
       if (binding?.kind === 'localState') {
-        if (binding.exposedAs === undefined) return 'local';
-        // The runtime attribute comes from the declared name. If that name is
-        // not statically readable the extractor emits nothing, so substituting
-        // the expose key here would certify a selector that never exists.
-        if (binding.declaredAs === null) return null;
-        return {
-          exposedLocal: {
-            state: argument.text,
-            exposedAs: binding.exposedAs,
-            attribute: exposedDataAttributeName(binding.declaredAs),
-          },
-        };
+        const reads = [binding, ...(binding.alternatives ?? [])].map((candidate) =>
+          localStateRead(candidate, argument.text)
+        );
+        return reads.some((read) => read === null) ? null : (reads as StateRead[]);
       }
       return null;
     }
     if (ts.isPropertyAccessExpression(argument)) {
       const owner = bagHook(argument.expression, scope);
-      if (owner) return { hook: owner, state: argument.name.text };
+      if (owner) return [{ hook: owner, state: argument.name.text }];
+      // `const controls = { ready: flag }` — production reads the container the
+      // same way it reads an `asHook` bag, so this is not a blind spot.
+      const held = memberOfHandleObject(argument, scope);
+      if (held) return readState(held, scope);
+    }
+    return null;
+  };
+
+  /** The expression a plain object member holds, if the object is statically known. */
+  const memberOfHandleObject = (
+    node: ts.PropertyAccessExpression,
+    scope: Scope
+  ): ts.Expression | null => {
+    const owner = unwrap(node.expression);
+    if (!ts.isIdentifier(owner)) return null;
+    const binding = lookup(scope, owner.text);
+    if (binding?.kind !== 'token') return null;
+    const literal = unwrap(binding.initializer);
+    if (!ts.isObjectLiteralExpression(literal)) return null;
+    for (const property of literal.properties) {
+      if (ts.isShorthandPropertyAssignment(property) && property.name.text === node.name.text) {
+        return property.name;
+      }
+      if (
+        ts.isPropertyAssignment(property) &&
+        (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name)) &&
+        property.name.text === node.name.text
+      ) {
+        return property.initializer;
+      }
     }
     return null;
   };
@@ -1130,7 +1207,7 @@ export function scanRuleStateReads(
   };
 
   type Leaf = {
-    usage: HookStateUsage | { exposedLocal: ExposedLocalUsage } | 'local' | null;
+    usages: StateRead[] | null;
     /** The `w.state(...)` argument. */
     subject: string;
     /** The whole `w.state(...).eq(...)` leaf. */
@@ -1256,7 +1333,7 @@ export function scanRuleStateReads(
             receiver.arguments.length === 1
           ) {
             leaves.push({
-              usage: readState(receiver.arguments[0], scope),
+              usages: readState(receiver.arguments[0], scope),
               subject: receiver.arguments[0].getText(source),
               text: node.getText(source),
               comparison: comparisonOf(node.arguments[0]),
@@ -1326,13 +1403,18 @@ export function scanRuleStateReads(
         unresolved.push({ expression: leaf.text, reason: 'comparison' });
         continue;
       }
-      if (leaf.usage === 'local') continue;
-      if (leaf.usage && 'exposedLocal' in leaf.usage) {
-        exposedLocals.push(leaf.usage.exposedLocal);
+      if (!leaf.usages) {
+        unresolved.push({ expression: leaf.subject, reason: 'subject' });
         continue;
       }
-      if (leaf.usage) usages.push(leaf.usage);
-      else unresolved.push({ expression: leaf.subject, reason: 'subject' });
+      for (const read of leaf.usages) {
+        if (read === 'local') continue;
+        if ('exposedLocal' in read) {
+          exposedLocals.push(read.exposedLocal);
+          continue;
+        }
+        usages.push(read);
+      }
     }
   };
 
@@ -1374,7 +1456,7 @@ export function scanRuleStateReads(
     ) {
       const name = node.left.text;
       const owner = scopeBinding(current, name) ?? current;
-      declareValue(node.left, node.right, owner, current);
+      declareConditionally(owner, name, node.left, current, node.right);
     }
 
     if (

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -26,8 +26,14 @@ export type UnresolvedStateRead = {
 export type ExposedLocalUsage = {
   /** The name the prototype declared the state under. */
   state: string;
-  /** The public key it is exposed as, which the Web runtime turns into an attribute. */
+  /** The public key it is exposed as. */
   exposedAs: string;
+  /**
+   * The attribute the Web runtime will use. `ExposeStateWebModuleImpl` maps the
+   * declared name — the state's `__stateSemantic` — before it falls back to the
+   * expose key, so this is derived from the declaration, not the key.
+   */
+  attribute: string;
 };
 
 export type RuleStateScan = {
@@ -54,7 +60,7 @@ type Binding =
   | { kind: 'handleBag'; hook: string }
   | { kind: 'handle'; hook: string; state: string }
   /** `def.state.bool(...)` — owned by the prototype, not borrowed from a hook. */
-  | { kind: 'localState'; exposedAs?: string }
+  | { kind: 'localState'; declaredAs?: string; exposedAs?: string }
   /** A value a `tw(...)` argument may name, resolved where it was declared. */
   | { kind: 'token'; initializer: ts.Expression }
   /** A named import; only a relative one is something the extractor follows. */
@@ -122,6 +128,18 @@ export function scanRuleStateReads(
    * the exposed key into a `data-` attribute and lowers rules on that state, so
    * an exposed local is not the same as a purely internal one.
    */
+  /** The same normalization `createExposeStateWebNameMap` applies. */
+  const exposedDataAttributeName = (key: string): string =>
+    key
+      .trim()
+      .replace(/\s+/g, '-')
+      .replace(/\./g, '-')
+      .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+      .replace(/[^a-zA-Z0-9-]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .toLowerCase();
+
   const exposedKeys = new Map<string, string>();
   const collectExposedKeys = (node: ts.Node): void => {
     if (
@@ -220,8 +238,13 @@ export function scanRuleStateReads(
       initializer.expression.expression.name.text === 'state' &&
       ts.isIdentifier(declaration.name)
     ) {
+      const declaredArgument = initializer.arguments[0];
       declare(scope, declaration.name.text, {
         kind: 'localState',
+        declaredAs:
+          declaredArgument && ts.isStringLiteralLike(declaredArgument)
+            ? declaredArgument.text
+            : undefined,
         exposedAs: exposedKeys.get(declaration.name.text),
       });
       return;
@@ -274,9 +297,14 @@ export function scanRuleStateReads(
       const binding = lookup(scope, argument.text);
       if (binding?.kind === 'handle') return { hook: binding.hook, state: binding.state };
       if (binding?.kind === 'localState') {
-        return binding.exposedAs
-          ? { exposedLocal: { state: argument.text, exposedAs: binding.exposedAs } }
-          : 'local';
+        if (!binding.exposedAs) return 'local';
+        return {
+          exposedLocal: {
+            state: argument.text,
+            exposedAs: binding.exposedAs,
+            attribute: exposedDataAttributeName(binding.declaredAs ?? binding.exposedAs),
+          },
+        };
       }
       return null;
     }

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -421,22 +421,27 @@ export function scanRuleStateReads(
    * either name lands on the same table. A base that may be two different
    * objects is left as itself: there is no single table to move.
    */
-  const containerRoot = (
+  const containerRoots = (
     name: string,
     chain: ts.Node[],
     at: number,
     seen = new Set<string>()
-  ): string => {
-    if (seen.has(name)) return name;
+  ): string[] => {
+    if (seen.has(name)) return [name];
     for (const owner of chain) {
       const candidates = aliasEdges.filter((edge) => edge.owner === owner && edge.name === name);
       if (candidates.length === 0) continue;
       const visible = visibleEdges(candidates, at);
-      if (visible.length !== 1) return name;
-      const [edge] = visible;
-      return containerRoot(edge.target, edge.chain ?? chain, edge.at, new Set([...seen, name]));
+      if (visible.length === 0) return [name];
+      const next = new Set([...seen, name]);
+      // A base that may be either of two objects writes to both tables.
+      return [
+        ...new Set(
+          visible.flatMap((edge) => containerRoots(edge.target, edge.chain ?? chain, edge.at, next))
+        ),
+      ];
     }
-    return name;
+    return [name];
   };
 
   const recordMember = (
@@ -489,7 +494,7 @@ export function scanRuleStateReads(
       return null;
     }
     if (!ts.isIdentifier(value)) return null;
-    const container = containerRoot(value.text, chain, at);
+    const [container] = containerRoots(value.text, chain, at);
     for (const scope of chain) {
       const members = objectMembers.get(scope)?.get(container);
       if (!members) continue;
@@ -554,17 +559,19 @@ export function scanRuleStateReads(
     if (!owner) return [];
     const base = unwrap(owner);
     if (!ts.isIdentifier(base)) return [];
-    const container = containerRoot(base.text, chain, at);
-    for (const scope of chain) {
-      const members = objectMembers.get(scope)?.get(container);
-      if (!members) continue;
-      for (const [key, edges] of members) {
-        if (!memberNamed(value, key)) continue;
-        return visibleEdges(edges, at).map((edge) => ({ name: edge.target, at: edge.at }));
+    const out: Array<{ name: string; at: number }> = [];
+    for (const container of containerRoots(base.text, chain, at)) {
+      for (const scope of chain) {
+        const members = objectMembers.get(scope)?.get(container);
+        if (!members) continue;
+        for (const [key, edges] of members) {
+          if (!memberNamed(value, key)) continue;
+          out.push(...visibleEdges(edges, at).map((edge) => ({ name: edge.target, at: edge.at })));
+        }
+        break;
       }
-      return [];
     }
-    return [];
+    return out;
   };
   const rawExposures: Array<{
     handles: Array<{ name: string; at: number }>;
@@ -671,16 +678,31 @@ export function scanRuleStateReads(
     ) {
       const base = unwrap(ownerOf(node.left) ?? node.left);
       const member = memberNameOf(node.left);
-      if (ts.isIdentifier(base) && member !== null) {
+      if (ts.isIdentifier(base)) {
         const chain = [...nextChain, source];
-        const container = containerRoot(base.text, chain, node.getStart());
-        const memberOwnerScope =
-          chain.find((candidate) => declaredIn.get(candidate)?.has(container)) ??
-          nextChain[0] ??
-          source;
-        const conditional = isConditionallyReached(node);
-        for (const target of aliasTargets(node.right)) {
-          recordMember(memberOwnerScope, container, member, target, node.getStart(), conditional);
+        const at = node.getStart();
+        const containers = containerRoots(base.text, chain, at);
+        const declaring =
+          chain.find((candidate) => declaredIn.get(candidate)?.has(containers[0])) ?? null;
+        const conditional =
+          isConditionallyReached(node) ||
+          isDeferredWrite(node, enclosingFunction(declaring)) ||
+          containers.length > 1 ||
+          member === null;
+        for (const container of containers) {
+          const memberOwnerScope =
+            chain.find((candidate) => declaredIn.get(candidate)?.has(container)) ??
+            nextChain[0] ??
+            source;
+          const keys =
+            member === null
+              ? [...(objectMembers.get(memberOwnerScope)?.get(container)?.keys() ?? [])]
+              : [member];
+          for (const key of keys) {
+            for (const target of aliasTargets(node.right)) {
+              recordMember(memberOwnerScope, container, key, target, at, conditional);
+            }
+          }
         }
       }
     }
@@ -1128,6 +1150,13 @@ export function scanRuleStateReads(
       const element = value.elements[index];
       return element && !ts.isOmittedExpression(element) ? [element] : [];
     }
+    if (ts.isConditionalExpression(value)) {
+      // Either object may be the one written through, so both answer.
+      return [
+        ...containerMembers(value.whenTrue, key, scope, seen),
+        ...containerMembers(value.whenFalse, key, scope, seen),
+      ];
+    }
     if (ts.isIdentifier(value) && !seen.has(value.text)) {
       const binding = lookup(scope, value.text);
       if (binding?.kind === 'token') {
@@ -1138,6 +1167,53 @@ export function scanRuleStateReads(
       }
     }
     return [];
+  };
+
+  /** The members a container's declaration names, for an unreadable write key. */
+  const containerKeys = (node: ts.Node, scope: Scope, seen = new Set<string>()): string[] => {
+    const value = unwrap(node);
+    if (ts.isObjectLiteralExpression(value)) {
+      return value.properties.flatMap((property) =>
+        ts.isShorthandPropertyAssignment(property) ||
+        (ts.isPropertyAssignment(property) &&
+          (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name)))
+          ? [(property.name as ts.Identifier | ts.StringLiteral).text]
+          : []
+      );
+    }
+    if (ts.isArrayLiteralExpression(value)) return value.elements.map((_, index) => String(index));
+    if (ts.isIdentifier(value) && !seen.has(value.text)) {
+      const binding = lookup(scope, value.text);
+      if (binding?.kind === 'token') {
+        return containerKeys(binding.initializer, scope, new Set([...seen, value.text]));
+      }
+    }
+    return [];
+  };
+
+  /** Every binding a base expression may name, following a conditional. */
+  const containerBindings = (
+    node: ts.Node,
+    scope: Scope,
+    seen = new Set<string>()
+  ): Array<{ scope: Scope; name: string }> => {
+    const value = unwrap(node);
+    if (ts.isConditionalExpression(value)) {
+      return [
+        ...containerBindings(value.whenTrue, scope, seen),
+        ...containerBindings(value.whenFalse, scope, seen),
+      ];
+    }
+    if (!ts.isIdentifier(value) || seen.has(value.text)) return [];
+    const owner = scopeBinding(scope, value.text);
+    const held = owner?.bindings.get(value.text);
+    if (!owner || held?.kind !== 'token') return [];
+    const initializer = unwrap(held.initializer);
+    if (ts.isIdentifier(initializer) || ts.isConditionalExpression(initializer)) {
+      const next = containerBindings(initializer, scope, new Set([...seen, value.text]));
+      if (next.length > 0) return next;
+    }
+    return [{ scope: owner, name: value.text }];
   };
 
   const memberOfHandleObject = (node: ts.Node, scope: Scope): ts.Expression[] => {
@@ -1687,30 +1763,38 @@ export function scanRuleStateReads(
     ) {
       const base = unwrap(ownerOf(node.left) ?? node.left);
       const member = memberNameOf(node.left);
-      if (ts.isIdentifier(base) && member !== null) {
+      if (ts.isIdentifier(base) || ts.isConditionalExpression(base)) {
         // An alias of the container is the same object, so the write lands on
-        // the binding that actually holds the literal.
-        let name = base.text;
-        for (let hop = 0; hop < 8; hop += 1) {
-          const held = lookup(current, name);
-          if (held?.kind !== 'token') break;
-          const initializer = unwrap(held.initializer);
-          if (!ts.isIdentifier(initializer)) break;
-          name = initializer.text;
-        }
-        const owner = scopeBinding(current, name) ?? current;
-        const container = owner.bindings.get(name);
-        if (container?.kind === 'token') {
-          // Before the first write the member still lives in the declaration.
-          const previous =
-            container.members?.get(member) ??
-            containerMembers(container.initializer, member, current);
+        // the binding that actually holds the literal — on each of them when
+        // the base may be either of two objects.
+        const targets = containerBindings(base, current);
+        for (const target of targets) {
+          const container = target.scope.bindings.get(target.name);
+          if (container?.kind !== 'token') continue;
+          // The declaring scope, not this one: inside a callback the write
+          // would otherwise be compared against itself and always look ordered.
           const uncertain =
-            isConditionallyReached(node) || isDeferredWrite(node, enclosingFunction(current.node));
-          const kept = uncertain ? previous : [];
+            isConditionallyReached(node) ||
+            isDeferredWrite(node, enclosingFunction(target.scope.node)) ||
+            targets.length > 1 ||
+            member === null;
+          const keys =
+            member === null
+              ? [
+                  ...new Set([
+                    ...(container.members?.keys() ?? []),
+                    ...containerKeys(container.initializer, current),
+                  ]),
+                ]
+              : [member];
           const members = new Map(container.members ?? []);
-          members.set(member, [node.right, ...kept]);
-          declare(owner, name, { ...container, members });
+          for (const key of keys) {
+            // Before the first write the member still lives in the declaration.
+            const previous =
+              container.members?.get(key) ?? containerMembers(container.initializer, key, current);
+            members.set(key, [node.right, ...(uncertain ? previous : [])]);
+          }
+          declare(target.scope, target.name, { ...container, members });
         }
       }
     }

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -151,8 +151,14 @@ export function scanRuleStateReads(
       : node;
 
   const exposedKeys = new Map<ts.Node, Map<string, string>>();
-  const aliasOf = new Map<ts.Node, Map<string, string>>();
-  const rawExposures: Array<{ handle: string; key: ts.Expression; chain: ts.Node[] }> = [];
+  type AliasEdge = { owner: ts.Node; name: string; target: string; at: number };
+  const aliasEdges: AliasEdge[] = [];
+  const rawExposures: Array<{
+    handle: string;
+    key: ts.Expression;
+    chain: ts.Node[];
+    at: number;
+  }> = [];
 
   const memberNamed = (node: ts.Node, name: string): boolean => {
     const target = unwrap(node);
@@ -176,20 +182,30 @@ export function scanRuleStateReads(
     if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
       const initializer = unwrap(node.initializer);
       if (ts.isIdentifier(initializer)) {
-        const owner = nextChain[0] ?? source;
-        const scoped = aliasOf.get(owner) ?? new Map<string, string>();
-        scoped.set(node.name.text, initializer.text);
-        aliasOf.set(owner, scoped);
+        aliasEdges.push({
+          owner: nextChain[0] ?? source,
+          name: node.name.text,
+          target: initializer.text,
+          at: node.getStart(),
+        });
       }
     }
     if (ts.isCallExpression(node)) {
       const callee = unwrap(node.expression);
       const owner = ownerOf(callee);
-      if (memberNamed(callee, 'state') && owner && memberNamed(owner, 'expose')) {
+      const exposesState = memberNamed(callee, 'state') && owner && memberNamed(owner, 'expose');
+      // `def.expose('ready', state)` wraps a state handle too.
+      const exposesDirectly = memberNamed(callee, 'expose');
+      if (exposesState || exposesDirectly) {
         const [nameArg, handleArg] = node.arguments;
         const handle = handleArg && unwrap(handleArg);
         if (nameArg && handle && ts.isIdentifier(handle)) {
-          rawExposures.push({ handle: handle.text, key: nameArg, chain: [...nextChain, source] });
+          rawExposures.push({
+            handle: handle.text,
+            key: nameArg,
+            chain: [...nextChain, source],
+            at: node.getStart(),
+          });
         }
       }
     }
@@ -197,27 +213,35 @@ export function scanRuleStateReads(
   };
   collectExposedKeys(source, []);
 
-  const aliasRoot = (name: string, chain: ts.Node[]): string => {
+  const aliasRoot = (name: string, chain: ts.Node[], at: number): string => {
     const seen = new Set<string>();
     let current = name;
     for (;;) {
       if (seen.has(current)) return current;
       seen.add(current);
+      // The edge in effect where the exposure was written, nearest scope first.
       let next: string | undefined;
       for (const owner of chain) {
-        next = aliasOf.get(owner)?.get(current);
-        if (next !== undefined) break;
+        let best: AliasEdge | null = null;
+        for (const edge of aliasEdges) {
+          if (edge.owner !== owner || edge.name !== current || edge.at > at) continue;
+          if (!best || edge.at > best.at) best = edge;
+        }
+        if (best) {
+          next = best.target;
+          break;
+        }
       }
       if (next === undefined) return current;
       current = next;
     }
   };
 
-  for (const { handle, key, chain } of rawExposures) {
+  for (const { handle, key, chain, at } of rawExposures) {
     // A key the scanner cannot read still means the state is exposed, and the
     // attribute comes from the declared name anyway.
     const text = ts.isStringLiteralLike(key) ? key.text : '';
-    for (const name of new Set([handle, aliasRoot(handle, chain)])) {
+    for (const name of new Set([handle, aliasRoot(handle, chain, at)])) {
       for (const owner of chain) {
         const scoped = exposedKeys.get(owner) ?? new Map<string, string>();
         if (!scoped.has(name)) scoped.set(name, text);
@@ -403,8 +427,16 @@ export function scanRuleStateReads(
     if (node.kind === ts.SyntaxKind.TrueKeyword) return 'positive';
     if (node.kind === ts.SyntaxKind.FalseKeyword) return 'negative';
     if (ts.isStringLiteralLike(node) && /^[a-zA-Z0-9_-]+$/.test(node.text)) return 'positive';
-    // `number.discrete` bindings lower by stringifying the literal.
+    // `number.discrete` bindings lower by stringifying the literal, and `-1`
+    // parses as a prefix unary expression rather than a numeric literal.
     if (ts.isNumericLiteral(node)) return 'positive';
+    if (
+      ts.isPrefixUnaryExpression(node) &&
+      (node.operator === ts.SyntaxKind.MinusToken || node.operator === ts.SyntaxKind.PlusToken) &&
+      ts.isNumericLiteral(node.operand)
+    ) {
+      return 'positive';
+    }
     return null;
   };
 

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -190,6 +190,22 @@ export function scanRuleStateReads(
         });
       }
     }
+    // A plain reassignment moves the handle just as a declaration does.
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(node.left)
+    ) {
+      const value = unwrap(node.right);
+      if (ts.isIdentifier(value)) {
+        aliasEdges.push({
+          owner: nextChain[0] ?? source,
+          name: node.left.text,
+          target: value.text,
+          at: node.getStart(),
+        });
+      }
+    }
     if (ts.isCallExpression(node)) {
       const callee = unwrap(node.expression);
       const owner = ownerOf(callee);

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -23,6 +23,13 @@ export type UnresolvedStateRead = {
   reason: 'subject' | 'comparison' | 'intent' | 'spec' | 'condition';
 };
 
+export type ExposedLocalUsage = {
+  /** The name the prototype declared the state under. */
+  state: string;
+  /** The public key it is exposed as, which the Web runtime turns into an attribute. */
+  exposedAs: string;
+};
+
 export type RuleStateScan = {
   /** Reads traced to a hook and state the extractor must be able to resolve. */
   usages: HookStateUsage[];
@@ -34,6 +41,12 @@ export type RuleStateScan = {
    * static extractor is most likely to be silently missing the same rule.
    */
   unresolved: UnresolvedStateRead[];
+  /**
+   * Reads of a prototype-owned state that is exposed, and therefore lowered by
+   * the Web runtime to a `data-` attribute. These are not hook pairs, so they
+   * are reported separately rather than pretending they came from an `asHook`.
+   */
+  exposedLocals: ExposedLocalUsage[];
 };
 
 type Binding =
@@ -41,7 +54,7 @@ type Binding =
   | { kind: 'handleBag'; hook: string }
   | { kind: 'handle'; hook: string; state: string }
   /** `def.state.bool(...)` — owned by the prototype, not borrowed from a hook. */
-  | { kind: 'localState' }
+  | { kind: 'localState'; exposedAs?: string }
   /** A value a `tw(...)` argument may name, resolved where it was declared. */
   | { kind: 'token'; initializer: ts.Expression }
   /** A named import; only a relative one is something the extractor follows. */
@@ -102,6 +115,30 @@ export function scanRuleStateReads(
   const source = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true);
   const usages: HookStateUsage[] = [];
   const unresolved: UnresolvedStateRead[] = [];
+  const exposedLocals: ExposedLocalUsage[] = [];
+
+  /**
+   * `def.expose.state('hidden', hidden)` by handle name. The Web runtime turns
+   * the exposed key into a `data-` attribute and lowers rules on that state, so
+   * an exposed local is not the same as a purely internal one.
+   */
+  const exposedKeys = new Map<string, string>();
+  const collectExposedKeys = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'state' &&
+      ts.isPropertyAccessExpression(node.expression.expression) &&
+      node.expression.expression.name.text === 'expose'
+    ) {
+      const [nameArg, handleArg] = node.arguments;
+      if (nameArg && handleArg && ts.isStringLiteralLike(nameArg) && ts.isIdentifier(handleArg)) {
+        exposedKeys.set(handleArg.text, nameArg.text);
+      }
+    }
+    ts.forEachChild(node, collectExposedKeys);
+  };
+  collectExposedKeys(source);
 
   const unwrap = (node: ts.Node): ts.Node =>
     ts.isNonNullExpression(node) ||
@@ -183,7 +220,10 @@ export function scanRuleStateReads(
       initializer.expression.expression.name.text === 'state' &&
       ts.isIdentifier(declaration.name)
     ) {
-      declare(scope, declaration.name.text, { kind: 'localState' });
+      declare(scope, declaration.name.text, {
+        kind: 'localState',
+        exposedAs: exposedKeys.get(declaration.name.text),
+      });
       return;
     }
 
@@ -225,12 +265,19 @@ export function scanRuleStateReads(
    * `'local'` means traced to a prototype-owned state, which needs no hook
    * entry and must not be reported either way.
    */
-  const readState = (node: ts.Node, scope: Scope): HookStateUsage | 'local' | null => {
+  const readState = (
+    node: ts.Node,
+    scope: Scope
+  ): HookStateUsage | { exposedLocal: ExposedLocalUsage } | 'local' | null => {
     const argument = unwrap(node);
     if (ts.isIdentifier(argument)) {
       const binding = lookup(scope, argument.text);
       if (binding?.kind === 'handle') return { hook: binding.hook, state: binding.state };
-      if (binding?.kind === 'localState') return 'local';
+      if (binding?.kind === 'localState') {
+        return binding.exposedAs
+          ? { exposedLocal: { state: argument.text, exposedAs: binding.exposedAs } }
+          : 'local';
+      }
       return null;
     }
     if (ts.isPropertyAccessExpression(argument)) {
@@ -513,7 +560,7 @@ export function scanRuleStateReads(
   };
 
   type Leaf = {
-    usage: HookStateUsage | 'local' | null;
+    usage: HookStateUsage | { exposedLocal: ExposedLocalUsage } | 'local' | null;
     /** The `w.state(...)` argument. */
     subject: string;
     /** The whole `w.state(...).eq(...)` leaf. */
@@ -710,6 +757,10 @@ export function scanRuleStateReads(
         continue;
       }
       if (leaf.usage === 'local') continue;
+      if (leaf.usage && 'exposedLocal' in leaf.usage) {
+        exposedLocals.push(leaf.usage.exposedLocal);
+        continue;
+      }
       if (leaf.usage) usages.push(leaf.usage);
       else unresolved.push({ expression: leaf.subject, reason: 'subject' });
     }
@@ -771,5 +822,5 @@ export function scanRuleStateReads(
   declareImports(rootScope);
   visit(source, rootScope);
 
-  return { usages, unresolved };
+  return { usages, unresolved, exposedLocals };
 }

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -189,6 +189,29 @@ function visibleEdges<T extends { at: number; conditional?: boolean }>(
   return selected;
 }
 
+function enclosingFunction(node: ts.Node | null): ts.Node | null {
+  return node ? (ts.findAncestor(node, (candidate) => ts.isFunctionLike(candidate)) ?? null) : null;
+}
+
+/** `(() => { … })()` runs where it is written, so its writes are ordered. */
+function isImmediatelyInvoked(fn: ts.Node): boolean {
+  let node: ts.Node = fn;
+  while (node.parent && ts.isParenthesizedExpression(node.parent)) node = node.parent;
+  return Boolean(
+    node.parent && ts.isCallExpression(node.parent) && node.parent.expression === node
+  );
+}
+
+/**
+ * A write inside a callback has not run when a later `def.rule` registers, so
+ * the name may still hold what it held before.
+ */
+function isDeferredWrite(node: ts.Node, readFunction: ts.Node | null): boolean {
+  const writing = enclosingFunction(node);
+  if (writing === readFunction) return false;
+  return !(writing && isImmediatelyInvoked(writing));
+}
+
 /** `var` binds to the function however deeply the declaration is nested. */
 function functionScope(scope: Scope): Scope {
   for (let current: Scope | null = scope; current; current = current.parent) {
@@ -297,6 +320,7 @@ export function scanRuleStateReads(
     at: number;
     conditional: boolean;
     chain: ts.Node[];
+    node: ts.Node;
   };
   const aliasEdges: AliasEdge[] = [];
   const declaredIn = new Map<ts.Node, Set<string>>();
@@ -557,6 +581,7 @@ export function scanRuleStateReads(
             at: node.getStart(),
             conditional,
             chain: [...nextChain, source],
+            node,
           });
         }
       }
@@ -581,6 +606,7 @@ export function scanRuleStateReads(
           at: alias.at,
           conditional,
           chain: [...nextChain, source],
+          node,
         });
       }
     }
@@ -633,6 +659,7 @@ export function scanRuleStateReads(
           at: node.getStart(),
           conditional,
           chain: [...nextChain, source],
+          node,
         });
       }
     }
@@ -665,9 +692,18 @@ export function scanRuleStateReads(
     seen = new Set<string>()
   ): Array<{ name: string; chain: ts.Node[] }> => {
     if (seen.has(name)) return [{ name, chain }];
+    // A write in another function is unordered against this read, so it adds a
+    // candidate rather than replacing one.
+    const readFunction = enclosingFunction(chain[0] ?? null);
+    const ordered = (edge: AliasEdge): AliasEdge =>
+      edge.conditional || !edge.node || !isDeferredWrite(edge.node, readFunction)
+        ? edge
+        : { ...edge, conditional: true };
     let found: AliasEdge[] = [];
     for (const owner of chain) {
-      const candidates = aliasEdges.filter((edge) => edge.owner === owner && edge.name === name);
+      const candidates = aliasEdges
+        .filter((edge) => edge.owner === owner && edge.name === name)
+        .map(ordered);
       if (candidates.length === 0) continue;
       found = visibleEdges(candidates, at);
       break;
@@ -760,7 +796,10 @@ export function scanRuleStateReads(
     const previous = scope.bindings.get(name);
     declareValue(node as ts.BindingName, initializer, scope, lookupScope);
     const next = scope.bindings.get(name);
-    if (!isConditionallyReached(initializer.parent) || !previous || !next) return;
+    const uncertain =
+      isConditionallyReached(initializer.parent) ||
+      isDeferredWrite(initializer, enclosingFunction(scope.node));
+    if (!uncertain || !previous || !next) return;
     if (next.kind !== 'localState' || previous.kind !== 'localState') return;
     // Alternatives are flat: a candidate carries no candidates of its own.
     const bare = (binding: LocalStateBinding): LocalStateBinding => ({
@@ -1196,11 +1235,20 @@ export function scanRuleStateReads(
     if (ts.isArrayLiteralExpression(inner))
       return inner.elements.every((element) => resolvableTokenArgument(element, scope, seen));
     if (ts.isObjectLiteralExpression(inner))
-      return inner.properties.every(
-        (property) =>
-          ts.isPropertyAssignment(property) &&
-          resolvableTokenArgument(property.initializer, scope, seen)
-      );
+      return inner.properties.every((property) => {
+        // A property holding a state handle is not token data. Production reads
+        // the container for handles and tokens at once and takes strings only
+        // where they exist, so such a property does not stop the read.
+        if (ts.isShorthandPropertyAssignment(property)) {
+          return (
+            readState(property.name, scope) !== null ||
+            resolvableTokenArgument(property.name, scope, seen)
+          );
+        }
+        if (!ts.isPropertyAssignment(property)) return false;
+        if (readState(property.initializer, scope) !== null) return true;
+        return resolvableTokenArgument(property.initializer, scope, seen);
+      });
     if (ts.isConditionalExpression(inner))
       return (
         resolvableTokenArgument(inner.whenTrue, scope, seen) &&
@@ -1605,7 +1653,9 @@ export function scanRuleStateReads(
           const previous =
             container.members?.get(member) ??
             containerMembers(container.initializer, member, current);
-          const kept = isConditionallyReached(node) ? previous : [];
+          const uncertain =
+            isConditionallyReached(node) || isDeferredWrite(node, enclosingFunction(current.node));
+          const kept = uncertain ? previous : [];
           const members = new Map(container.members ?? []);
           members.set(member, [node.right, ...kept]);
           declare(owner, name, { ...container, members });

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -291,6 +291,7 @@ export function scanRuleStateReads(
     target: string;
     at: number;
     conditional: boolean;
+    chain: ts.Node[];
   };
   const aliasEdges: AliasEdge[] = [];
   const declaredIn = new Map<ts.Node, Set<string>>();
@@ -525,6 +526,7 @@ export function scanRuleStateReads(
             target,
             at: node.getStart(),
             conditional,
+            chain: [...nextChain, source],
           });
         }
       }
@@ -548,6 +550,7 @@ export function scanRuleStateReads(
           target: alias.target,
           at: alias.at,
           conditional,
+          chain: [...nextChain, source],
         });
       }
     }
@@ -597,6 +600,7 @@ export function scanRuleStateReads(
           target,
           at: node.getStart(),
           conditional,
+          chain: [...nextChain, source],
         });
       }
     }
@@ -627,8 +631,8 @@ export function scanRuleStateReads(
     chain: ts.Node[],
     at: number,
     seen = new Set<string>()
-  ): string[] => {
-    if (seen.has(name)) return [name];
+  ): Array<{ name: string; chain: ts.Node[] }> => {
+    if (seen.has(name)) return [{ name, chain }];
     let found: AliasEdge[] = [];
     for (const owner of chain) {
       const candidates = aliasEdges.filter((edge) => edge.owner === owner && edge.name === name);
@@ -636,9 +640,11 @@ export function scanRuleStateReads(
       found = visibleEdges(candidates, at);
       break;
     }
-    if (found.length === 0) return [name];
+    if (found.length === 0) return [{ name, chain }];
     const next = new Set([...seen, name]);
-    return found.flatMap((edge) => aliasRoots(edge.target, chain, edge.at, next));
+    // An alias captured its target where the alias was written, so a name the
+    // exposure site shadows must not answer for it.
+    return found.flatMap((edge) => aliasRoots(edge.target, edge.chain ?? chain, edge.at, next));
   };
 
   // An exposure names a binding, and a binding lives in one scope. Writing it
@@ -651,13 +657,19 @@ export function scanRuleStateReads(
     // A key the scanner cannot read still means the state is exposed, and the
     // attribute comes from the declared name anyway.
     const text = ts.isStringLiteralLike(key) ? key.text : '';
-    for (const name of new Set(
-      handles.flatMap((handle) => [handle.name, ...aliasRoots(handle.name, chain, handle.at)])
-    )) {
-      const owner = declaringScope(name, chain);
+    const named = handles.flatMap((handle) => [
+      { name: handle.name, chain },
+      ...aliasRoots(handle.name, chain, handle.at),
+    ]);
+    const seen = new Set<string>();
+    for (const entry of named) {
+      const owner = declaringScope(entry.name, entry.chain);
       if (!owner) continue;
+      const identity = `${entry.name}\u0000${owner.pos}`;
+      if (seen.has(identity)) continue;
+      seen.add(identity);
       const scoped = exposedKeys.get(owner) ?? new Map<string, string>();
-      if (!scoped.has(name)) scoped.set(name, text);
+      if (!scoped.has(entry.name)) scoped.set(entry.name, text);
       exposedKeys.set(owner, scoped);
     }
   }
@@ -762,6 +774,38 @@ export function scanRuleStateReads(
         declare(scope, name.text, { kind: 'handleBag', hook: bag });
       }
       return;
+    }
+
+    // `const current = enabled ? first : second` — the runtime keeps one branch
+    // and it carries its own declared name, so both candidates are retained.
+    const chosen = unwrap(initializer);
+    if (ts.isConditionalExpression(chosen) && ts.isIdentifier(name)) {
+      // Each branch is bound into a throwaway scope so this reads exactly what
+      // the same expression would name on its own.
+      const branches = [chosen.whenTrue, chosen.whenFalse].map((branch) => {
+        const probe: Scope = { parent: lookupScope, bindings: new Map(), node: lookupScope.node };
+        declareValue(name, branch, probe, lookupScope);
+        return probe.bindings.get(name.text);
+      });
+      const locals = branches.filter(
+        (binding): binding is Binding & { kind: 'localState' } => binding?.kind === 'localState'
+      );
+      if (locals.length === branches.length && locals.length > 0) {
+        const [head, ...rest] = locals;
+        const bare = (binding: LocalStateBinding): LocalStateBinding => ({
+          kind: 'localState',
+          declaredAs: binding.declaredAs,
+          exposedAs: binding.exposedAs,
+        });
+        declare(scope, name.text, {
+          ...head,
+          exposedAs: exposureFor(name.text, scope) ?? head.exposedAs,
+          alternatives: rest
+            .map(bare)
+            .filter((candidate) => candidate.declaredAs !== head.declaredAs),
+        });
+        return;
+      }
     }
 
     // `const { ready: publicFlag } = { ready: flag }` and `const [publicFlag] =

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -2,6 +2,25 @@ import { readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import ts from 'typescript';
 
+/**
+ * Mirrors `OFFICIAL_EXPOSED_STATE_NAMES` in `@proto.ui/module-expose-state-web`,
+ * which the Web projection maps before it normalizes anything.
+ */
+const OFFICIAL_EXPOSED_STATE_NAMES: Readonly<Record<string, string>> = Object.freeze({
+  '@interaction/disabled': 'disabled',
+  '@interaction/hovered': 'hovered',
+  '@interaction/pressed': 'pressed',
+  '@interaction/focused': 'focused',
+  '@focus/focused': 'focused',
+  '@interaction/focusVisible': 'focus-visible',
+  '@focus/focusVisible': 'focus-visible',
+  '@accessibility/expanded': 'expanded',
+  '@accessibility/invalid': 'invalid',
+  '@accessibility/selected': 'selected',
+  '@accessibility/checked': 'checked',
+  '@accessibility/current': 'current',
+});
+
 export type HookStateUsage = {
   hook: string;
   state: string;
@@ -132,6 +151,7 @@ export function scanRuleStateReads(
    */
   /** The same normalization `createExposeStateWebNameMap` applies. */
   const exposedDataAttributeName = (key: string): string =>
+    OFFICIAL_EXPOSED_STATE_NAMES[key] ??
     key
       .trim()
       .replace(/\s+/g, '-')
@@ -154,7 +174,20 @@ export function scanRuleStateReads(
   type AliasEdge = { owner: ts.Node; name: string; target: string; at: number };
   const aliasEdges: AliasEdge[] = [];
   const declaredIn = new Map<ts.Node, Set<string>>();
-  const objectMembers = new Map<string, Map<string, string>>();
+
+  /** A statically known string, following one hop through a local constant. */
+  const constantStringValue = (node: ts.Node, scope: Scope): string | null => {
+    const value = unwrap(node);
+    if (ts.isStringLiteralLike(value) || ts.isNoSubstitutionTemplateLiteral(value)) {
+      return value.text;
+    }
+    if (ts.isIdentifier(value)) {
+      const binding = lookup(scope, value.text);
+      if (binding?.kind === 'token') return constantStringValue(binding.initializer, scope);
+    }
+    return null;
+  };
+  const objectMembers = new Map<ts.Node, Map<string, Map<string, string>>>();
 
   /** Every handle an initializer may name; a conditional contributes both. */
   const aliasTargets = (node: ts.Node): string[] => {
@@ -166,17 +199,20 @@ export function scanRuleStateReads(
     return [];
   };
 
-  const resolveHandleIdentifier = (node: ts.Node): string | null => {
+  const resolveHandleIdentifier = (node: ts.Node, chain: ts.Node[]): string | null => {
     const value = unwrap(node);
     if (ts.isIdentifier(value)) return value.text;
     const owner = ownerOf(value);
     if (!owner) return null;
     const base = unwrap(owner);
     if (!ts.isIdentifier(base)) return null;
-    const members = objectMembers.get(base.text);
-    if (!members) return null;
-    for (const [key, target] of members) {
-      if (memberNamed(value, key)) return target;
+    for (const scope of chain) {
+      const members = objectMembers.get(scope)?.get(base.text);
+      if (!members) continue;
+      for (const [key, target] of members) {
+        if (memberNamed(value, key)) return target;
+      }
+      return null;
     }
     return null;
   };
@@ -238,7 +274,9 @@ export function scanRuleStateReads(
               if (ts.isIdentifier(value)) members.set(property.name.text, value.text);
             }
           }
-          objectMembers.set(node.name.text, members);
+          const scopedMembers = objectMembers.get(owner) ?? new Map<string, Map<string, string>>();
+          scopedMembers.set(node.name.text, members);
+          objectMembers.set(owner, scopedMembers);
         }
         for (const target of aliasTargets(node.initializer)) {
           aliasEdges.push({ owner, name: node.name.text, target, at: node.getStart() });
@@ -271,7 +309,7 @@ export function scanRuleStateReads(
       const exposesDirectly = memberNamed(callee, 'expose');
       if (exposesState || exposesDirectly) {
         const [nameArg, handleArg] = node.arguments;
-        const handle = handleArg && resolveHandleIdentifier(handleArg);
+        const handle = handleArg && resolveHandleIdentifier(handleArg, [...nextChain, source]);
         if (nameArg && handle) {
           rawExposures.push({
             handle,
@@ -417,10 +455,9 @@ export function scanRuleStateReads(
         kind: 'localState',
         // `null` means the declaration exists but its runtime name cannot be
         // read here, which is not the same as having no declaration at all.
-        declaredAs:
-          declaredArgument && ts.isStringLiteralLike(declaredArgument)
-            ? declaredArgument.text
-            : null,
+        // A constant the extractor resolves has to resolve here too, or the
+        // gate reports a blind spot production does not have.
+        declaredAs: declaredArgument ? constantStringValue(declaredArgument, scope) : null,
         exposedAs: exposureFor(declaration.name.text, scope),
       });
       return;

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -151,7 +151,10 @@ export function scanRuleStateReads(
    */
   /** The same normalization `createExposeStateWebNameMap` applies. */
   const exposedDataAttributeName = (key: string): string =>
-    OFFICIAL_EXPOSED_STATE_NAMES[key] ??
+    // The table inherits `Object.prototype`, so `constructor` is not an entry.
+    (Object.hasOwn(OFFICIAL_EXPOSED_STATE_NAMES, key)
+      ? OFFICIAL_EXPOSED_STATE_NAMES[key]
+      : undefined) ??
     key
       .trim()
       .replace(/\s+/g, '-')
@@ -187,7 +190,24 @@ export function scanRuleStateReads(
     }
     return null;
   };
-  const objectMembers = new Map<ts.Node, Map<string, Map<string, string>>>();
+  // Members carry positions for the same reason aliases do: a write through the
+  // container retargets the member from there on.
+  type MemberEdge = { target: string; at: number };
+  const objectMembers = new Map<ts.Node, Map<string, Map<string, MemberEdge[]>>>();
+
+  const recordMember = (
+    owner: ts.Node,
+    base: string,
+    key: string,
+    target: string,
+    at: number
+  ): void => {
+    const scoped = objectMembers.get(owner) ?? new Map<string, Map<string, MemberEdge[]>>();
+    const members = scoped.get(base) ?? new Map<string, MemberEdge[]>();
+    members.set(key, [...(members.get(key) ?? []), { target, at }]);
+    scoped.set(base, members);
+    objectMembers.set(owner, scoped);
+  };
 
   /** Every handle an initializer may name; a conditional contributes both. */
   const aliasTargets = (node: ts.Node): string[] => {
@@ -199,7 +219,7 @@ export function scanRuleStateReads(
     return [];
   };
 
-  const resolveHandleIdentifier = (node: ts.Node, chain: ts.Node[]): string | null => {
+  const resolveHandleIdentifier = (node: ts.Node, chain: ts.Node[], at: number): string | null => {
     const value = unwrap(node);
     if (ts.isIdentifier(value)) return value.text;
     const owner = ownerOf(value);
@@ -209,8 +229,11 @@ export function scanRuleStateReads(
     for (const scope of chain) {
       const members = objectMembers.get(scope)?.get(base.text);
       if (!members) continue;
-      for (const [key, target] of members) {
-        if (memberNamed(value, key)) return target;
+      for (const [key, edges] of members) {
+        if (!memberNamed(value, key)) continue;
+        const visible = edges.filter((edge) => edge.at <= at);
+        if (visible.length === 0) return null;
+        return visible.reduce((latest, edge) => (edge.at > latest.at ? edge : latest)).target;
       }
       return null;
     }
@@ -240,6 +263,17 @@ export function scanRuleStateReads(
       : null;
   };
 
+  /** The member a `x.name` or `x['name']` write names, if it is static. */
+  const memberNameOf = (node: ts.Node): string | null => {
+    const target = unwrap(node);
+    if (ts.isPropertyAccessExpression(target)) return target.name.text;
+    if (ts.isElementAccessExpression(target)) {
+      const argument = target.argumentExpression;
+      return argument && ts.isStringLiteralLike(argument) ? argument.text : null;
+    }
+    return null;
+  };
+
   const collectExposedKeys = (node: ts.Node, chain: ts.Node[]): void => {
     const nextChain = introducesScope(node) ? [node, ...chain] : chain;
     if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
@@ -262,25 +296,42 @@ export function scanRuleStateReads(
       if (node.initializer) {
         const literal = unwrap(node.initializer);
         if (ts.isObjectLiteralExpression(literal)) {
-          const members = new Map<string, string>();
+          const at = node.getStart();
           for (const property of literal.properties) {
             if (ts.isShorthandPropertyAssignment(property)) {
-              members.set(property.name.text, property.name.text);
+              recordMember(owner, node.name.text, property.name.text, property.name.text, at);
             } else if (
               ts.isPropertyAssignment(property) &&
               (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name))
             ) {
               const value = unwrap(property.initializer);
-              if (ts.isIdentifier(value)) members.set(property.name.text, value.text);
+              if (ts.isIdentifier(value)) {
+                recordMember(owner, node.name.text, property.name.text, value.text, at);
+              }
             }
           }
-          const scopedMembers = objectMembers.get(owner) ?? new Map<string, Map<string, string>>();
-          scopedMembers.set(node.name.text, members);
-          objectMembers.set(owner, scopedMembers);
         }
         for (const target of aliasTargets(node.initializer)) {
           aliasEdges.push({ owner, name: node.name.text, target, at: node.getStart() });
         }
+      }
+    }
+    // Writing through the container moves the handle the same way, so the
+    // member the exposure reads is the one assigned last before it.
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      (ts.isPropertyAccessExpression(node.left) || ts.isElementAccessExpression(node.left))
+    ) {
+      const base = unwrap(ownerOf(node.left) ?? node.left);
+      const member = memberNameOf(node.left);
+      const value = unwrap(node.right);
+      if (ts.isIdentifier(base) && member !== null && ts.isIdentifier(value)) {
+        const memberOwnerScope =
+          [...nextChain, source].find((candidate) => declaredIn.get(candidate)?.has(base.text)) ??
+          nextChain[0] ??
+          source;
+        recordMember(memberOwnerScope, base.text, member, value.text, node.getStart());
       }
     }
     // A plain reassignment moves the handle just as a declaration does.
@@ -309,7 +360,8 @@ export function scanRuleStateReads(
       const exposesDirectly = memberNamed(callee, 'expose');
       if (exposesState || exposesDirectly) {
         const [nameArg, handleArg] = node.arguments;
-        const handle = handleArg && resolveHandleIdentifier(handleArg, [...nextChain, source]);
+        const handle =
+          handleArg && resolveHandleIdentifier(handleArg, [...nextChain, source], node.getStart());
         if (nameArg && handle) {
           rawExposures.push({
             handle,

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -60,7 +60,7 @@ type Binding =
   | { kind: 'handleBag'; hook: string }
   | { kind: 'handle'; hook: string; state: string }
   /** `def.state.bool(...)` — owned by the prototype, not borrowed from a hook. */
-  | { kind: 'localState'; declaredAs?: string; exposedAs?: string }
+  | { kind: 'localState'; declaredAs: string | null; exposedAs?: string }
   /** A value a `tw(...)` argument may name, resolved where it was declared. */
   | { kind: 'token'; initializer: ts.Expression }
   /** A named import; only a relative one is something the extractor follows. */
@@ -71,6 +71,8 @@ type Binding =
 type Scope = {
   parent: Scope | null;
   bindings: Map<string, Binding>;
+  /** The node that created this scope, used to resolve exposures lexically. */
+  node: ts.Node | null;
 };
 
 function lookup(scope: Scope | null, name: string): Binding | null {
@@ -148,9 +150,9 @@ export function scanRuleStateReads(
       ? unwrap(node.expression)
       : node;
 
-  const exposedKeys = new Map<string, string>();
-  const aliasOf = new Map<string, string>();
-  const rawExposures: Array<{ handle: string; key: ts.Expression }> = [];
+  const exposedKeys = new Map<ts.Node, Map<string, string>>();
+  const aliasOf = new Map<ts.Node, Map<string, string>>();
+  const rawExposures: Array<{ handle: string; key: ts.Expression; chain: ts.Node[] }> = [];
 
   const memberNamed = (node: ts.Node, name: string): boolean => {
     const target = unwrap(node);
@@ -169,10 +171,16 @@ export function scanRuleStateReads(
       : null;
   };
 
-  const collectExposedKeys = (node: ts.Node): void => {
+  const collectExposedKeys = (node: ts.Node, chain: ts.Node[]): void => {
+    const nextChain = introducesScope(node) ? [node, ...chain] : chain;
     if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
       const initializer = unwrap(node.initializer);
-      if (ts.isIdentifier(initializer)) aliasOf.set(node.name.text, initializer.text);
+      if (ts.isIdentifier(initializer)) {
+        const owner = nextChain[0] ?? source;
+        const scoped = aliasOf.get(owner) ?? new Map<string, string>();
+        scoped.set(node.name.text, initializer.text);
+        aliasOf.set(owner, scoped);
+      }
     }
     if (ts.isCallExpression(node)) {
       const callee = unwrap(node.expression);
@@ -181,32 +189,53 @@ export function scanRuleStateReads(
         const [nameArg, handleArg] = node.arguments;
         const handle = handleArg && unwrap(handleArg);
         if (nameArg && handle && ts.isIdentifier(handle)) {
-          rawExposures.push({ handle: handle.text, key: nameArg });
+          rawExposures.push({ handle: handle.text, key: nameArg, chain: [...nextChain, source] });
         }
       }
     }
-    ts.forEachChild(node, collectExposedKeys);
+    ts.forEachChild(node, (child) => collectExposedKeys(child, nextChain));
   };
-  collectExposedKeys(source);
+  collectExposedKeys(source, []);
 
-  const aliasRoot = (name: string): string => {
+  const aliasRoot = (name: string, chain: ts.Node[]): string => {
     const seen = new Set<string>();
     let current = name;
-    while (aliasOf.has(current) && !seen.has(current)) {
+    for (;;) {
+      if (seen.has(current)) return current;
       seen.add(current);
-      current = aliasOf.get(current) as string;
+      let next: string | undefined;
+      for (const owner of chain) {
+        next = aliasOf.get(owner)?.get(current);
+        if (next !== undefined) break;
+      }
+      if (next === undefined) return current;
+      current = next;
     }
-    return current;
   };
 
-  for (const { handle, key } of rawExposures) {
+  for (const { handle, key, chain } of rawExposures) {
     // A key the scanner cannot read still means the state is exposed, and the
     // attribute comes from the declared name anyway.
     const text = ts.isStringLiteralLike(key) ? key.text : '';
-    for (const name of new Set([handle, aliasRoot(handle)])) {
-      if (!exposedKeys.has(name)) exposedKeys.set(name, text);
+    for (const name of new Set([handle, aliasRoot(handle, chain)])) {
+      for (const owner of chain) {
+        const scoped = exposedKeys.get(owner) ?? new Map<string, string>();
+        if (!scoped.has(name)) scoped.set(name, text);
+        exposedKeys.set(owner, scoped);
+      }
     }
   }
+
+  /** The exposure visible from a scope chain, nearest scope first. */
+  const exposureFor = (name: string, scope: Scope): string | undefined => {
+    for (let current: Scope | null = scope; current; current = current.parent) {
+      if (!current.node) continue;
+      const scoped = exposedKeys.get(current.node);
+      const found = scoped?.get(name);
+      if (found !== undefined) return found;
+    }
+    return undefined;
+  };
 
   const hookOfCall = (node: ts.Node): string | null => {
     const call = unwrap(node);
@@ -283,11 +312,13 @@ export function scanRuleStateReads(
       const declaredArgument = initializer.arguments[0];
       declare(scope, declaration.name.text, {
         kind: 'localState',
+        // `null` means the declaration exists but its runtime name cannot be
+        // read here, which is not the same as having no declaration at all.
         declaredAs:
           declaredArgument && ts.isStringLiteralLike(declaredArgument)
             ? declaredArgument.text
-            : undefined,
-        exposedAs: exposedKeys.get(declaration.name.text),
+            : null,
+        exposedAs: exposureFor(declaration.name.text, scope),
       });
       return;
     }
@@ -340,11 +371,15 @@ export function scanRuleStateReads(
       if (binding?.kind === 'handle') return { hook: binding.hook, state: binding.state };
       if (binding?.kind === 'localState') {
         if (binding.exposedAs === undefined) return 'local';
+        // The runtime attribute comes from the declared name. If that name is
+        // not statically readable the extractor emits nothing, so substituting
+        // the expose key here would certify a selector that never exists.
+        if (binding.declaredAs === null) return null;
         return {
           exposedLocal: {
             state: argument.text,
             exposedAs: binding.exposedAs,
-            attribute: exposedDataAttributeName(binding.declaredAs ?? binding.exposedAs),
+            attribute: exposedDataAttributeName(binding.declaredAs),
           },
         };
       }
@@ -424,7 +459,7 @@ export function scanRuleStateReads(
   const moduleRootScope = (module: ts.SourceFile): Scope => {
     const cached = moduleScopes.get(module);
     if (cached) return cached;
-    const scope: Scope = { parent: null, bindings: new Map() };
+    const scope: Scope = { parent: null, bindings: new Map(), node: null };
     // Insert before filling so a cycle of relative modules terminates.
     moduleScopes.set(module, scope);
     for (const statement of module.statements) {
@@ -840,7 +875,7 @@ export function scanRuleStateReads(
 
   const visit = (node: ts.Node, scope: Scope): void => {
     const current = introducesScope(node)
-      ? { parent: scope, bindings: new Map<string, Binding>() }
+      ? { parent: scope, bindings: new Map<string, Binding>(), node }
       : scope;
 
     // The extractor registers declarations while iterating the variable
@@ -890,7 +925,7 @@ export function scanRuleStateReads(
     ts.forEachChild(node, (child) => visit(child, current));
   };
 
-  const rootScope: Scope = { parent: null, bindings: new Map() };
+  const rootScope: Scope = { parent: null, bindings: new Map(), node: source };
   declareImports(rootScope);
   visit(source, rootScope);
 

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -340,6 +340,29 @@ export function scanRuleStateReads(
     }
   };
 
+  /**
+   * `const alias = controls` names one object, so a member written through
+   * either name lands on the same table. A base that may be two different
+   * objects is left as itself: there is no single table to move.
+   */
+  const containerRoot = (
+    name: string,
+    chain: ts.Node[],
+    at: number,
+    seen = new Set<string>()
+  ): string => {
+    if (seen.has(name)) return name;
+    for (const owner of chain) {
+      const candidates = aliasEdges.filter((edge) => edge.owner === owner && edge.name === name);
+      if (candidates.length === 0) continue;
+      const visible = visibleEdges(candidates, at);
+      if (visible.length !== 1) return name;
+      const [edge] = visible;
+      return containerRoot(edge.target, edge.chain ?? chain, edge.at, new Set([...seen, name]));
+    }
+    return name;
+  };
+
   const recordMember = (
     owner: ts.Node,
     base: string,
@@ -390,8 +413,9 @@ export function scanRuleStateReads(
       return null;
     }
     if (!ts.isIdentifier(value)) return null;
+    const container = containerRoot(value.text, chain, at);
     for (const scope of chain) {
-      const members = objectMembers.get(scope)?.get(value.text);
+      const members = objectMembers.get(scope)?.get(container);
       if (!members) continue;
       const edges = members.get(key);
       if (!edges) return null;
@@ -454,8 +478,9 @@ export function scanRuleStateReads(
     if (!owner) return [];
     const base = unwrap(owner);
     if (!ts.isIdentifier(base)) return [];
+    const container = containerRoot(base.text, chain, at);
     for (const scope of chain) {
-      const members = objectMembers.get(scope)?.get(base.text);
+      const members = objectMembers.get(scope)?.get(container);
       if (!members) continue;
       for (const [key, edges] of members) {
         if (!memberNamed(value, key)) continue;
@@ -569,13 +594,15 @@ export function scanRuleStateReads(
       const base = unwrap(ownerOf(node.left) ?? node.left);
       const member = memberNameOf(node.left);
       if (ts.isIdentifier(base) && member !== null) {
+        const chain = [...nextChain, source];
+        const container = containerRoot(base.text, chain, node.getStart());
         const memberOwnerScope =
-          [...nextChain, source].find((candidate) => declaredIn.get(candidate)?.has(base.text)) ??
+          chain.find((candidate) => declaredIn.get(candidate)?.has(container)) ??
           nextChain[0] ??
           source;
         const conditional = isConditionallyReached(node);
         for (const target of aliasTargets(node.right)) {
-          recordMember(memberOwnerScope, base.text, member, target, node.getStart(), conditional);
+          recordMember(memberOwnerScope, container, member, target, node.getStart(), conditional);
         }
       }
     }
@@ -1561,8 +1588,18 @@ export function scanRuleStateReads(
       const base = unwrap(ownerOf(node.left) ?? node.left);
       const member = memberNameOf(node.left);
       if (ts.isIdentifier(base) && member !== null) {
-        const owner = scopeBinding(current, base.text) ?? current;
-        const container = owner.bindings.get(base.text);
+        // An alias of the container is the same object, so the write lands on
+        // the binding that actually holds the literal.
+        let name = base.text;
+        for (let hop = 0; hop < 8; hop += 1) {
+          const held = lookup(current, name);
+          if (held?.kind !== 'token') break;
+          const initializer = unwrap(held.initializer);
+          if (!ts.isIdentifier(initializer)) break;
+          name = initializer.text;
+        }
+        const owner = scopeBinding(current, name) ?? current;
+        const container = owner.bindings.get(name);
         if (container?.kind === 'token') {
           // Before the first write the member still lives in the declaration.
           const previous =
@@ -1571,7 +1608,7 @@ export function scanRuleStateReads(
           const kept = isConditionallyReached(node) ? previous : [];
           const members = new Map(container.members ?? []);
           members.set(member, [node.right, ...kept]);
-          declare(owner, base.text, { ...container, members });
+          declare(owner, name, { ...container, members });
         }
       }
     }

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -193,8 +193,17 @@ function enclosingFunction(node: ts.Node | null): ts.Node | null {
   return node ? (ts.findAncestor(node, (candidate) => ts.isFunctionLike(candidate)) ?? null) : null;
 }
 
-/** `(() => { … })()` runs where it is written, so its writes are ordered. */
-function isImmediatelyInvoked(fn: ts.Node): boolean {
+/**
+ * `(() => { … })()` runs where it is written, so its writes are ordered. An
+ * async function may suspend before the write and a generator does not run its
+ * body on the call at all, so neither is ordered however it is invoked.
+ */
+function runsInPlace(fn: ts.Node): boolean {
+  const declaration = fn as ts.FunctionLikeDeclaration;
+  if (declaration.asteriskToken) return false;
+  if (declaration.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword)) {
+    return false;
+  }
   let node: ts.Node = fn;
   while (node.parent && ts.isParenthesizedExpression(node.parent)) node = node.parent;
   return Boolean(
@@ -209,7 +218,7 @@ function isImmediatelyInvoked(fn: ts.Node): boolean {
 function isDeferredWrite(node: ts.Node, readFunction: ts.Node | null): boolean {
   const writing = enclosingFunction(node);
   if (writing === readFunction) return false;
-  return !(writing && isImmediatelyInvoked(writing));
+  return !(writing && runsInPlace(writing));
 }
 
 /** `var` binds to the function however deeply the declaration is nested. */

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -368,6 +368,8 @@ export function scanRuleStateReads(
     if (node.kind === ts.SyntaxKind.TrueKeyword) return 'positive';
     if (node.kind === ts.SyntaxKind.FalseKeyword) return 'negative';
     if (ts.isStringLiteralLike(node) && /^[a-zA-Z0-9_-]+$/.test(node.text)) return 'positive';
+    // `number.discrete` bindings lower by stringifying the literal.
+    if (ts.isNumericLiteral(node)) return 'positive';
     return null;
   };
 

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -215,10 +215,53 @@ function runsInPlace(fn: ts.Node): boolean {
  * A write inside a callback has not run when a later `def.rule` registers, so
  * the name may still hold what it held before.
  */
+/**
+ * Whether a statement may hand control somewhere else before finishing. Nested
+ * functions are skipped: their `return` belongs to them, not to this sequence.
+ */
+function mayCompleteAbruptly(node: ts.Node): boolean {
+  let found = false;
+  const visit = (current: ts.Node): void => {
+    if (found || ts.isFunctionLike(current)) return;
+    if (
+      ts.isReturnStatement(current) ||
+      ts.isThrowStatement(current) ||
+      ts.isBreakStatement(current) ||
+      ts.isContinueStatement(current)
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(current, visit);
+  };
+  visit(node);
+  return found;
+}
+
+/**
+ * Whether a write is guaranteed to have run by the time `boundary` returns.
+ * Being called synchronously proves the function starts, not that this write is
+ * reached.
+ */
+function reachedInPlace(node: ts.Node, boundary: ts.Node): boolean {
+  let child: ts.Node = node;
+  for (let parent = node.parent; parent; child = parent, parent = parent.parent) {
+    if (ts.isBlock(parent) || ts.isCaseClause(parent) || ts.isDefaultClause(parent)) {
+      for (const statement of parent.statements) {
+        if (statement === child) break;
+        if (mayCompleteAbruptly(statement)) return false;
+      }
+    }
+    if (parent === boundary) break;
+  }
+  return true;
+}
+
 function isDeferredWrite(node: ts.Node, readFunction: ts.Node | null): boolean {
   const writing = enclosingFunction(node);
   if (writing === readFunction) return false;
-  return !(writing && runsInPlace(writing));
+  if (!writing || !runsInPlace(writing)) return true;
+  return !reachedInPlace(node, writing);
 }
 
 /** `var` binds to the function however deeply the declaration is nested. */

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -207,6 +207,27 @@ export function scanRuleStateReads(
   type MemberEdge = { target: string; at: number };
   const objectMembers = new Map<ts.Node, Map<string, Map<string, MemberEdge[]>>>();
 
+  /** Every member an object literal names, at the position it was written. */
+  const recordObjectLiteral = (
+    owner: ts.Node,
+    base: string,
+    literal: ts.ObjectLiteralExpression,
+    at: number
+  ): void => {
+    for (const property of literal.properties) {
+      if (ts.isShorthandPropertyAssignment(property)) {
+        recordMember(owner, base, property.name.text, property.name.text, at);
+      } else if (
+        ts.isPropertyAssignment(property) &&
+        (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name))
+      ) {
+        for (const target of aliasTargets(property.initializer)) {
+          recordMember(owner, base, property.name.text, target, at);
+        }
+      }
+    }
+  };
+
   const recordMember = (
     owner: ts.Node,
     base: string,
@@ -259,9 +280,9 @@ export function scanRuleStateReads(
       if (!members) continue;
       const edges = members.get(key);
       if (!edges) return null;
-      const visible = edges.filter((edge) => edge.at <= at);
-      if (visible.length === 0) return null;
-      return visible.reduce((latest, edge) => (edge.at > latest.at ? edge : latest)).target;
+      const targets = latestTargets(edges, at);
+      // A pattern binds one name, so a conditional member leaves it ambiguous.
+      return targets.length === 1 ? targets[0] : null;
     }
     return null;
   };
@@ -303,28 +324,35 @@ export function scanRuleStateReads(
     return out;
   };
 
-  const resolveHandleIdentifier = (node: ts.Node, chain: ts.Node[], at: number): string | null => {
+  /** Every edge written at the latest position at or before `at`. */
+  const latestTargets = (edges: MemberEdge[], at: number): string[] => {
+    const visible = edges.filter((edge) => edge.at <= at);
+    if (visible.length === 0) return [];
+    const latest = Math.max(...visible.map((edge) => edge.at));
+    return visible.filter((edge) => edge.at === latest).map((edge) => edge.target);
+  };
+
+  /** The handles an expose argument may name; a conditional member gives both. */
+  const resolveHandleNames = (node: ts.Node, chain: ts.Node[], at: number): string[] => {
     const value = unwrap(node);
-    if (ts.isIdentifier(value)) return value.text;
+    if (ts.isIdentifier(value)) return [value.text];
     const owner = ownerOf(value);
-    if (!owner) return null;
+    if (!owner) return [];
     const base = unwrap(owner);
-    if (!ts.isIdentifier(base)) return null;
+    if (!ts.isIdentifier(base)) return [];
     for (const scope of chain) {
       const members = objectMembers.get(scope)?.get(base.text);
       if (!members) continue;
       for (const [key, edges] of members) {
         if (!memberNamed(value, key)) continue;
-        const visible = edges.filter((edge) => edge.at <= at);
-        if (visible.length === 0) return null;
-        return visible.reduce((latest, edge) => (edge.at > latest.at ? edge : latest)).target;
+        return latestTargets(edges, at);
       }
-      return null;
+      return [];
     }
-    return null;
+    return [];
   };
   const rawExposures: Array<{
-    handle: string;
+    handles: string[];
     key: ts.Expression;
     chain: ts.Node[];
     at: number;
@@ -380,20 +408,7 @@ export function scanRuleStateReads(
       if (node.initializer) {
         const literal = unwrap(node.initializer);
         if (ts.isObjectLiteralExpression(literal)) {
-          const at = node.getStart();
-          for (const property of literal.properties) {
-            if (ts.isShorthandPropertyAssignment(property)) {
-              recordMember(owner, node.name.text, property.name.text, property.name.text, at);
-            } else if (
-              ts.isPropertyAssignment(property) &&
-              (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name))
-            ) {
-              const value = unwrap(property.initializer);
-              if (ts.isIdentifier(value)) {
-                recordMember(owner, node.name.text, property.name.text, value.text, at);
-              }
-            }
-          }
+          recordObjectLiteral(owner, node.name.text, literal, node.getStart());
         }
         for (const target of aliasTargets(node.initializer)) {
           aliasEdges.push({ owner, name: node.name.text, target, at: node.getStart() });
@@ -424,13 +439,14 @@ export function scanRuleStateReads(
     ) {
       const base = unwrap(ownerOf(node.left) ?? node.left);
       const member = memberNameOf(node.left);
-      const value = unwrap(node.right);
-      if (ts.isIdentifier(base) && member !== null && ts.isIdentifier(value)) {
+      if (ts.isIdentifier(base) && member !== null) {
         const memberOwnerScope =
           [...nextChain, source].find((candidate) => declaredIn.get(candidate)?.has(base.text)) ??
           nextChain[0] ??
           source;
-        recordMember(memberOwnerScope, base.text, member, value.text, node.getStart());
+        for (const target of aliasTargets(node.right)) {
+          recordMember(memberOwnerScope, base.text, member, target, node.getStart());
+        }
       }
     }
     // A plain reassignment moves the handle just as a declaration does.
@@ -447,6 +463,10 @@ export function scanRuleStateReads(
         [...nextChain, source].find((candidate) => declaredIn.get(candidate)?.has(left)) ??
         nextChain[0] ??
         source;
+      const replacement = unwrap(node.right);
+      if (ts.isObjectLiteralExpression(replacement)) {
+        recordObjectLiteral(assignOwner, left, replacement, node.getStart());
+      }
       for (const target of aliasTargets(node.right)) {
         aliasEdges.push({ owner: assignOwner, name: left, target, at: node.getStart() });
       }
@@ -459,11 +479,12 @@ export function scanRuleStateReads(
       const exposesDirectly = memberNamed(callee, 'expose');
       if (exposesState || exposesDirectly) {
         const [nameArg, handleArg] = node.arguments;
-        const handle =
-          handleArg && resolveHandleIdentifier(handleArg, [...nextChain, source], node.getStart());
-        if (nameArg && handle) {
+        const handles = handleArg
+          ? resolveHandleNames(handleArg, [...nextChain, source], node.getStart())
+          : [];
+        if (nameArg && handles.length > 0) {
           rawExposures.push({
-            handle,
+            handles,
             key: nameArg,
             chain: [...nextChain, source],
             at: node.getStart(),
@@ -505,11 +526,13 @@ export function scanRuleStateReads(
   const declaringScope = (name: string, chain: ts.Node[]): ts.Node | undefined =>
     chain.find((candidate) => declaredIn.get(candidate)?.has(name)) ?? chain[chain.length - 1];
 
-  for (const { handle, key, chain, at } of rawExposures) {
+  for (const { handles, key, chain, at } of rawExposures) {
     // A key the scanner cannot read still means the state is exposed, and the
     // attribute comes from the declared name anyway.
     const text = ts.isStringLiteralLike(key) ? key.text : '';
-    for (const name of new Set([handle, ...aliasRoots(handle, chain, at)])) {
+    for (const name of new Set(
+      handles.flatMap((handle) => [handle, ...aliasRoots(handle, chain, at)])
+    )) {
       const owner = declaringScope(name, chain);
       if (!owner) continue;
       const scoped = exposedKeys.get(owner) ?? new Map<string, string>();

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -140,24 +140,6 @@ export function scanRuleStateReads(
       .replace(/^-+|-+$/g, '')
       .toLowerCase();
 
-  const exposedKeys = new Map<string, string>();
-  const collectExposedKeys = (node: ts.Node): void => {
-    if (
-      ts.isCallExpression(node) &&
-      ts.isPropertyAccessExpression(node.expression) &&
-      node.expression.name.text === 'state' &&
-      ts.isPropertyAccessExpression(node.expression.expression) &&
-      node.expression.expression.name.text === 'expose'
-    ) {
-      const [nameArg, handleArg] = node.arguments;
-      if (nameArg && handleArg && ts.isStringLiteralLike(nameArg) && ts.isIdentifier(handleArg)) {
-        exposedKeys.set(handleArg.text, nameArg.text);
-      }
-    }
-    ts.forEachChild(node, collectExposedKeys);
-  };
-  collectExposedKeys(source);
-
   const unwrap = (node: ts.Node): ts.Node =>
     ts.isNonNullExpression(node) ||
     ts.isParenthesizedExpression(node) ||
@@ -165,6 +147,66 @@ export function scanRuleStateReads(
     ts.isTypeAssertionExpression(node)
       ? unwrap(node.expression)
       : node;
+
+  const exposedKeys = new Map<string, string>();
+  const aliasOf = new Map<string, string>();
+  const rawExposures: Array<{ handle: string; key: ts.Expression }> = [];
+
+  const memberNamed = (node: ts.Node, name: string): boolean => {
+    const target = unwrap(node);
+    if (ts.isPropertyAccessExpression(target)) return target.name.text === name;
+    if (ts.isElementAccessExpression(target)) {
+      const argument = target.argumentExpression;
+      return Boolean(argument) && ts.isStringLiteralLike(argument) && argument.text === name;
+    }
+    return false;
+  };
+
+  const ownerOf = (node: ts.Node): ts.Node | null => {
+    const target = unwrap(node);
+    return ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)
+      ? target.expression
+      : null;
+  };
+
+  const collectExposedKeys = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const initializer = unwrap(node.initializer);
+      if (ts.isIdentifier(initializer)) aliasOf.set(node.name.text, initializer.text);
+    }
+    if (ts.isCallExpression(node)) {
+      const callee = unwrap(node.expression);
+      const owner = ownerOf(callee);
+      if (memberNamed(callee, 'state') && owner && memberNamed(owner, 'expose')) {
+        const [nameArg, handleArg] = node.arguments;
+        const handle = handleArg && unwrap(handleArg);
+        if (nameArg && handle && ts.isIdentifier(handle)) {
+          rawExposures.push({ handle: handle.text, key: nameArg });
+        }
+      }
+    }
+    ts.forEachChild(node, collectExposedKeys);
+  };
+  collectExposedKeys(source);
+
+  const aliasRoot = (name: string): string => {
+    const seen = new Set<string>();
+    let current = name;
+    while (aliasOf.has(current) && !seen.has(current)) {
+      seen.add(current);
+      current = aliasOf.get(current) as string;
+    }
+    return current;
+  };
+
+  for (const { handle, key } of rawExposures) {
+    // A key the scanner cannot read still means the state is exposed, and the
+    // attribute comes from the declared name anyway.
+    const text = ts.isStringLiteralLike(key) ? key.text : '';
+    for (const name of new Set([handle, aliasRoot(handle)])) {
+      if (!exposedKeys.has(name)) exposedKeys.set(name, text);
+    }
+  }
 
   const hookOfCall = (node: ts.Node): string | null => {
     const call = unwrap(node);
@@ -297,7 +339,7 @@ export function scanRuleStateReads(
       const binding = lookup(scope, argument.text);
       if (binding?.kind === 'handle') return { hook: binding.hook, state: binding.state };
       if (binding?.kind === 'localState') {
-        if (!binding.exposedAs) return 'local';
+        if (binding.exposedAs === undefined) return 'local';
         return {
           exposedLocal: {
             state: argument.text,

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -382,6 +382,17 @@ function memberOwner(node) {
     : null;
 }
 
+/** The member a `x.name` or `x['name']` write names, if it is static. */
+function memberName(node) {
+  const target = unwrapTransparent(node);
+  if (ts.isPropertyAccessExpression(target)) return target.name.text;
+  if (ts.isElementAccessExpression(target)) {
+    const argument = target.argumentExpression;
+    return argument && ts.isStringLiteralLike(argument) ? argument.text : null;
+  }
+  return null;
+}
+
 function resolveDeclaredStateName(initializer, scope) {
   const node = unwrapTransparent(initializer);
   if (!ts.isCallExpression(node)) return null;
@@ -425,10 +436,28 @@ const OFFICIAL_EXPOSED_STATE_NAMES = Object.freeze({
   '@accessibility/current': 'current',
 });
 
+/**
+ * The variant the Web optimizer emits for an official semantic instead of its
+ * attribute. `buildVariant` consults `buildSemanticVariant` first, so an owned
+ * `@interaction/hovered` lowers to `hover:`; every other official semantic
+ * either has no native variant or is refused by the adapter's native-variant
+ * policy and falls back to `data-[…]`, which is what `resolveSemanticBinding`
+ * already returns for the matching `fromInteraction` name.
+ */
+const OFFICIAL_NATIVE_VARIANTS = Object.freeze({
+  '@interaction/hovered': 'hover',
+  '@interaction/pressed': 'active',
+});
+
+/** Both tables inherit `Object.prototype`, so `constructor` is not an entry. */
+function officialEntry(table, key) {
+  return Object.hasOwn(table, key) ? table[key] : null;
+}
+
 function exposedDataAttributeName(key) {
   // The runtime maps an official semantic before it normalizes anything, so
   // `@accessibility/checked` is `data-checked`, not `data-accessibility-checked`.
-  const official = OFFICIAL_EXPOSED_STATE_NAMES[key];
+  const official = officialEntry(OFFICIAL_EXPOSED_STATE_NAMES, key);
   if (official) return official;
   return key
     .trim()
@@ -518,10 +547,19 @@ function collectExposures(root) {
   };
 
   // Scoped like every other binding: a nested `controls` must not answer for
-  // an outer one of the same name.
+  // an outer one of the same name. Members carry positions for the same reason
+  // aliases do: `controls.ready = second` retargets the member from there on.
   const objectMembers = new Map();
 
-  const resolveHandleIdentifier = (node, chain) => {
+  const recordMember = (owner, base, key, target, at) => {
+    const scoped = objectMembers.get(owner) ?? new Map();
+    const members = scoped.get(base) ?? new Map();
+    members.set(key, [...(members.get(key) ?? []), { target, at }]);
+    scoped.set(base, members);
+    objectMembers.set(owner, scoped);
+  };
+
+  const resolveHandleIdentifier = (node, chain, at) => {
     const value = unwrapExpression(node);
     if (ts.isIdentifier(value)) return value.text;
     const owner = memberOwner(value);
@@ -531,8 +569,11 @@ function collectExposures(root) {
     for (const scope of chain) {
       const members = objectMembers.get(scope)?.get(base.text);
       if (!members) continue;
-      for (const [key, target] of members) {
-        if (memberIs(value, key)) return target;
+      for (const [key, edges] of members) {
+        if (!memberIs(value, key)) continue;
+        const visible = edges.filter((edge) => edge.at <= at);
+        if (visible.length === 0) return null;
+        return visible.reduce((latest, edge) => (edge.at > latest.at ? edge : latest)).target;
       }
       return null;
     }
@@ -561,25 +602,42 @@ function collectExposures(root) {
       if (node.initializer) {
         const literal = unwrapExpression(node.initializer);
         if (ts.isObjectLiteralExpression(literal)) {
-          const members = new Map();
+          const at = node.getStart();
           for (const property of literal.properties) {
             if (ts.isShorthandPropertyAssignment(property)) {
-              members.set(property.name.text, property.name.text);
+              recordMember(owner, node.name.text, property.name.text, property.name.text, at);
             } else if (
               ts.isPropertyAssignment(property) &&
               (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name))
             ) {
               const value = unwrapExpression(property.initializer);
-              if (ts.isIdentifier(value)) members.set(property.name.text, value.text);
+              if (ts.isIdentifier(value)) {
+                recordMember(owner, node.name.text, property.name.text, value.text, at);
+              }
             }
           }
-          const scoped = objectMembers.get(owner) ?? new Map();
-          scoped.set(node.name.text, members);
-          objectMembers.set(owner, scoped);
         }
         for (const target of aliasTargets(node.initializer)) {
           aliasEdges.push({ owner, name: node.name.text, target, at: node.getStart() });
         }
+      }
+    }
+    // Writing through the container moves the handle the same way, so the
+    // member the exposure reads is the one assigned last before it.
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      (ts.isPropertyAccessExpression(node.left) || ts.isElementAccessExpression(node.left))
+    ) {
+      const base = unwrapExpression(memberOwner(node.left) ?? node.left);
+      const member = memberName(node.left);
+      const value = unwrapExpression(node.right);
+      if (ts.isIdentifier(base) && member !== null && ts.isIdentifier(value)) {
+        const owner =
+          [...nextChain, root].find((candidate) => declaredIn.get(candidate)?.has(base.text)) ??
+          nextChain[0] ??
+          root;
+        recordMember(owner, base.text, member, value.text, node.getStart());
       }
     }
     // A plain reassignment moves the handle just as a declaration does.
@@ -607,7 +665,8 @@ function collectExposures(root) {
         namesExpose(unwrapExpression(node.expression)))
     ) {
       const [nameArg, handleArg] = node.arguments;
-      const handle = handleArg && resolveHandleIdentifier(handleArg, [...nextChain, root]);
+      const handle =
+        handleArg && resolveHandleIdentifier(handleArg, [...nextChain, root], node.getStart());
       if (nameArg && handle) {
         exposures.push({
           handle,
@@ -686,7 +745,12 @@ function applyExposure(name, binding, scope, exposures) {
   // leaves no safe selector to emit; the expose key would be the wrong one.
   if (binding.stateName === UNKNOWN_STATE_NAME) return binding;
   const exposedKey = ts.isStringLiteralLike(key) ? key.text : resolveExpression(key, scope).single;
-  const attribute = exposedDataAttributeName(binding.stateName ?? exposedKey ?? '');
+  const declared = binding.stateName ?? exposedKey ?? '';
+  // An owned state may carry an official semantic itself, and the optimizer
+  // lowers that to a native variant before it ever reaches the attribute.
+  const native = officialEntry(OFFICIAL_NATIVE_VARIANTS, declared);
+  if (native) return { ...binding, semantic: native };
+  const attribute = exposedDataAttributeName(declared);
   if (!attribute) return binding;
   return { ...binding, semantic: `data-[${attribute}]` };
 }

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -452,6 +452,22 @@ function collectExposures(root) {
         });
       }
     }
+    // A plain reassignment moves the handle just as a declaration does.
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(node.left)
+    ) {
+      const value = unwrapExpression(node.right);
+      if (ts.isIdentifier(value)) {
+        aliasEdges.push({
+          owner: nextChain[0] ?? root,
+          name: node.left.text,
+          target: value.text,
+          at: node.getStart(),
+        });
+      }
+    }
     if (
       ts.isCallExpression(node) &&
       (namesExposeState(unwrapExpression(node.expression)) ||

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -106,15 +106,21 @@ function walk(node, scope, tokens) {
     const nextScope = createScope(scope);
 
     if (hasStatements(node)) {
+      // Declarations first, then every exposure, then the rules. The runtime
+      // builds its exposed-state map after setup returns, so a rule written
+      // above the expose call is still lowered with the attribute.
+      for (const stmt of node.statements) {
+        if (!ts.isVariableStatement(stmt)) continue;
+        for (const decl of stmt.declarationList.declarations) registerDeclaration(decl, nextScope);
+      }
+      for (const stmt of node.statements) registerExposedState(stmt, nextScope);
       for (const stmt of node.statements) {
         if (ts.isVariableStatement(stmt)) {
           for (const decl of stmt.declarationList.declarations) {
-            registerDeclaration(decl, nextScope);
             if (decl.initializer) walk(decl.initializer, nextScope, tokens);
           }
           continue;
         }
-        registerExposedState(stmt, nextScope);
         walk(stmt, nextScope, tokens);
       }
       return;
@@ -328,7 +334,24 @@ function lookup(name, scope) {
 function resolveBinding(node, scope) {
   const semantic = resolveSemanticBinding(node);
   const value = resolveExpression(node, scope);
-  return semantic ? { ...value, semantic } : value;
+  const declared = resolveDeclaredStateName(node);
+  const withName = declared ? { ...value, stateName: declared } : value;
+  return semantic ? { ...withName, semantic } : withName;
+}
+
+/**
+ * `def.state.bool('hidden', …)` — the name the prototype declared. `StateKernel`
+ * stores it as `__stateSemantic`, and `ExposeStateWebModuleImpl` maps that
+ * before it would fall back to the expose key, so this is the name the Web
+ * attribute comes from.
+ */
+function resolveDeclaredStateName(node) {
+  if (!ts.isCallExpression(node)) return null;
+  if (!ts.isPropertyAccessExpression(node.expression)) return null;
+  const owner = node.expression.expression;
+  if (!ts.isPropertyAccessExpression(owner) || owner.name.text !== 'state') return null;
+  const first = node.arguments[0];
+  return first && ts.isStringLiteralLike(first) ? first.text : null;
 }
 
 /**
@@ -365,11 +388,19 @@ function registerExposedState(statement, scope) {
   if (!isPropertyAccessChain(call.expression, ['expose', 'state'])) return;
   const [nameArg, handleArg] = call.arguments;
   if (!nameArg || !handleArg) return;
-  if (!ts.isStringLiteralLike(nameArg) || !ts.isIdentifier(handleArg)) return;
-  const attribute = exposedDataAttributeName(nameArg.text);
-  if (!attribute) return;
+  if (!ts.isIdentifier(handleArg)) return;
+  // The key may be a constant the runtime resolves to a real string.
+  const exposedKey = ts.isStringLiteralLike(nameArg)
+    ? nameArg.text
+    : resolveExpression(nameArg, scope).single;
+  if (!exposedKey) return;
   const existing = lookup(handleArg.text, scope);
   if (existing.semantic) return;
+  // The runtime maps `__stateSemantic` — the declared name — before it falls
+  // back to the expose key, so exposing `internalFlag` as `visible` still
+  // produces `data-internal-flag`.
+  const attribute = exposedDataAttributeName(existing.stateName ?? exposedKey);
+  if (!attribute) return;
   scope.bindings.set(handleArg.text, { ...existing, semantic: `data-[${attribute}]` });
 }
 
@@ -740,14 +771,18 @@ function collectTwTokens(node, scope) {
       const nextScope = createScope(currentScope);
       if (hasStatements(current)) {
         for (const stmt of current.statements) {
+          if (!ts.isVariableStatement(stmt)) continue;
+          for (const decl of stmt.declarationList.declarations)
+            registerDeclaration(decl, nextScope);
+        }
+        for (const stmt of current.statements) registerExposedState(stmt, nextScope);
+        for (const stmt of current.statements) {
           if (ts.isVariableStatement(stmt)) {
             for (const decl of stmt.declarationList.declarations) {
-              registerDeclaration(decl, nextScope);
               if (decl.initializer) visit(decl.initializer, nextScope);
             }
             continue;
           }
-          registerExposedState(stmt, nextScope);
           visit(stmt, nextScope);
         }
         return;

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -216,6 +216,24 @@ function readMemberSemantics(node, scope) {
   return memberSemantics(resolveExpression(owner, scope).semanticMap?.get(name));
 }
 
+/**
+ * The outermost scope holding this exact container value. An alias and the
+ * container are one object, so the object's lifetime — not the alias's
+ * declaration — decides whether a write through it has run.
+ */
+function scopeOwningValue(value, scope) {
+  let owning = null;
+  for (let current = scope; current; current = current.parent) {
+    for (const held of current.bindings.values()) {
+      if (held === value) {
+        owning = current;
+        break;
+      }
+    }
+  }
+  return owning;
+}
+
 /** The scope a name is already bound in, so an assignment does not shadow it. */
 function scopeDeclaring(name, scope) {
   for (let current = scope; current; current = current.parent) {
@@ -289,9 +307,10 @@ function walk(node, scope, tokens, exposures) {
       const written = bindingSemantics(resolveBinding(node.right, scope));
       for (const container of targets) {
         if (written.length === 0) break;
-        // The declaring scope, not this one: inside a callback the write would
-        // otherwise be compared against itself and always look ordered.
-        const declaring = scopeDeclaring(base.text, scope);
+        // The scope that owns the container object, not the one that declares
+        // the name written through: an alias declared inside a callback would
+        // otherwise make the write look ordered against itself.
+        const declaring = scopeOwningValue(container, scope) ?? scopeDeclaring(base.text, scope);
         const uncertain =
           isConditionallyReached(node) ||
           isDeferredWrite(node, enclosingFunction(declaring?.node ?? null)) ||

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -353,12 +353,29 @@ function unwrapTransparent(node) {
     : node;
 }
 
+/** `x.name` and `x['name']` reach the same member. */
+function memberIs(node, name) {
+  const target = unwrapTransparent(node);
+  if (ts.isPropertyAccessExpression(target)) return target.name.text === name;
+  if (ts.isElementAccessExpression(target)) {
+    const argument = target.argumentExpression;
+    return Boolean(argument) && ts.isStringLiteralLike(argument) && argument.text === name;
+  }
+  return false;
+}
+
+function memberOwner(node) {
+  const target = unwrapTransparent(node);
+  return ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)
+    ? target.expression
+    : null;
+}
+
 function resolveDeclaredStateName(initializer, scope) {
   const node = unwrapTransparent(initializer);
   if (!ts.isCallExpression(node)) return null;
-  if (!ts.isPropertyAccessExpression(node.expression)) return null;
-  const owner = node.expression.expression;
-  if (!ts.isPropertyAccessExpression(owner) || owner.name.text !== 'state') return null;
+  const owner = memberOwner(node.expression);
+  if (!owner || !memberIs(owner, 'state')) return null;
   const first = node.arguments[0];
   if (!first) return null;
   // The name may be a constant the runtime resolves to a real string. A name
@@ -449,23 +466,77 @@ function collectExposures(root) {
     return false;
   };
 
+  // `const controls = { ready }; def.expose.state('ready', controls.ready)`
+  /**
+   * Every handle an initializer may end up naming. A conditional selects one at
+   * runtime, so both are recorded: over-approximating gives each candidate its
+   * variant, which is safe, while recording neither leaves the chosen one
+   * without CSS.
+   */
+  const aliasTargets = (node) => {
+    const value = unwrapExpression(node);
+    if (ts.isIdentifier(value)) return [value.text];
+    if (ts.isConditionalExpression(value)) {
+      return [...aliasTargets(value.whenTrue), ...aliasTargets(value.whenFalse)];
+    }
+    return [];
+  };
+
+  const objectMembers = new Map();
+
+  const resolveHandleIdentifier = (node) => {
+    const value = unwrapExpression(node);
+    if (ts.isIdentifier(value)) return value.text;
+    const owner = memberOwner(value);
+    if (!owner) return null;
+    const base = unwrapExpression(owner);
+    if (!ts.isIdentifier(base)) return null;
+    const members = objectMembers.get(base.text);
+    if (!members) return null;
+    for (const [key, target] of members) {
+      if (memberIs(value, key)) return target;
+    }
+    return null;
+  };
+
   const visit = (node, chain) => {
     // Every scope the extractor itself creates, so two sibling blocks in one
     // setup may reuse an alias name without either edge overwriting the other.
     const nextChain = createsScope(node) ? [node, ...chain] : chain;
     if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
-      const owner = nextChain[0] ?? root;
+      // `var` binds to the enclosing function however deeply it is nested, so a
+      // redeclaration inside a block is the same binding seen from outside it.
+      const isVar =
+        ts.isVariableDeclarationList(node.parent) &&
+        !(node.parent.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const));
+      const enclosingFunctionBody = isVar
+        ? ts.findAncestor(node, (candidate) => ts.isFunctionLike(candidate))?.body
+        : undefined;
+      const owner =
+        (enclosingFunctionBody && nextChain.includes(enclosingFunctionBody)
+          ? enclosingFunctionBody
+          : nextChain[0]) ?? root;
       if (!declaredIn.has(owner)) declaredIn.set(owner, new Set());
       declaredIn.get(owner).add(node.name.text);
       if (node.initializer) {
-        const initializer = unwrapExpression(node.initializer);
-        if (ts.isIdentifier(initializer)) {
-          aliasEdges.push({
-            owner,
-            name: node.name.text,
-            target: initializer.text,
-            at: node.getStart(),
-          });
+        const literal = unwrapExpression(node.initializer);
+        if (ts.isObjectLiteralExpression(literal)) {
+          const members = new Map();
+          for (const property of literal.properties) {
+            if (ts.isShorthandPropertyAssignment(property)) {
+              members.set(property.name.text, property.name.text);
+            } else if (
+              ts.isPropertyAssignment(property) &&
+              (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name))
+            ) {
+              const value = unwrapExpression(property.initializer);
+              if (ts.isIdentifier(value)) members.set(property.name.text, value.text);
+            }
+          }
+          objectMembers.set(node.name.text, members);
+        }
+        for (const target of aliasTargets(node.initializer)) {
+          aliasEdges.push({ owner, name: node.name.text, target, at: node.getStart() });
         }
       }
     }
@@ -475,18 +546,15 @@ function collectExposures(root) {
       node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
       ts.isIdentifier(node.left)
     ) {
-      const value = unwrapExpression(node.right);
-      if (ts.isIdentifier(value)) {
-        // An assignment does not declare, so it belongs to whichever scope
-        // owns the binding — otherwise a reassignment inside a nested block
-        // would be invisible to an exposure written outside it.
-        const owner =
-          [...nextChain, root].find((candidate) =>
-            declaredIn.get(candidate)?.has(node.left.text)
-          ) ??
-          nextChain[0] ??
-          root;
-        aliasEdges.push({ owner, name: node.left.text, target: value.text, at: node.getStart() });
+      // An assignment does not declare, so it belongs to whichever scope owns
+      // the binding — otherwise a reassignment inside a nested block would be
+      // invisible to an exposure written outside it.
+      const owner =
+        [...nextChain, root].find((candidate) => declaredIn.get(candidate)?.has(node.left.text)) ??
+        nextChain[0] ??
+        root;
+      for (const target of aliasTargets(node.right)) {
+        aliasEdges.push({ owner, name: node.left.text, target, at: node.getStart() });
       }
     }
     if (
@@ -497,10 +565,10 @@ function collectExposures(root) {
         namesExpose(unwrapExpression(node.expression)))
     ) {
       const [nameArg, handleArg] = node.arguments;
-      const handle = handleArg && unwrapExpression(handleArg);
-      if (nameArg && handle && ts.isIdentifier(handle)) {
+      const handle = handleArg && resolveHandleIdentifier(handleArg);
+      if (nameArg && handle) {
         exposures.push({
-          handle: handle.text,
+          handle,
           key: nameArg,
           chain: [...nextChain, root],
           at: node.getStart(),
@@ -512,39 +580,37 @@ function collectExposures(root) {
   visit(root, []);
 
   // The edge in effect where the exposure was written, nearest scope first.
-  const lookupAlias = (name, chain, at) => {
+  // Every edge written at the latest position at or before `at`, nearest scope
+  // first. A conditional contributes several edges at one position.
+  const lookupAliases = (name, chain, at) => {
     for (const owner of chain) {
-      let best = null;
-      for (const edge of aliasEdges) {
-        if (edge.owner !== owner || edge.name !== name || edge.at > at) continue;
-        if (!best || edge.at > best.at) best = edge;
-      }
-      if (best) return best;
+      const candidates = aliasEdges.filter(
+        (edge) => edge.owner === owner && edge.name === name && edge.at <= at
+      );
+      if (candidates.length === 0) continue;
+      const latest = Math.max(...candidates.map((edge) => edge.at));
+      return candidates.filter((edge) => edge.at === latest);
     }
-    return null;
+    return [];
   };
 
   // Each hop resolves where that edge was created, not where the exposure was
   // written: an alias captured its target at its own initialization, so a later
   // redeclaration of the intermediate name cannot retarget it.
-  const rootName = (name, chain, at) => {
-    const seen = new Set();
-    let current = name;
-    let cursor = at;
-    for (;;) {
-      if (seen.has(current)) return current;
-      seen.add(current);
-      const edge = lookupAlias(current, chain, cursor);
-      if (!edge) return current;
-      current = edge.target;
-      cursor = edge.at;
-    }
+  // A conditional alias records one edge per branch, so resolution fans out
+  // rather than picking one: whichever handle the runtime selects has a variant.
+  const rootNames = (name, chain, at, seen = new Set()) => {
+    if (seen.has(name)) return [name];
+    const edges = lookupAliases(name, chain, at);
+    if (edges.length === 0) return [name];
+    const next = new Set([...seen, name]);
+    return edges.flatMap((edge) => rootNames(edge.target, chain, edge.at, next));
   };
 
   const byHandle = new Map();
   for (const { handle, key, chain, at } of exposures) {
     // Both the alias and the handle it names carry the same state id.
-    for (const name of new Set([handle, rootName(handle, chain, at)])) {
+    for (const name of new Set([handle, ...rootNames(handle, chain, at)])) {
       if (!byHandle.has(name)) byHandle.set(name, key);
     }
   }

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -102,6 +102,25 @@ function createScope(parent = null, node = null) {
   return { parent, bindings: new Map(), node };
 }
 
+/** `var` binds to the function however deeply the declaration is nested. */
+function functionScope(scope) {
+  for (let current = scope; current; current = current.parent) {
+    const node = current.node;
+    // The variable environment is a function body, the function itself when it
+    // has an expression body, or the module.
+    if (!node || !current.parent) return current;
+    if (ts.isSourceFile(node) || ts.isFunctionLike(node)) return current;
+    if (node.parent && ts.isFunctionLike(node.parent)) return current;
+  }
+  return scope;
+}
+
+function isVarList(list) {
+  return (
+    ts.isVariableDeclarationList(list) && !(list.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const))
+  );
+}
+
 /** The scope a name is already bound in, so an assignment does not shadow it. */
 function scopeDeclaring(name, scope) {
   for (let current = scope; current; current = current.parent) {
@@ -125,8 +144,11 @@ function walk(node, scope, tokens, exposures) {
       // are collected from the whole source before the walk begins.
       for (const stmt of node.statements) {
         if (ts.isVariableStatement(stmt)) {
+          // `var` is one function-scoped binding however deeply it is nested,
+          // so a nested redeclaration is the same binding seen from outside.
+          const owner = isVarList(stmt.declarationList) ? functionScope(nextScope) : nextScope;
           for (const decl of stmt.declarationList.declarations) {
-            registerDeclaration(decl, nextScope, exposures);
+            registerDeclaration(decl, owner, exposures);
             if (decl.initializer) walk(decl.initializer, nextScope, tokens, exposures);
           }
           continue;
@@ -144,8 +166,9 @@ function walk(node, scope, tokens, exposures) {
     // A declaration under single-statement control flow — `if (x) var f = …` —
     // is reached here rather than through a statement list, and the runtime
     // executes it just the same.
+    const owner = isVarList(node.declarationList) ? functionScope(scope) : scope;
     for (const decl of node.declarationList.declarations) {
-      registerDeclaration(decl, scope, exposures);
+      registerDeclaration(decl, owner, exposures);
       if (decl.initializer) walk(decl.initializer, scope, tokens, exposures);
     }
     return;
@@ -520,6 +543,76 @@ function exposedDataAttributeName(key) {
  * sits in nor its position relative to a rule decides whether the rule lowers.
  * Aliases are followed because two references to one handle carry one state id.
  */
+/**
+ * Whether a write may be skipped at runtime. A branch the source decides
+ * statically executes exactly as written; anything else has to keep whatever
+ * the name held before it, because the runtime may take the other path.
+ */
+function isConditionallyReached(node) {
+  for (let child = node, parent = node.parent; parent; child = parent, parent = parent.parent) {
+    if (ts.isFunctionLike(parent)) return false;
+    if (ts.isIfStatement(parent)) {
+      if (child === parent.expression) continue;
+      if (child === parent.thenStatement && parent.expression.kind === ts.SyntaxKind.TrueKeyword) {
+        continue;
+      }
+      if (child === parent.elseStatement && parent.expression.kind === ts.SyntaxKind.FalseKeyword) {
+        continue;
+      }
+      return true;
+    }
+    if (ts.isConditionalExpression(parent)) {
+      if (child !== parent.condition) return true;
+      continue;
+    }
+    if (
+      ts.isSwitchStatement(parent) ||
+      ts.isCaseBlock(parent) ||
+      ts.isCaseClause(parent) ||
+      ts.isDefaultClause(parent) ||
+      ts.isTryStatement(parent) ||
+      ts.isCatchClause(parent)
+    ) {
+      return true;
+    }
+    if (
+      ts.isForStatement(parent) ||
+      ts.isForOfStatement(parent) ||
+      ts.isForInStatement(parent) ||
+      ts.isWhileStatement(parent)
+    ) {
+      if (child === parent.statement) return true;
+      continue;
+    }
+    if (ts.isBinaryExpression(parent)) {
+      const operator = parent.operatorToken.kind;
+      const shortCircuits =
+        operator === ts.SyntaxKind.AmpersandAmpersandToken ||
+        operator === ts.SyntaxKind.BarBarToken ||
+        operator === ts.SyntaxKind.QuestionQuestionToken;
+      if (shortCircuits && child === parent.right) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Every edge at the latest position at or before `at`, plus everything an
+ * earlier position still contributes because the later write may be skipped.
+ */
+function visibleEdges(edges, at) {
+  const candidates = edges.filter((edge) => edge.at <= at);
+  if (candidates.length === 0) return [];
+  const positions = [...new Set(candidates.map((edge) => edge.at))].sort((a, b) => b - a);
+  const selected = [];
+  for (const position of positions) {
+    const group = candidates.filter((edge) => edge.at === position);
+    selected.push(...group);
+    if (!group.every((edge) => edge.conditional)) break;
+  }
+  return selected;
+}
+
 function collectExposures(root) {
   // Alias edges carry their scope and source position, so two sibling scopes
   // may bind the same name and a later redeclaration cannot rewrite what an
@@ -593,25 +686,25 @@ function collectExposures(root) {
   const objectMembers = new Map();
 
   /** Every member an object literal names, at the position it was written. */
-  const recordObjectLiteral = (owner, base, literal, at) => {
+  const recordObjectLiteral = (owner, base, literal, at, conditional) => {
     for (const property of literal.properties) {
       if (ts.isShorthandPropertyAssignment(property)) {
-        recordMember(owner, base, property.name.text, property.name.text, at);
+        recordMember(owner, base, property.name.text, property.name.text, at, conditional);
       } else if (
         ts.isPropertyAssignment(property) &&
         (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name))
       ) {
         for (const target of aliasTargets(property.initializer)) {
-          recordMember(owner, base, property.name.text, target, at);
+          recordMember(owner, base, property.name.text, target, at, conditional);
         }
       }
     }
   };
 
-  const recordMember = (owner, base, key, target, at) => {
+  const recordMember = (owner, base, key, target, at, conditional) => {
     const scoped = objectMembers.get(owner) ?? new Map();
     const members = scoped.get(base) ?? new Map();
-    members.set(key, [...(members.get(key) ?? []), { target, at }]);
+    members.set(key, [...(members.get(key) ?? []), { target, at, conditional }]);
     scoped.set(base, members);
     objectMembers.set(owner, scoped);
   };
@@ -622,7 +715,7 @@ function collectExposures(root) {
     if (ts.isObjectLiteralExpression(value)) {
       for (const property of value.properties) {
         if (ts.isShorthandPropertyAssignment(property) && property.name.text === key) {
-          return key;
+          return { target: key, at };
         }
         if (
           ts.isPropertyAssignment(property) &&
@@ -630,7 +723,7 @@ function collectExposures(root) {
           property.name.text === key
         ) {
           const assigned = unwrapExpression(property.initializer);
-          return ts.isIdentifier(assigned) ? assigned.text : null;
+          return ts.isIdentifier(assigned) ? { target: assigned.text, at } : null;
         }
       }
       return null;
@@ -641,9 +734,9 @@ function collectExposures(root) {
       if (!members) continue;
       const edges = members.get(key);
       if (!edges) return null;
-      const targets = latestTargets(edges, at);
-      // A pattern binds one name, so a conditional member leaves it ambiguous.
-      return targets.length === 1 ? targets[0] : null;
+      const visible = visibleEdges(edges, at);
+      // A pattern binds one name, so several candidates leave it ambiguous.
+      return visible.length === 1 ? { target: visible[0].target, at: visible[0].at } : null;
     }
     return null;
   };
@@ -662,8 +755,8 @@ function collectExposures(root) {
           ? getPropertyName(element.propertyName)
           : element.name.text;
         if (!key) continue;
-        const target = memberTargetName(initializer, key, chain, at);
-        if (target) out.push({ name: element.name.text, target });
+        const resolved = memberTargetName(initializer, key, chain, at);
+        if (resolved) out.push({ name: element.name.text, ...resolved });
       }
       return out;
     }
@@ -675,27 +768,19 @@ function collectExposures(root) {
       if (!ts.isIdentifier(element.name) || element.dotDotDotToken) return;
       const value = values.elements[index] && unwrapExpression(values.elements[index]);
       if (value && ts.isIdentifier(value))
-        out.push({ name: element.name.text, target: value.text });
+        out.push({ name: element.name.text, target: value.text, at });
     });
     return out;
   };
 
-  /** Every edge written at the latest position at or before `at`. */
-  const latestTargets = (edges, at) => {
-    const visible = edges.filter((edge) => edge.at <= at);
-    if (visible.length === 0) return [];
-    const latest = Math.max(...visible.map((edge) => edge.at));
-    return visible.filter((edge) => edge.at === latest).map((edge) => edge.target);
-  };
-
   /**
-   * The handles an expose argument may name. A conditional member selects one
-   * at runtime, so both are returned for the same reason `aliasTargets` fans
-   * out: whichever the runtime picks has to have a variant.
+   * The handles an expose argument may name, each with the position its own
+   * edge was written at: a member captured whatever its target named then, not
+   * what that name was reassigned to later.
    */
   const resolveHandleNames = (node, chain, at) => {
     const value = unwrapExpression(node);
-    if (ts.isIdentifier(value)) return [value.text];
+    if (ts.isIdentifier(value)) return [{ name: value.text, at }];
     const owner = memberOwner(value);
     if (!owner) return [];
     const base = unwrapExpression(owner);
@@ -705,7 +790,7 @@ function collectExposures(root) {
       if (!members) continue;
       for (const [key, edges] of members) {
         if (!memberIs(value, key)) continue;
-        return latestTargets(edges, at);
+        return visibleEdges(edges, at).map((edge) => ({ name: edge.target, at: edge.at }));
       }
       return [];
     }
@@ -733,11 +818,18 @@ function collectExposures(root) {
       declaredIn.get(owner).add(node.name.text);
       if (node.initializer) {
         const literal = unwrapExpression(node.initializer);
+        const conditional = isConditionallyReached(node);
         if (ts.isObjectLiteralExpression(literal)) {
-          recordObjectLiteral(owner, node.name.text, literal, node.getStart());
+          recordObjectLiteral(owner, node.name.text, literal, node.getStart(), conditional);
         }
         for (const target of aliasTargets(node.initializer)) {
-          aliasEdges.push({ owner, name: node.name.text, target, at: node.getStart() });
+          aliasEdges.push({
+            owner,
+            name: node.name.text,
+            target,
+            at: node.getStart(),
+            conditional,
+          });
         }
       }
     }
@@ -749,10 +841,19 @@ function collectExposures(root) {
     ) {
       const owner = nextChain[0] ?? root;
       const at = node.getStart();
-      for (const { name, target } of patternTargets(node.name, node.initializer, nextChain, at)) {
+      const conditional = isConditionallyReached(node);
+      for (const alias of patternTargets(node.name, node.initializer, nextChain, at)) {
         if (!declaredIn.has(owner)) declaredIn.set(owner, new Set());
-        declaredIn.get(owner).add(name);
-        aliasEdges.push({ owner, name, target, at });
+        declaredIn.get(owner).add(alias.name);
+        // The edge sits where the member was written, so following it resolves
+        // the target as it stood then.
+        aliasEdges.push({
+          owner,
+          name: alias.name,
+          target: alias.target,
+          at: alias.at,
+          conditional,
+        });
       }
     }
     // Writing through the container moves the handle the same way, so the
@@ -769,8 +870,9 @@ function collectExposures(root) {
           [...nextChain, root].find((candidate) => declaredIn.get(candidate)?.has(base.text)) ??
           nextChain[0] ??
           root;
+        const conditional = isConditionallyReached(node);
         for (const target of aliasTargets(node.right)) {
-          recordMember(owner, base.text, member, target, node.getStart());
+          recordMember(owner, base.text, member, target, node.getStart(), conditional);
         }
       }
     }
@@ -787,12 +889,13 @@ function collectExposures(root) {
         [...nextChain, root].find((candidate) => declaredIn.get(candidate)?.has(node.left.text)) ??
         nextChain[0] ??
         root;
+      const conditional = isConditionallyReached(node);
       const replacement = unwrapExpression(node.right);
       if (ts.isObjectLiteralExpression(replacement)) {
-        recordObjectLiteral(owner, node.left.text, replacement, node.getStart());
+        recordObjectLiteral(owner, node.left.text, replacement, node.getStart(), conditional);
       }
       for (const target of aliasTargets(node.right)) {
-        aliasEdges.push({ owner, name: node.left.text, target, at: node.getStart() });
+        aliasEdges.push({ owner, name: node.left.text, target, at: node.getStart(), conditional });
       }
     }
     if (
@@ -807,12 +910,7 @@ function collectExposures(root) {
         ? resolveHandleNames(handleArg, [...nextChain, root], node.getStart())
         : [];
       if (nameArg && handles.length > 0) {
-        exposures.push({
-          handles,
-          key: nameArg,
-          chain: [...nextChain, root],
-          at: node.getStart(),
-        });
+        exposures.push({ handles, key: nameArg, chain: [...nextChain, root] });
       }
     }
     ts.forEachChild(node, (child) => visit(child, nextChain));
@@ -824,12 +922,9 @@ function collectExposures(root) {
   // first. A conditional contributes several edges at one position.
   const lookupAliases = (name, chain, at) => {
     for (const owner of chain) {
-      const candidates = aliasEdges.filter(
-        (edge) => edge.owner === owner && edge.name === name && edge.at <= at
-      );
+      const candidates = aliasEdges.filter((edge) => edge.owner === owner && edge.name === name);
       if (candidates.length === 0) continue;
-      const latest = Math.max(...candidates.map((edge) => edge.at));
-      return candidates.filter((edge) => edge.at === latest);
+      return visibleEdges(candidates, at);
     }
     return [];
   };
@@ -854,10 +949,10 @@ function collectExposures(root) {
     chain.find((candidate) => declaredIn.get(candidate)?.has(name)) ?? chain[chain.length - 1];
 
   const byScope = new Map();
-  for (const { handles, key, chain, at } of exposures) {
+  for (const { handles, key, chain } of exposures) {
     // Both the alias and the handle it names carry the same state id.
     for (const name of new Set(
-      handles.flatMap((handle) => [handle, ...rootNames(handle, chain, at)])
+      handles.flatMap((handle) => [handle.name, ...rootNames(handle.name, chain, handle.at)])
     )) {
       const owner = declaringScope(name, chain);
       if (!owner) continue;

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -102,6 +102,31 @@ function createScope(parent = null, node = null) {
   return { parent, bindings: new Map(), node };
 }
 
+function enclosingFunction(node) {
+  return node ? (ts.findAncestor(node, (candidate) => ts.isFunctionLike(candidate)) ?? null) : null;
+}
+
+/** `(() => { … })()` runs where it is written, so its writes are ordered. */
+function isImmediatelyInvoked(fn) {
+  let node = fn;
+  while (node.parent && ts.isParenthesizedExpression(node.parent)) node = node.parent;
+  return Boolean(
+    node.parent && ts.isCallExpression(node.parent) && node.parent.expression === node
+  );
+}
+
+/**
+ * A write inside a callback has not run when a later `def.rule` registers, so
+ * the name may still hold what it held before. This is the same
+ * over-approximation the conditional path applies, in time rather than in name
+ * resolution.
+ */
+function isDeferredWrite(node, readFunction) {
+  const writing = enclosingFunction(node);
+  if (writing === readFunction) return false;
+  return !(writing && isImmediatelyInvoked(writing));
+}
+
 /** `var` binds to the function however deeply the declaration is nested. */
 function functionScope(scope) {
   for (let current = scope; current; current = current.parent) {
@@ -212,9 +237,9 @@ function walk(node, scope, tokens, exposures) {
       const written = bindingSemantics(resolveBinding(node.right, scope));
       if (container && written.length > 0) {
         const previous = memberSemantics(container.semanticMap?.get(member));
-        const kept = isConditionallyReached(node)
-          ? previous.filter((candidate) => !written.includes(candidate))
-          : [];
+        const uncertain =
+          isConditionallyReached(node) || isDeferredWrite(node, enclosingFunction(scope.node));
+        const kept = uncertain ? previous.filter((candidate) => !written.includes(candidate)) : [];
         if (!container.semanticMap) container.semanticMap = new Map();
         container.semanticMap.set(member, [...written, ...kept]);
       }
@@ -234,12 +259,14 @@ function walk(node, scope, tokens, exposures) {
     const owner = scopeDeclaring(name, scope) ?? scope;
     const previous = owner.bindings.get(name);
     const binding = applyExposure(name, resolveBinding(node.right, scope), owner, exposures);
-    // A write the source may skip leaves the name on either handle, and the
-    // runtime lowers whichever it holds, so both need a selector.
+    // A write the source may skip, or one that has not run yet, leaves the name
+    // on either handle, and the runtime lowers whichever it holds.
     const kept = bindingSemantics(previous).filter((candidate) => candidate !== binding.semantic);
+    const uncertain =
+      isConditionallyReached(node) || isDeferredWrite(node, enclosingFunction(owner.node));
     owner.bindings.set(
       name,
-      isConditionallyReached(node) && kept.length > 0
+      uncertain && kept.length > 0
         ? { ...binding, alternatives: [...new Set([...(binding.alternatives ?? []), ...kept])] }
         : binding
     );
@@ -957,6 +984,7 @@ function collectExposures(root) {
             at: node.getStart(),
             conditional,
             chain: [...nextChain, root],
+            node,
           });
         }
       }
@@ -982,6 +1010,7 @@ function collectExposures(root) {
           at: alias.at,
           conditional,
           chain: [...nextChain, root],
+          node,
         });
       }
     }
@@ -1033,6 +1062,7 @@ function collectExposures(root) {
           at: node.getStart(),
           conditional,
           chain: [...nextChain, root],
+          node,
         });
       }
     }
@@ -1059,8 +1089,17 @@ function collectExposures(root) {
   // Every edge written at the latest position at or before `at`, nearest scope
   // first. A conditional contributes several edges at one position.
   const lookupAliases = (name, chain, at) => {
+    // A write in another function is unordered against this read, so it adds a
+    // candidate rather than replacing one.
+    const readFunction = enclosingFunction(chain[0] ?? null);
+    const ordered = (edge) =>
+      edge.conditional || !edge.node || !isDeferredWrite(edge.node, readFunction)
+        ? edge
+        : { ...edge, conditional: true };
     for (const owner of chain) {
-      const candidates = aliasEdges.filter((edge) => edge.owner === owner && edge.name === name);
+      const candidates = aliasEdges
+        .filter((edge) => edge.owner === owner && edge.name === name)
+        .map(ordered);
       if (candidates.length === 0) continue;
       return visibleEdges(candidates, at);
     }

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -592,6 +592,22 @@ function collectExposures(root) {
   // aliases do: `controls.ready = second` retargets the member from there on.
   const objectMembers = new Map();
 
+  /** Every member an object literal names, at the position it was written. */
+  const recordObjectLiteral = (owner, base, literal, at) => {
+    for (const property of literal.properties) {
+      if (ts.isShorthandPropertyAssignment(property)) {
+        recordMember(owner, base, property.name.text, property.name.text, at);
+      } else if (
+        ts.isPropertyAssignment(property) &&
+        (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name))
+      ) {
+        for (const target of aliasTargets(property.initializer)) {
+          recordMember(owner, base, property.name.text, target, at);
+        }
+      }
+    }
+  };
+
   const recordMember = (owner, base, key, target, at) => {
     const scoped = objectMembers.get(owner) ?? new Map();
     const members = scoped.get(base) ?? new Map();
@@ -625,9 +641,9 @@ function collectExposures(root) {
       if (!members) continue;
       const edges = members.get(key);
       if (!edges) return null;
-      const visible = edges.filter((edge) => edge.at <= at);
-      if (visible.length === 0) return null;
-      return visible.reduce((latest, edge) => (edge.at > latest.at ? edge : latest)).target;
+      const targets = latestTargets(edges, at);
+      // A pattern binds one name, so a conditional member leaves it ambiguous.
+      return targets.length === 1 ? targets[0] : null;
     }
     return null;
   };
@@ -664,25 +680,36 @@ function collectExposures(root) {
     return out;
   };
 
-  const resolveHandleIdentifier = (node, chain, at) => {
+  /** Every edge written at the latest position at or before `at`. */
+  const latestTargets = (edges, at) => {
+    const visible = edges.filter((edge) => edge.at <= at);
+    if (visible.length === 0) return [];
+    const latest = Math.max(...visible.map((edge) => edge.at));
+    return visible.filter((edge) => edge.at === latest).map((edge) => edge.target);
+  };
+
+  /**
+   * The handles an expose argument may name. A conditional member selects one
+   * at runtime, so both are returned for the same reason `aliasTargets` fans
+   * out: whichever the runtime picks has to have a variant.
+   */
+  const resolveHandleNames = (node, chain, at) => {
     const value = unwrapExpression(node);
-    if (ts.isIdentifier(value)) return value.text;
+    if (ts.isIdentifier(value)) return [value.text];
     const owner = memberOwner(value);
-    if (!owner) return null;
+    if (!owner) return [];
     const base = unwrapExpression(owner);
-    if (!ts.isIdentifier(base)) return null;
+    if (!ts.isIdentifier(base)) return [];
     for (const scope of chain) {
       const members = objectMembers.get(scope)?.get(base.text);
       if (!members) continue;
       for (const [key, edges] of members) {
         if (!memberIs(value, key)) continue;
-        const visible = edges.filter((edge) => edge.at <= at);
-        if (visible.length === 0) return null;
-        return visible.reduce((latest, edge) => (edge.at > latest.at ? edge : latest)).target;
+        return latestTargets(edges, at);
       }
-      return null;
+      return [];
     }
-    return null;
+    return [];
   };
 
   const visit = (node, chain) => {
@@ -707,20 +734,7 @@ function collectExposures(root) {
       if (node.initializer) {
         const literal = unwrapExpression(node.initializer);
         if (ts.isObjectLiteralExpression(literal)) {
-          const at = node.getStart();
-          for (const property of literal.properties) {
-            if (ts.isShorthandPropertyAssignment(property)) {
-              recordMember(owner, node.name.text, property.name.text, property.name.text, at);
-            } else if (
-              ts.isPropertyAssignment(property) &&
-              (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name))
-            ) {
-              const value = unwrapExpression(property.initializer);
-              if (ts.isIdentifier(value)) {
-                recordMember(owner, node.name.text, property.name.text, value.text, at);
-              }
-            }
-          }
+          recordObjectLiteral(owner, node.name.text, literal, node.getStart());
         }
         for (const target of aliasTargets(node.initializer)) {
           aliasEdges.push({ owner, name: node.name.text, target, at: node.getStart() });
@@ -750,13 +764,14 @@ function collectExposures(root) {
     ) {
       const base = unwrapExpression(memberOwner(node.left) ?? node.left);
       const member = memberName(node.left);
-      const value = unwrapExpression(node.right);
-      if (ts.isIdentifier(base) && member !== null && ts.isIdentifier(value)) {
+      if (ts.isIdentifier(base) && member !== null) {
         const owner =
           [...nextChain, root].find((candidate) => declaredIn.get(candidate)?.has(base.text)) ??
           nextChain[0] ??
           root;
-        recordMember(owner, base.text, member, value.text, node.getStart());
+        for (const target of aliasTargets(node.right)) {
+          recordMember(owner, base.text, member, target, node.getStart());
+        }
       }
     }
     // A plain reassignment moves the handle just as a declaration does.
@@ -772,6 +787,10 @@ function collectExposures(root) {
         [...nextChain, root].find((candidate) => declaredIn.get(candidate)?.has(node.left.text)) ??
         nextChain[0] ??
         root;
+      const replacement = unwrapExpression(node.right);
+      if (ts.isObjectLiteralExpression(replacement)) {
+        recordObjectLiteral(owner, node.left.text, replacement, node.getStart());
+      }
       for (const target of aliasTargets(node.right)) {
         aliasEdges.push({ owner, name: node.left.text, target, at: node.getStart() });
       }
@@ -784,11 +803,12 @@ function collectExposures(root) {
         namesExpose(unwrapExpression(node.expression)))
     ) {
       const [nameArg, handleArg] = node.arguments;
-      const handle =
-        handleArg && resolveHandleIdentifier(handleArg, [...nextChain, root], node.getStart());
-      if (nameArg && handle) {
+      const handles = handleArg
+        ? resolveHandleNames(handleArg, [...nextChain, root], node.getStart())
+        : [];
+      if (nameArg && handles.length > 0) {
         exposures.push({
-          handle,
+          handles,
           key: nameArg,
           chain: [...nextChain, root],
           at: node.getStart(),
@@ -834,9 +854,11 @@ function collectExposures(root) {
     chain.find((candidate) => declaredIn.get(candidate)?.has(name)) ?? chain[chain.length - 1];
 
   const byScope = new Map();
-  for (const { handle, key, chain, at } of exposures) {
+  for (const { handles, key, chain, at } of exposures) {
     // Both the alias and the handle it names carry the same state id.
-    for (const name of new Set([handle, ...rootNames(handle, chain, at)])) {
+    for (const name of new Set(
+      handles.flatMap((handle) => [handle, ...rootNames(handle, chain, at)])
+    )) {
       const owner = declaringScope(name, chain);
       if (!owner) continue;
       const scoped = byScope.get(owner) ?? new Map();

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -127,6 +127,20 @@ function bindingSemantics(binding) {
   return [binding.semantic, ...(binding.alternatives ?? [])].filter(Boolean);
 }
 
+/** A member entry holds one semantic, or several once a write may be skipped. */
+function memberSemantics(entry) {
+  if (!entry) return [];
+  return Array.isArray(entry) ? entry.filter(Boolean) : [entry];
+}
+
+/** The member entry a `x.name` or `x['name']` read names, if the owner has one. */
+function readMemberSemantics(node, scope) {
+  const owner = memberOwner(node);
+  const name = memberName(node);
+  if (!owner || name === null) return [];
+  return memberSemantics(resolveExpression(owner, scope).semanticMap?.get(name));
+}
+
 /** The scope a name is already bound in, so an assignment does not shadow it. */
 function scopeDeclaring(name, scope) {
   for (let current = scope; current; current = current.parent) {
@@ -176,6 +190,33 @@ function walk(node, scope, tokens, exposures) {
     for (const decl of node.declarationList.declarations) {
       registerDeclaration(decl, owner, exposures);
       if (decl.initializer) walk(decl.initializer, scope, tokens, exposures);
+    }
+    return;
+  }
+
+  if (
+    ts.isBinaryExpression(node) &&
+    node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    (ts.isPropertyAccessExpression(node.left) || ts.isElementAccessExpression(node.left))
+  ) {
+    // Writing through the container moves the member for every read that
+    // follows, so the rule side has to see it the way the exposure does.
+    walk(node.right, scope, tokens, exposures);
+    const base = unwrapTransparent(memberOwner(node.left) ?? node.left);
+    const member = memberName(node.left);
+    if (ts.isIdentifier(base) && member !== null) {
+      const owner = scopeDeclaring(base.text, scope) ?? scope;
+      const container = owner.bindings.get(base.text);
+      const written = bindingSemantics(resolveBinding(node.right, scope));
+      if (container && written.length > 0) {
+        const previous = memberSemantics(container.semanticMap?.get(member));
+        const kept = isConditionallyReached(node)
+          ? previous.filter((candidate) => !written.includes(candidate))
+          : [];
+        const semanticMap = new Map(container.semanticMap ?? []);
+        semanticMap.set(member, [...written, ...kept]);
+        owner.bindings.set(base.text, { ...container, semanticMap });
+      }
     }
     return;
   }
@@ -363,10 +404,11 @@ function resolveExpression(node, scope) {
   // `asHook().stateHandles.checked` bound straight to a name. Without this the
   // leaf resolves to nothing and `w.state(checked)` emits no variant, while the
   // same read through a destructure or through the bag resolves fine.
-  if (ts.isPropertyAccessExpression(node)) {
-    const owner = resolveExpression(node.expression, scope);
-    const semantic = owner.semanticMap?.get(node.name.text);
-    if (semantic) return asSemanticValue(semantic);
+  if (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) {
+    const semantics = readMemberSemantics(node, scope);
+    if (semantics.length > 0) {
+      return { ...asSemanticValue(semantics[0]), alternatives: semantics.slice(1) };
+    }
   }
 
   if (
@@ -1411,10 +1453,7 @@ function resolveStateHandleSemantic(node, scope) {
     return resolveStateHandleSemantic(node.expression, scope);
   }
   if (ts.isIdentifier(node)) return lookup(node.text, scope).semantic ?? null;
-  if (!ts.isPropertyAccessExpression(node)) return null;
-
-  const owner = resolveExpression(node.expression, scope);
-  return owner.semanticMap?.get(node.name.text) ?? null;
+  return readMemberSemantics(node, scope)[0] ?? null;
 }
 
 /**
@@ -1428,10 +1467,13 @@ const NATIVE_VARIANT_ATTRIBUTES = Object.freeze({
 
 /** Every semantic a `w.state(x)` argument may stand for. */
 function resolveStateHandleSemantics(node, scope) {
-  if (ts.isIdentifier(node)) {
-    const semantics = bindingSemantics(lookup(node.text, scope));
+  const inner = unwrapTransparent(node);
+  if (ts.isIdentifier(inner)) {
+    const semantics = bindingSemantics(lookup(inner.text, scope));
     if (semantics.length > 0) return semantics;
   }
+  const members = readMemberSemantics(inner, scope);
+  if (members.length > 0) return members;
   const single = resolveStateHandleSemantic(node, scope);
   return single ? [single] : [];
 }

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -102,9 +102,22 @@ function createScope(parent = null, node = null) {
   return { parent, bindings: new Map(), node };
 }
 
+/** The scope a name is already bound in, so an assignment does not shadow it. */
+function scopeDeclaring(name, scope) {
+  for (let current = scope; current; current = current.parent) {
+    if (current.bindings.has(name)) return current;
+  }
+  return null;
+}
+
 function walk(node, scope, tokens, exposures) {
   if (createsScope(node)) {
     const nextScope = createScope(scope, node);
+
+    // Registered before the body is walked, the same order the loop runs in.
+    for (const decl of loopInitializerDeclarations(node)) {
+      registerDeclaration(decl, nextScope, exposures);
+    }
 
     if (hasStatements(node)) {
       // Sequential, so a legal redeclaration still registers each binding for
@@ -139,6 +152,21 @@ function walk(node, scope, tokens, exposures) {
   }
 
   if (
+    ts.isBinaryExpression(node) &&
+    node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    ts.isIdentifier(node.left)
+  ) {
+    // A reassignment moves the handle for every read that follows it, so the
+    // binding has to move with it rather than stay at its declaration.
+    walk(node.right, scope, tokens, exposures);
+    const name = node.left.text;
+    const owner = scopeDeclaring(name, scope) ?? scope;
+    const binding = resolveBinding(node.right, scope);
+    owner.bindings.set(name, applyExposure(name, binding, owner, exposures));
+    return;
+  }
+
+  if (
     ts.isCallExpression(node) &&
     ts.isIdentifier(node.expression) &&
     node.expression.text === 'tw'
@@ -166,8 +194,21 @@ function createsScope(node) {
     ts.isCaseBlock(node) ||
     ts.isFunctionDeclaration(node) ||
     ts.isFunctionExpression(node) ||
-    ts.isArrowFunction(node)
+    ts.isArrowFunction(node) ||
+    // A loop initializer binds in the loop's own scope, so a name it shadows
+    // must not answer for the body.
+    isLoopStatement(node)
   );
+}
+
+function isLoopStatement(node) {
+  return ts.isForStatement(node) || ts.isForOfStatement(node) || ts.isForInStatement(node);
+}
+
+/** The declarations a loop initializer introduces, if it declares anything. */
+function loopInitializerDeclarations(node) {
+  const initializer = isLoopStatement(node) ? node.initializer : undefined;
+  return initializer && ts.isVariableDeclarationList(initializer) ? initializer.declarations : [];
 }
 
 function hasStatements(node) {
@@ -559,6 +600,70 @@ function collectExposures(root) {
     objectMembers.set(owner, scoped);
   };
 
+  /** The identifier member `key` of an initializer names, if it names one. */
+  const memberTargetName = (initializer, key, chain, at) => {
+    const value = unwrapExpression(initializer);
+    if (ts.isObjectLiteralExpression(value)) {
+      for (const property of value.properties) {
+        if (ts.isShorthandPropertyAssignment(property) && property.name.text === key) {
+          return key;
+        }
+        if (
+          ts.isPropertyAssignment(property) &&
+          (ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name)) &&
+          property.name.text === key
+        ) {
+          const assigned = unwrapExpression(property.initializer);
+          return ts.isIdentifier(assigned) ? assigned.text : null;
+        }
+      }
+      return null;
+    }
+    if (!ts.isIdentifier(value)) return null;
+    for (const scope of chain) {
+      const members = objectMembers.get(scope)?.get(value.text);
+      if (!members) continue;
+      const edges = members.get(key);
+      if (!edges) return null;
+      const visible = edges.filter((edge) => edge.at <= at);
+      if (visible.length === 0) return null;
+      return visible.reduce((latest, edge) => (edge.at > latest.at ? edge : latest)).target;
+    }
+    return null;
+  };
+
+  /**
+   * The handle each name in a binding pattern ends up on. A pattern aliases the
+   * same state object a plain `const publicFlag = flag` does, so it has to
+   * create the same edge.
+   */
+  const patternTargets = (name, initializer, chain, at) => {
+    const out = [];
+    if (ts.isObjectBindingPattern(name)) {
+      for (const element of name.elements) {
+        if (!ts.isIdentifier(element.name) || element.dotDotDotToken) continue;
+        const key = element.propertyName
+          ? getPropertyName(element.propertyName)
+          : element.name.text;
+        if (!key) continue;
+        const target = memberTargetName(initializer, key, chain, at);
+        if (target) out.push({ name: element.name.text, target });
+      }
+      return out;
+    }
+    if (!ts.isArrayBindingPattern(name)) return out;
+    const values = unwrapExpression(initializer);
+    if (!ts.isArrayLiteralExpression(values)) return out;
+    name.elements.forEach((element, index) => {
+      if (ts.isOmittedExpression(element)) return;
+      if (!ts.isIdentifier(element.name) || element.dotDotDotToken) return;
+      const value = values.elements[index] && unwrapExpression(values.elements[index]);
+      if (value && ts.isIdentifier(value))
+        out.push({ name: element.name.text, target: value.text });
+    });
+    return out;
+  };
+
   const resolveHandleIdentifier = (node, chain, at) => {
     const value = unwrapExpression(node);
     if (ts.isIdentifier(value)) return value.text;
@@ -620,6 +725,20 @@ function collectExposures(root) {
         for (const target of aliasTargets(node.initializer)) {
           aliasEdges.push({ owner, name: node.name.text, target, at: node.getStart() });
         }
+      }
+    }
+    if (
+      ts.isVariableDeclaration(node) &&
+      !ts.isIdentifier(node.name) &&
+      node.initializer &&
+      nextChain.length > 0
+    ) {
+      const owner = nextChain[0] ?? root;
+      const at = node.getStart();
+      for (const { name, target } of patternTargets(node.name, node.initializer, nextChain, at)) {
+        if (!declaredIn.has(owner)) declaredIn.set(owner, new Set());
+        declaredIn.get(owner).add(name);
+        aliasEdges.push({ owner, name, target, at });
       }
     }
     // Writing through the container moves the handle the same way, so the
@@ -1089,13 +1208,23 @@ function resolveStateHandleSemantic(node, scope) {
   return owner.semanticMap?.get(node.name.text) ?? null;
 }
 
+/**
+ * `buildSemanticVariant` takes a native variant only for a true comparison, so
+ * every other comparison falls back to the attribute the same binding carries.
+ */
+const NATIVE_VARIANT_ATTRIBUTES = Object.freeze({
+  hover: 'data-[hovered]',
+  active: 'data-[pressed]',
+});
+
 function resolveStateEqVariant(semantic, expected) {
   if (!semantic) return null;
   if (!expected) return null;
   if (expected.kind === ts.SyntaxKind.TrueKeyword) return semantic;
-  if (expected.kind === ts.SyntaxKind.FalseKeyword) return negateDataVariant(semantic);
+  const attribute = officialEntry(NATIVE_VARIANT_ATTRIBUTES, semantic) ?? semantic;
+  if (expected.kind === ts.SyntaxKind.FalseKeyword) return negateDataVariant(attribute);
   if (ts.isStringLiteralLike(expected)) {
-    const match = semantic.match(/^data-\[([a-zA-Z0-9-]+)\]$/);
+    const match = attribute.match(/^data-\[([a-zA-Z0-9-]+)\]$/);
     if (!match || !/^[a-zA-Z0-9_-]+$/.test(expected.text)) return null;
     return `data-[${match[1]}=${expected.text}]`;
   }
@@ -1103,7 +1232,7 @@ function resolveStateEqVariant(semantic, expected) {
   // enum and string bindings do.
   const numeric = signedNumericText(expected);
   if (numeric !== null) {
-    const match = semantic.match(/^data-\[([a-zA-Z0-9-]+)\]$/);
+    const match = attribute.match(/^data-\[([a-zA-Z0-9-]+)\]$/);
     if (!match) return null;
     return `data-[${match[1]}=${numeric}]`;
   }

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -482,20 +482,25 @@ function collectExposures(root) {
         if (edge.owner !== owner || edge.name !== name || edge.at > at) continue;
         if (!best || edge.at > best.at) best = edge;
       }
-      if (best) return best.target;
+      if (best) return best;
     }
     return null;
   };
 
+  // Each hop resolves where that edge was created, not where the exposure was
+  // written: an alias captured its target at its own initialization, so a later
+  // redeclaration of the intermediate name cannot retarget it.
   const rootName = (name, chain, at) => {
     const seen = new Set();
     let current = name;
+    let cursor = at;
     for (;;) {
       if (seen.has(current)) return current;
       seen.add(current);
-      const next = lookupAlias(current, chain, at);
-      if (!next) return current;
-      current = next;
+      const edge = lookupAlias(current, chain, cursor);
+      if (!edge) return current;
+      current = edge.target;
+      cursor = edge.at;
     }
   };
 
@@ -885,13 +890,17 @@ function resolveStateEqVariant(semantic, expected) {
 
 /** `-1` parses as a prefix unary expression rather than a numeric literal. */
 function signedNumericText(node) {
-  if (ts.isNumericLiteral(node)) return node.text;
+  // The runtime lowers with `String(literal)`, so the canonical value is what
+  // the selector must carry — `-0` projects as `0`, not `-0`.
+  const canonical = (value) => (Number.isFinite(value) ? String(value) : null);
+  if (ts.isNumericLiteral(node)) return canonical(Number(node.text));
   if (
     ts.isPrefixUnaryExpression(node) &&
     (node.operator === ts.SyntaxKind.MinusToken || node.operator === ts.SyntaxKind.PlusToken) &&
     ts.isNumericLiteral(node.operand)
   ) {
-    return node.operator === ts.SyntaxKind.MinusToken ? `-${node.operand.text}` : node.operand.text;
+    const magnitude = Number(node.operand.text);
+    return canonical(node.operator === ts.SyntaxKind.MinusToken ? -magnitude : magnitude);
   }
   return null;
 }

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -388,9 +388,10 @@ function exposedDataAttributeName(key) {
  * Aliases are followed because two references to one handle carry one state id.
  */
 function collectExposures(root) {
-  // Alias edges are keyed by the scope they were declared in, so two sibling
-  // scopes may each bind the same alias name without colliding.
-  const aliasesByScope = new Map();
+  // Alias edges carry their scope and source position, so two sibling scopes
+  // may bind the same name and a later redeclaration cannot rewrite what an
+  // earlier expose call captured.
+  const aliasEdges = [];
   const exposures = [];
 
   const unwrapExpression = (node) =>
@@ -417,6 +418,15 @@ function collectExposures(root) {
     return false;
   };
 
+  const namesExpose = (callee) => {
+    if (ts.isPropertyAccessExpression(callee)) return callee.name.text === 'expose';
+    if (ts.isElementAccessExpression(callee)) {
+      const argument = callee.argumentExpression;
+      return Boolean(argument) && ts.isStringLiteralLike(argument) && argument.text === 'expose';
+    }
+    return false;
+  };
+
   const namesExposeOwner = (node) => {
     const owner = unwrapExpression(node);
     if (ts.isPropertyAccessExpression(owner)) return owner.name.text === 'expose';
@@ -434,46 +444,65 @@ function collectExposures(root) {
     if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
       const initializer = unwrapExpression(node.initializer);
       if (ts.isIdentifier(initializer)) {
-        const owner = nextChain[0] ?? root;
-        if (!aliasesByScope.has(owner)) aliasesByScope.set(owner, new Map());
-        aliasesByScope.get(owner).set(node.name.text, initializer.text);
+        aliasEdges.push({
+          owner: nextChain[0] ?? root,
+          name: node.name.text,
+          target: initializer.text,
+          at: node.getStart(),
+        });
       }
     }
-    if (ts.isCallExpression(node) && namesExposeState(unwrapExpression(node.expression))) {
+    if (
+      ts.isCallExpression(node) &&
+      (namesExposeState(unwrapExpression(node.expression)) ||
+        // `def.expose('ready', state)` — the generic entry wraps a state handle,
+        // so the Web optimizer lowers rules on it just the same.
+        namesExpose(unwrapExpression(node.expression)))
+    ) {
       const [nameArg, handleArg] = node.arguments;
       const handle = handleArg && unwrapExpression(handleArg);
       if (nameArg && handle && ts.isIdentifier(handle)) {
-        exposures.push({ handle: handle.text, key: nameArg, chain: [...nextChain, root] });
+        exposures.push({
+          handle: handle.text,
+          key: nameArg,
+          chain: [...nextChain, root],
+          at: node.getStart(),
+        });
       }
     }
     ts.forEachChild(node, (child) => visit(child, nextChain));
   };
   visit(root, []);
 
-  const lookupAlias = (name, chain) => {
+  // The edge in effect where the exposure was written, nearest scope first.
+  const lookupAlias = (name, chain, at) => {
     for (const owner of chain) {
-      const scoped = aliasesByScope.get(owner);
-      if (scoped?.has(name)) return scoped.get(name);
+      let best = null;
+      for (const edge of aliasEdges) {
+        if (edge.owner !== owner || edge.name !== name || edge.at > at) continue;
+        if (!best || edge.at > best.at) best = edge;
+      }
+      if (best) return best.target;
     }
     return null;
   };
 
-  const rootName = (name, chain) => {
+  const rootName = (name, chain, at) => {
     const seen = new Set();
     let current = name;
     for (;;) {
       if (seen.has(current)) return current;
       seen.add(current);
-      const next = lookupAlias(current, chain);
+      const next = lookupAlias(current, chain, at);
       if (!next) return current;
       current = next;
     }
   };
 
   const byHandle = new Map();
-  for (const { handle, key, chain } of exposures) {
+  for (const { handle, key, chain, at } of exposures) {
     // Both the alias and the handle it names carry the same state id.
-    for (const name of new Set([handle, rootName(handle, chain)])) {
+    for (const name of new Set([handle, rootName(handle, chain, at)])) {
       if (!byHandle.has(name)) byHandle.set(name, key);
     }
   }
@@ -845,10 +874,24 @@ function resolveStateEqVariant(semantic, expected) {
   }
   // `number.discrete` bindings lower by stringifying the literal, the same way
   // enum and string bindings do.
-  if (ts.isNumericLiteral(expected)) {
+  const numeric = signedNumericText(expected);
+  if (numeric !== null) {
     const match = semantic.match(/^data-\[([a-zA-Z0-9-]+)\]$/);
     if (!match) return null;
-    return `data-[${match[1]}=${expected.text}]`;
+    return `data-[${match[1]}=${numeric}]`;
+  }
+  return null;
+}
+
+/** `-1` parses as a prefix unary expression rather than a numeric literal. */
+function signedNumericText(node) {
+  if (ts.isNumericLiteral(node)) return node.text;
+  if (
+    ts.isPrefixUnaryExpression(node) &&
+    (node.operator === ts.SyntaxKind.MinusToken || node.operator === ts.SyntaxKind.PlusToken) &&
+    ts.isNumericLiteral(node.operand)
+  ) {
+    return node.operator === ts.SyntaxKind.MinusToken ? `-${node.operand.text}` : node.operand.text;
   }
   return null;
 }

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -205,17 +205,18 @@ function walk(node, scope, tokens, exposures) {
     const base = unwrapTransparent(memberOwner(node.left) ?? node.left);
     const member = memberName(node.left);
     if (ts.isIdentifier(base) && member !== null) {
-      const owner = scopeDeclaring(base.text, scope) ?? scope;
-      const container = owner.bindings.get(base.text);
+      // `const alias = controls` names the same object, and both bindings hold
+      // the one resolved value, so the member moves on that value rather than
+      // on a copy rebound to whichever name the write happened to use.
+      const container = resolveExpression(base, scope);
       const written = bindingSemantics(resolveBinding(node.right, scope));
       if (container && written.length > 0) {
         const previous = memberSemantics(container.semanticMap?.get(member));
         const kept = isConditionallyReached(node)
           ? previous.filter((candidate) => !written.includes(candidate))
           : [];
-        const semanticMap = new Map(container.semanticMap ?? []);
-        semanticMap.set(member, [...written, ...kept]);
-        owner.bindings.set(base.text, { ...container, semanticMap });
+        if (!container.semanticMap) container.semanticMap = new Map();
+        container.semanticMap.set(member, [...written, ...kept]);
       }
     }
     return;
@@ -807,6 +808,24 @@ function collectExposures(root) {
     }
   };
 
+  /**
+   * `const alias = controls` names one object, so a member written through
+   * either name lands on the same table. A base that may be two different
+   * objects is left as itself: there is no single table to move.
+   */
+  const containerRoot = (name, chain, at, seen = new Set()) => {
+    if (seen.has(name)) return name;
+    for (const owner of chain) {
+      const candidates = aliasEdges.filter((edge) => edge.owner === owner && edge.name === name);
+      if (candidates.length === 0) continue;
+      const visible = visibleEdges(candidates, at);
+      if (visible.length !== 1) return name;
+      const [edge] = visible;
+      return containerRoot(edge.target, edge.chain ?? chain, edge.at, new Set([...seen, name]));
+    }
+    return name;
+  };
+
   const recordMember = (owner, base, key, target, at, conditional) => {
     const scoped = objectMembers.get(owner) ?? new Map();
     const members = scoped.get(base) ?? new Map();
@@ -835,8 +854,9 @@ function collectExposures(root) {
       return null;
     }
     if (!ts.isIdentifier(value)) return null;
+    const container = containerRoot(value.text, chain, at);
     for (const scope of chain) {
-      const members = objectMembers.get(scope)?.get(value.text);
+      const members = objectMembers.get(scope)?.get(container);
       if (!members) continue;
       const edges = members.get(key);
       if (!edges) return null;
@@ -891,8 +911,9 @@ function collectExposures(root) {
     if (!owner) return [];
     const base = unwrapExpression(owner);
     if (!ts.isIdentifier(base)) return [];
+    const container = containerRoot(base.text, chain, at);
     for (const scope of chain) {
-      const members = objectMembers.get(scope)?.get(base.text);
+      const members = objectMembers.get(scope)?.get(container);
       if (!members) continue;
       for (const [key, edges] of members) {
         if (!memberIs(value, key)) continue;
@@ -974,13 +995,15 @@ function collectExposures(root) {
       const base = unwrapExpression(memberOwner(node.left) ?? node.left);
       const member = memberName(node.left);
       if (ts.isIdentifier(base) && member !== null) {
+        const chain = [...nextChain, root];
+        const container = containerRoot(base.text, chain, node.getStart());
         const owner =
-          [...nextChain, root].find((candidate) => declaredIn.get(candidate)?.has(base.text)) ??
+          chain.find((candidate) => declaredIn.get(candidate)?.has(container)) ??
           nextChain[0] ??
           root;
         const conditional = isConditionallyReached(node);
         for (const target of aliasTargets(node.right)) {
-          recordMember(owner, base.text, member, target, node.getStart(), conditional);
+          recordMember(owner, container, member, target, node.getStart(), conditional);
         }
       }
     }

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -114,6 +114,7 @@ function walk(node, scope, tokens) {
           }
           continue;
         }
+        registerExposedState(stmt, nextScope);
         walk(stmt, nextScope, tokens);
       }
       return;
@@ -328,6 +329,48 @@ function resolveBinding(node, scope) {
   const semantic = resolveSemanticBinding(node);
   const value = resolveExpression(node, scope);
   return semantic ? { ...value, semantic } : value;
+}
+
+/**
+ * The same normalization `createExposeStateWebNameMap` applies to an
+ * unannotated exposed key before it becomes a data attribute.
+ */
+function exposedDataAttributeName(key) {
+  return key
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/\./g, '-')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+}
+
+/**
+ * `def.expose.state('hidden', hidden)` is what gives a prototype-owned state a
+ * host attribute, so it is also what tells the extractor the selector. Without
+ * it a `def.state.bool` handle has no semantic, the rule contributes a bare
+ * token, and the variant the Web runtime lowers has no CSS.
+ *
+ * The exposed key is a fallback only: a handle that already carries an official
+ * semantic keeps it, which is the precedence `createExposeStateWebNameMap` uses
+ * when it maps an official semantic before falling back to the key.
+ */
+function registerExposedState(statement, scope) {
+  if (!ts.isExpressionStatement(statement)) return;
+  const call = statement.expression;
+  if (!ts.isCallExpression(call)) return;
+  if (!ts.isPropertyAccessExpression(call.expression)) return;
+  if (!isPropertyAccessChain(call.expression, ['expose', 'state'])) return;
+  const [nameArg, handleArg] = call.arguments;
+  if (!nameArg || !handleArg) return;
+  if (!ts.isStringLiteralLike(nameArg) || !ts.isIdentifier(handleArg)) return;
+  const attribute = exposedDataAttributeName(nameArg.text);
+  if (!attribute) return;
+  const existing = lookup(handleArg.text, scope);
+  if (existing.semantic) return;
+  scope.bindings.set(handleArg.text, { ...existing, semantic: `data-[${attribute}]` });
 }
 
 function resolveSemanticBinding(node) {
@@ -704,6 +747,7 @@ function collectTwTokens(node, scope) {
             }
             continue;
           }
+          registerExposedState(stmt, nextScope);
           visit(stmt, nextScope);
         }
         return;

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -106,8 +106,14 @@ function enclosingFunction(node) {
   return node ? (ts.findAncestor(node, (candidate) => ts.isFunctionLike(candidate)) ?? null) : null;
 }
 
-/** `(() => { … })()` runs where it is written, so its writes are ordered. */
-function isImmediatelyInvoked(fn) {
+/**
+ * `(() => { … })()` runs where it is written, so its writes are ordered. An
+ * async function may suspend before the write and a generator does not run its
+ * body on the call at all, so neither is ordered however it is invoked.
+ */
+function runsInPlace(fn) {
+  if (fn.asteriskToken) return false;
+  if (fn.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword)) return false;
   let node = fn;
   while (node.parent && ts.isParenthesizedExpression(node.parent)) node = node.parent;
   return Boolean(
@@ -124,7 +130,7 @@ function isImmediatelyInvoked(fn) {
 function isDeferredWrite(node, readFunction) {
   const writing = enclosingFunction(node);
   if (writing === readFunction) return false;
-  return !(writing && isImmediatelyInvoked(writing));
+  return !(writing && runsInPlace(writing));
 }
 
 /** `var` binds to the function however deeply the declaration is nested. */

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -279,19 +279,34 @@ function walk(node, scope, tokens, exposures) {
     walk(node.right, scope, tokens, exposures);
     const base = unwrapTransparent(memberOwner(node.left) ?? node.left);
     const member = memberName(node.left);
-    if (ts.isIdentifier(base) && member !== null) {
+    if (ts.isIdentifier(base)) {
       // `const alias = controls` names the same object, and both bindings hold
       // the one resolved value, so the member moves on that value rather than
       // on a copy rebound to whichever name the write happened to use.
-      const container = resolveExpression(base, scope);
+      const resolved = resolveExpression(base, scope);
+      // A base that may be either of two objects writes to both tables.
+      const targets = resolved?.containers ?? (resolved ? [resolved] : []);
       const written = bindingSemantics(resolveBinding(node.right, scope));
-      if (container && written.length > 0) {
-        const previous = memberSemantics(container.semanticMap?.get(member));
+      for (const container of targets) {
+        if (written.length === 0) break;
+        // The declaring scope, not this one: inside a callback the write would
+        // otherwise be compared against itself and always look ordered.
+        const declaring = scopeDeclaring(base.text, scope);
         const uncertain =
-          isConditionallyReached(node) || isDeferredWrite(node, enclosingFunction(scope.node));
-        const kept = uncertain ? previous.filter((candidate) => !written.includes(candidate)) : [];
+          isConditionallyReached(node) ||
+          isDeferredWrite(node, enclosingFunction(declaring?.node ?? null)) ||
+          targets.length > 1 ||
+          // A key this cannot read may name any member the container has.
+          member === null;
         if (!container.semanticMap) container.semanticMap = new Map();
-        container.semanticMap.set(member, [...written, ...kept]);
+        const keys = member === null ? [...container.semanticMap.keys()] : [member];
+        for (const key of keys) {
+          const previous = memberSemantics(container.semanticMap.get(key));
+          const kept = uncertain
+            ? previous.filter((candidate) => !written.includes(candidate))
+            : [];
+          container.semanticMap.set(key, [...written, ...kept]);
+        }
       }
     }
     return;
@@ -587,6 +602,10 @@ function resolveBinding(node, scope) {
     if (semantics.length > 0) {
       return { ...branches[0], semantic: semantics[0], alternatives: semantics.slice(1) };
     }
+    // Neither branch is a handle, but the name may still be either object, so
+    // it carries both and a member write through it reaches both tables.
+    const containers = branches.filter((branch) => branch.semanticMap);
+    if (containers.length > 0) return { ...branches[0], containers };
   }
 
   const semantic = resolveSemanticBinding(node);
@@ -890,18 +909,27 @@ function collectExposures(root) {
    * either name lands on the same table. A base that may be two different
    * objects is left as itself: there is no single table to move.
    */
-  const containerRoot = (name, chain, at, seen = new Set()) => {
-    if (seen.has(name)) return name;
+  const containerRoots = (name, chain, at, seen = new Set()) => {
+    if (seen.has(name)) return [name];
     for (const owner of chain) {
       const candidates = aliasEdges.filter((edge) => edge.owner === owner && edge.name === name);
       if (candidates.length === 0) continue;
       const visible = visibleEdges(candidates, at);
-      if (visible.length !== 1) return name;
-      const [edge] = visible;
-      return containerRoot(edge.target, edge.chain ?? chain, edge.at, new Set([...seen, name]));
+      if (visible.length === 0) return [name];
+      const next = new Set([...seen, name]);
+      // A base that may be either of two objects writes to both tables, and
+      // reads consult both; recording under the alias would reach neither.
+      return [
+        ...new Set(
+          visible.flatMap((edge) => containerRoots(edge.target, edge.chain ?? chain, edge.at, next))
+        ),
+      ];
     }
-    return name;
+    return [name];
   };
+
+  const declaringScopeNode = (chain, name) =>
+    chain.find((candidate) => declaredIn.get(candidate)?.has(name)) ?? null;
 
   const recordMember = (owner, base, key, target, at, conditional) => {
     const scoped = objectMembers.get(owner) ?? new Map();
@@ -931,7 +959,7 @@ function collectExposures(root) {
       return null;
     }
     if (!ts.isIdentifier(value)) return null;
-    const container = containerRoot(value.text, chain, at);
+    const [container] = containerRoots(value.text, chain, at);
     for (const scope of chain) {
       const members = objectMembers.get(scope)?.get(container);
       if (!members) continue;
@@ -988,17 +1016,19 @@ function collectExposures(root) {
     if (!owner) return [];
     const base = unwrapExpression(owner);
     if (!ts.isIdentifier(base)) return [];
-    const container = containerRoot(base.text, chain, at);
-    for (const scope of chain) {
-      const members = objectMembers.get(scope)?.get(container);
-      if (!members) continue;
-      for (const [key, edges] of members) {
-        if (!memberIs(value, key)) continue;
-        return visibleEdges(edges, at).map((edge) => ({ name: edge.target, at: edge.at }));
+    const out = [];
+    for (const container of containerRoots(base.text, chain, at)) {
+      for (const scope of chain) {
+        const members = objectMembers.get(scope)?.get(container);
+        if (!members) continue;
+        for (const [key, edges] of members) {
+          if (!memberIs(value, key)) continue;
+          out.push(...visibleEdges(edges, at).map((edge) => ({ name: edge.target, at: edge.at })));
+        }
+        break;
       }
-      return [];
     }
-    return [];
+    return out;
   };
 
   const visit = (node, chain) => {
@@ -1073,16 +1103,33 @@ function collectExposures(root) {
     ) {
       const base = unwrapExpression(memberOwner(node.left) ?? node.left);
       const member = memberName(node.left);
-      if (ts.isIdentifier(base) && member !== null) {
+      if (ts.isIdentifier(base)) {
         const chain = [...nextChain, root];
-        const container = containerRoot(base.text, chain, node.getStart());
-        const owner =
-          chain.find((candidate) => declaredIn.get(candidate)?.has(container)) ??
-          nextChain[0] ??
-          root;
-        const conditional = isConditionallyReached(node);
-        for (const target of aliasTargets(node.right)) {
-          recordMember(owner, container, member, target, node.getStart(), conditional);
+        const at = node.getStart();
+        const containers = containerRoots(base.text, chain, at);
+        // A write the source may skip, one that has not run, one that may land
+        // on either of two objects, or one whose key is not statically known:
+        // in each case the member may still hold what it held before.
+        const conditional =
+          isConditionallyReached(node) ||
+          isDeferredWrite(node, enclosingFunction(declaringScopeNode(chain, containers[0]))) ||
+          containers.length > 1 ||
+          member === null;
+        for (const container of containers) {
+          const owner =
+            chain.find((candidate) => declaredIn.get(candidate)?.has(container)) ??
+            nextChain[0] ??
+            root;
+          // An unreadable key may be any member the container already has.
+          const keys =
+            member === null
+              ? [...(objectMembers.get(owner)?.get(container)?.keys() ?? [])]
+              : [member];
+          for (const key of keys) {
+            for (const target of aliasTargets(node.right)) {
+              recordMember(owner, container, key, target, at, conditional);
+            }
+          }
         }
       }
     }

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -127,10 +127,54 @@ function runsInPlace(fn) {
  * over-approximation the conditional path applies, in time rather than in name
  * resolution.
  */
+/**
+ * Whether a statement may hand control somewhere else before finishing. Nested
+ * functions are skipped: their `return` belongs to them, not to this sequence.
+ */
+function mayCompleteAbruptly(node) {
+  let found = false;
+  const visit = (current) => {
+    if (found || ts.isFunctionLike(current)) return;
+    if (
+      ts.isReturnStatement(current) ||
+      ts.isThrowStatement(current) ||
+      ts.isBreakStatement(current) ||
+      ts.isContinueStatement(current)
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(current, visit);
+  };
+  visit(node);
+  return found;
+}
+
+/**
+ * Whether a write is guaranteed to have run by the time `boundary` returns.
+ * Being called synchronously proves the function starts, not that this write is
+ * reached, so any earlier statement that may complete abruptly leaves it
+ * unproven and the earlier handle stays a candidate.
+ */
+function reachedInPlace(node, boundary) {
+  let child = node;
+  for (let parent = node.parent; parent; child = parent, parent = parent.parent) {
+    if (ts.isBlock(parent) || ts.isCaseClause(parent) || ts.isDefaultClause(parent)) {
+      for (const statement of parent.statements) {
+        if (statement === child) break;
+        if (mayCompleteAbruptly(statement)) return false;
+      }
+    }
+    if (parent === boundary) break;
+  }
+  return true;
+}
+
 function isDeferredWrite(node, readFunction) {
   const writing = enclosingFunction(node);
   if (writing === readFunction) return false;
-  return !(writing && runsInPlace(writing));
+  if (!writing || !runsInPlace(writing)) return true;
+  return !reachedInPlace(node, writing);
 }
 
 /** `var` binds to the function however deeply the declaration is nested. */

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -307,30 +307,29 @@ function resolveExpression(node, scope) {
     return asStringValue([parts.join('')]);
   }
 
-  // `const [publicFlag] = [flag]` — the index is the member name. Checked
-  // before the token-array reading below, which needs every element to be a
-  // string and so gives up on an array holding a handle.
+  // The index is the member name a positional pattern binds, and an array may
+  // hold tokens and handles at once, so both are read in one pass.
   if (ts.isArrayLiteralExpression(node)) {
     const semantics = new Map();
+    const parts = [];
+    let readsAsTokens = true;
     node.elements.forEach((element, index) => {
-      if (ts.isOmittedExpression(element)) return;
+      if (ts.isOmittedExpression(element)) {
+        readsAsTokens = false;
+        return;
+      }
       const held = resolveBinding(element, scope);
       if (held.semantic) semantics.set(String(index), held.semantic);
+      if (held.single) parts.push(held.single);
+      else readsAsTokens = false;
     });
-    if (semantics.size > 0) return asSemanticMapValue(semantics);
-  }
-
-  if (ts.isArrayLiteralExpression(node)) {
-    const parts = [];
-    for (const element of node.elements) {
-      const value = resolveExpression(element, scope);
-      if (!value.single) return emptyValue();
-      parts.push(value.single);
-    }
     // Keep the element list: a comma-joined string cannot tell an element
     // boundary from a comma inside an arbitrary token such as
     // `transition-[color,box-shadow]`.
-    return { ...asStringValue([parts.join(',')]), elements: parts };
+    const value = readsAsTokens
+      ? { ...asStringValue([parts.join(',')]), elements: parts }
+      : emptyValue();
+    return semantics.size > 0 ? { ...value, semanticMap: semantics } : value;
   }
 
   if (
@@ -352,23 +351,6 @@ function resolveExpression(node, scope) {
 
   // `const controls = { ready: flag }` — a plain container of handles reads the
   // same way an `asHook` bag does, so `w.state(controls.ready)` has a variant.
-  if (ts.isObjectLiteralExpression(node)) {
-    const semantics = new Map();
-    for (const property of node.properties) {
-      if (ts.isShorthandPropertyAssignment(property)) {
-        const held = resolveBinding(property.name, scope);
-        if (held.semantic) semantics.set(property.name.text, held.semantic);
-        continue;
-      }
-      if (!ts.isPropertyAssignment(property)) continue;
-      const key = getPropertyName(property.name);
-      if (!key) continue;
-      const held = resolveBinding(property.initializer, scope);
-      if (held.semantic) semantics.set(key, held.semantic);
-    }
-    if (semantics.size > 0) return asSemanticMapValue(semantics);
-  }
-
   if (ts.isPropertyAccessExpression(node) && node.name.text === 'stateHandles') {
     const stateHandles = resolveKnownAsHookStateHandles(node.expression);
     if (stateHandles) return asSemanticMapValue(stateHandles);
@@ -398,20 +380,28 @@ function resolveExpression(node, scope) {
     return resolveExpression(node.expression, scope);
   }
 
+  // A container may hold token data and state handles at once — reading it for
+  // one must not discard the other. `const controls = { ready: flag, className:
+  // 'bg-red' }` has to answer both `w.state(controls.ready)` and
+  // `tw(controls.className)`.
   if (ts.isObjectLiteralExpression(node)) {
     const entries = new Map();
+    const semantics = new Map();
     for (const prop of node.properties) {
       if (ts.isPropertyAssignment(prop)) {
         const key = getPropertyName(prop.name);
         if (!key) continue;
-        const value = resolveExpression(prop.initializer, scope);
-        if (value.strings.length > 0) entries.set(key, value.strings);
+        const held = resolveBinding(prop.initializer, scope);
+        if (held.strings.length > 0) entries.set(key, held.strings);
+        if (held.semantic) semantics.set(key, held.semantic);
       } else if (ts.isShorthandPropertyAssignment(prop)) {
-        const value = lookup(prop.name.text, scope);
-        if (value.strings.length > 0) entries.set(prop.name.text, value.strings);
+        const held = lookup(prop.name.text, scope);
+        if (held.strings.length > 0) entries.set(prop.name.text, held.strings);
+        if (held.semantic) semantics.set(prop.name.text, held.semantic);
       }
     }
-    return asMapValue(entries);
+    const value = asMapValue(entries);
+    return semantics.size > 0 ? { ...value, semanticMap: semantics } : value;
   }
 
   if (ts.isElementAccessExpression(node)) {
@@ -464,6 +454,21 @@ function lookup(name, scope) {
 }
 
 function resolveBinding(node, scope) {
+  const inner = unwrapTransparent(node);
+  // The runtime keeps one branch, and whichever it keeps carries its own
+  // declared name, so both candidates need a selector and neither may fall
+  // back to the expose key.
+  if (ts.isConditionalExpression(inner)) {
+    const branches = [
+      resolveBinding(inner.whenTrue, scope),
+      resolveBinding(inner.whenFalse, scope),
+    ];
+    const semantics = [...new Set(branches.flatMap(bindingSemantics))];
+    if (semantics.length > 0) {
+      return { ...branches[0], semantic: semantics[0], alternatives: semantics.slice(1) };
+    }
+  }
+
   const semantic = resolveSemanticBinding(node);
   const value = resolveExpression(node, scope);
   const declared = resolveDeclaredStateName(node, scope);
@@ -888,6 +893,7 @@ function collectExposures(root) {
             target,
             at: node.getStart(),
             conditional,
+            chain: [...nextChain, root],
           });
         }
       }
@@ -912,6 +918,7 @@ function collectExposures(root) {
           target: alias.target,
           at: alias.at,
           conditional,
+          chain: [...nextChain, root],
         });
       }
     }
@@ -954,7 +961,14 @@ function collectExposures(root) {
         recordObjectLiteral(owner, node.left.text, replacement, node.getStart(), conditional);
       }
       for (const target of aliasTargets(node.right)) {
-        aliasEdges.push({ owner, name: node.left.text, target, at: node.getStart(), conditional });
+        aliasEdges.push({
+          owner,
+          name: node.left.text,
+          target,
+          at: node.getStart(),
+          conditional,
+          chain: [...nextChain, root],
+        });
       }
     }
     if (
@@ -994,11 +1008,13 @@ function collectExposures(root) {
   // A conditional alias records one edge per branch, so resolution fans out
   // rather than picking one: whichever handle the runtime selects has a variant.
   const rootNames = (name, chain, at, seen = new Set()) => {
-    if (seen.has(name)) return [name];
+    if (seen.has(name)) return [{ name, chain }];
     const edges = lookupAliases(name, chain, at);
-    if (edges.length === 0) return [name];
+    if (edges.length === 0) return [{ name, chain }];
     const next = new Set([...seen, name]);
-    return edges.flatMap((edge) => rootNames(edge.target, chain, edge.at, next));
+    // An alias captured its target where the alias was written, so a name the
+    // exposure site shadows must not answer for it.
+    return edges.flatMap((edge) => rootNames(edge.target, edge.chain ?? chain, edge.at, next));
   };
 
   // An exposure names a binding, and a binding lives in one scope. Recording it
@@ -1010,13 +1026,19 @@ function collectExposures(root) {
   const byScope = new Map();
   for (const { handles, key, chain } of exposures) {
     // Both the alias and the handle it names carry the same state id.
-    for (const name of new Set(
-      handles.flatMap((handle) => [handle.name, ...rootNames(handle.name, chain, handle.at)])
-    )) {
-      const owner = declaringScope(name, chain);
+    const named = handles.flatMap((handle) => [
+      { name: handle.name, chain },
+      ...rootNames(handle.name, chain, handle.at),
+    ]);
+    const seen = new Set();
+    for (const entry of named) {
+      const owner = declaringScope(entry.name, entry.chain);
       if (!owner) continue;
+      const identity = `${entry.name}\u0000${owner.pos}`;
+      if (seen.has(identity)) continue;
+      seen.add(identity);
       const scoped = byScope.get(owner) ?? new Map();
-      if (!scoped.has(name)) scoped.set(name, key);
+      if (!scoped.has(entry.name)) scoped.set(entry.name, key);
       byScope.set(owner, scoped);
     }
   }

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -388,8 +388,8 @@ function exposedDataAttributeName(key) {
  * Aliases are followed because two references to one handle carry one state id.
  */
 function collectExposures(root) {
-  // Alias edges are keyed by the function they were declared in, so two setups
-  // in one file may each bind the same alias name without colliding.
+  // Alias edges are keyed by the scope they were declared in, so two sibling
+  // scopes may each bind the same alias name without colliding.
   const aliasesByScope = new Map();
   const exposures = [];
 
@@ -428,7 +428,9 @@ function collectExposures(root) {
   };
 
   const visit = (node, chain) => {
-    const nextChain = ts.isFunctionLike(node) ? [node, ...chain] : chain;
+    // Every scope the extractor itself creates, so two sibling blocks in one
+    // setup may reuse an alias name without either edge overwriting the other.
+    const nextChain = createsScope(node) ? [node, ...chain] : chain;
     if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
       const initializer = unwrapExpression(node.initializer);
       if (ts.isIdentifier(initializer)) {

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -16,7 +16,7 @@ export async function collectProtoStyleTokens(root) {
     const sourceFile = await parseSourceFile(file);
     const scope = createScope();
     await applyImportBindings(file, sourceFile, scope, moduleCache, []);
-    walk(sourceFile, scope, tokens);
+    walk(sourceFile, scope, tokens, collectExposures(sourceFile));
   }
 
   return Array.from(tokens).sort();
@@ -91,7 +91,8 @@ async function loadModuleBindings(file, moduleCache, stack) {
   for (const stmt of sourceFile.statements) {
     if (!ts.isVariableStatement(stmt)) continue;
     for (const decl of stmt.declarationList.declarations) {
-      registerDeclaration(decl, scope);
+      // An imported module holds token constants, not this component's states.
+      registerDeclaration(decl, scope, undefined);
     }
   }
   for (const [name, value] of scope.bindings) bindings.set(name, value);
@@ -101,32 +102,28 @@ function createScope(parent = null) {
   return { parent, bindings: new Map() };
 }
 
-function walk(node, scope, tokens) {
+function walk(node, scope, tokens, exposures) {
   if (createsScope(node)) {
     const nextScope = createScope(scope);
 
     if (hasStatements(node)) {
-      // Declarations first, then every exposure, then the rules. The runtime
-      // builds its exposed-state map after setup returns, so a rule written
-      // above the expose call is still lowered with the attribute.
-      for (const stmt of node.statements) {
-        if (!ts.isVariableStatement(stmt)) continue;
-        for (const decl of stmt.declarationList.declarations) registerDeclaration(decl, nextScope);
-      }
-      for (const stmt of node.statements) registerExposedState(stmt, nextScope);
+      // Sequential, so a legal redeclaration still registers each binding for
+      // the statements that follow it. Exposures need no ordering because they
+      // are collected from the whole source before the walk begins.
       for (const stmt of node.statements) {
         if (ts.isVariableStatement(stmt)) {
           for (const decl of stmt.declarationList.declarations) {
-            if (decl.initializer) walk(decl.initializer, nextScope, tokens);
+            registerDeclaration(decl, nextScope, exposures);
+            if (decl.initializer) walk(decl.initializer, nextScope, tokens, exposures);
           }
           continue;
         }
-        walk(stmt, nextScope, tokens);
+        walk(stmt, nextScope, tokens, exposures);
       }
       return;
     }
 
-    ts.forEachChild(node, (child) => walk(child, nextScope, tokens));
+    ts.forEachChild(node, (child) => walk(child, nextScope, tokens, exposures));
     return;
   }
 
@@ -144,10 +141,10 @@ function walk(node, scope, tokens) {
   }
 
   if (ts.isCallExpression(node) && isPropertyNamed(node.expression, 'rule')) {
-    collectRuleVariantTokens(node, scope, tokens);
+    collectRuleVariantTokens(node, scope, tokens, exposures);
   }
 
-  ts.forEachChild(node, (child) => walk(child, scope, tokens));
+  ts.forEachChild(node, (child) => walk(child, scope, tokens, exposures));
 }
 
 function createsScope(node) {
@@ -166,11 +163,12 @@ function hasStatements(node) {
   return ts.isSourceFile(node) || ts.isBlock(node) || ts.isModuleBlock(node);
 }
 
-function registerDeclaration(decl, scope) {
+function registerDeclaration(decl, scope, exposures) {
   if (!decl.initializer) return;
 
   if (ts.isIdentifier(decl.name)) {
-    scope.bindings.set(decl.name.text, resolveBinding(decl.initializer, scope));
+    const binding = resolveBinding(decl.initializer, scope);
+    scope.bindings.set(decl.name.text, applyExposure(decl.name.text, binding, scope, exposures));
     return;
   }
 
@@ -334,7 +332,7 @@ function lookup(name, scope) {
 function resolveBinding(node, scope) {
   const semantic = resolveSemanticBinding(node);
   const value = resolveExpression(node, scope);
-  const declared = resolveDeclaredStateName(node);
+  const declared = resolveDeclaredStateName(node, scope);
   const withName = declared ? { ...value, stateName: declared } : value;
   return semantic ? { ...withName, semantic } : withName;
 }
@@ -345,13 +343,17 @@ function resolveBinding(node, scope) {
  * before it would fall back to the expose key, so this is the name the Web
  * attribute comes from.
  */
-function resolveDeclaredStateName(node) {
+function resolveDeclaredStateName(node, scope) {
   if (!ts.isCallExpression(node)) return null;
   if (!ts.isPropertyAccessExpression(node.expression)) return null;
   const owner = node.expression.expression;
   if (!ts.isPropertyAccessExpression(owner) || owner.name.text !== 'state') return null;
   const first = node.arguments[0];
-  return first && ts.isStringLiteralLike(first) ? first.text : null;
+  if (!first) return null;
+  // The name may be a constant the runtime resolves to a real string.
+  return ts.isStringLiteralLike(first)
+    ? first.text
+    : (resolveExpression(first, scope).single ?? null);
 }
 
 /**
@@ -371,37 +373,102 @@ function exposedDataAttributeName(key) {
 }
 
 /**
- * `def.expose.state('hidden', hidden)` is what gives a prototype-owned state a
- * host attribute, so it is also what tells the extractor the selector. Without
- * it a `def.state.bool` handle has no semantic, the rule contributes a bare
- * token, and the variant the Web runtime lowers has no CSS.
+ * Every `def.expose.state(key, handle)` in a source, resolved to the handle it
+ * ultimately names.
  *
- * The exposed key is a fallback only: a handle that already carries an official
- * semantic keeps it, which is the precedence `createExposeStateWebNameMap` uses
- * when it maps an official semantic before falling back to the key.
+ * Exposure is component-wide at runtime rather than block-scoped, and the
+ * exposed-state map is built after setup returns, so neither the block a call
+ * sits in nor its position relative to a rule decides whether the rule lowers.
+ * Aliases are followed because two references to one handle carry one state id.
  */
-function registerExposedState(statement, scope) {
-  if (!ts.isExpressionStatement(statement)) return;
-  const call = statement.expression;
-  if (!ts.isCallExpression(call)) return;
-  if (!ts.isPropertyAccessExpression(call.expression)) return;
-  if (!isPropertyAccessChain(call.expression, ['expose', 'state'])) return;
-  const [nameArg, handleArg] = call.arguments;
-  if (!nameArg || !handleArg) return;
-  if (!ts.isIdentifier(handleArg)) return;
-  // The key may be a constant the runtime resolves to a real string.
-  const exposedKey = ts.isStringLiteralLike(nameArg)
-    ? nameArg.text
-    : resolveExpression(nameArg, scope).single;
-  if (!exposedKey) return;
-  const existing = lookup(handleArg.text, scope);
-  if (existing.semantic) return;
-  // The runtime maps `__stateSemantic` — the declared name — before it falls
-  // back to the expose key, so exposing `internalFlag` as `visible` still
-  // produces `data-internal-flag`.
-  const attribute = exposedDataAttributeName(existing.stateName ?? exposedKey);
-  if (!attribute) return;
-  scope.bindings.set(handleArg.text, { ...existing, semantic: `data-[${attribute}]` });
+function collectExposures(root) {
+  const aliases = new Map();
+  const exposures = [];
+
+  const unwrapExpression = (node) =>
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isNonNullExpression(node)
+      ? unwrapExpression(node.expression)
+      : node;
+
+  const namesExposeState = (callee) => {
+    if (ts.isPropertyAccessExpression(callee)) {
+      return callee.name.text === 'state' && namesExposeOwner(callee.expression);
+    }
+    if (ts.isElementAccessExpression(callee)) {
+      const argument = callee.argumentExpression;
+      return (
+        Boolean(argument) &&
+        ts.isStringLiteralLike(argument) &&
+        argument.text === 'state' &&
+        namesExposeOwner(callee.expression)
+      );
+    }
+    return false;
+  };
+
+  const namesExposeOwner = (node) => {
+    const owner = unwrapExpression(node);
+    if (ts.isPropertyAccessExpression(owner)) return owner.name.text === 'expose';
+    if (ts.isElementAccessExpression(owner)) {
+      const argument = owner.argumentExpression;
+      return Boolean(argument) && ts.isStringLiteralLike(argument) && argument.text === 'expose';
+    }
+    return false;
+  };
+
+  const visit = (node) => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const initializer = unwrapExpression(node.initializer);
+      if (ts.isIdentifier(initializer)) aliases.set(node.name.text, initializer.text);
+    }
+    if (ts.isCallExpression(node) && namesExposeState(unwrapExpression(node.expression))) {
+      const [nameArg, handleArg] = node.arguments;
+      const handle = handleArg && unwrapExpression(handleArg);
+      if (nameArg && handle && ts.isIdentifier(handle)) {
+        exposures.push({ handle: handle.text, key: nameArg });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+
+  const rootName = (name) => {
+    const seen = new Set();
+    let current = name;
+    while (aliases.has(current) && !seen.has(current)) {
+      seen.add(current);
+      current = aliases.get(current);
+    }
+    return current;
+  };
+
+  const byHandle = new Map();
+  for (const { handle, key } of exposures) {
+    // Both the alias and the handle it names carry the same state id.
+    for (const name of new Set([handle, rootName(handle)])) {
+      if (!byHandle.has(name)) byHandle.set(name, key);
+    }
+  }
+  return byHandle;
+}
+
+/**
+ * The Web attribute comes from `__stateSemantic` — the declared name — and only
+ * falls back to the expose key, so a state exposed under a different key still
+ * lowers to its declared name. A handle that already carries an official
+ * semantic keeps it, which is the same precedence the runtime applies.
+ */
+function applyExposure(name, binding, scope, exposures) {
+  if (!exposures || binding.semantic) return binding;
+  const key = exposures.get(name);
+  if (!key) return binding;
+  const exposedKey = ts.isStringLiteralLike(key) ? key.text : resolveExpression(key, scope).single;
+  const attribute = exposedDataAttributeName(binding.stateName ?? exposedKey ?? '');
+  if (!attribute) return binding;
+  return { ...binding, semantic: `data-[${attribute}]` };
 }
 
 function resolveSemanticBinding(node) {
@@ -624,7 +691,7 @@ export function loweredHookStates(hookName) {
   return resolved ? new Map(resolved) : null;
 }
 
-function collectRuleVariantTokens(node, scope, tokens) {
+function collectRuleVariantTokens(node, scope, tokens, exposures) {
   const config = node.arguments[0];
   if (!config || !ts.isObjectLiteralExpression(config)) return;
 
@@ -646,7 +713,7 @@ function collectRuleVariantTokens(node, scope, tokens) {
   const variants = analyzeWhenVariants(whenProp.initializer, scope);
   if (variants.length === 0) return;
 
-  const intentTokens = collectTwTokens(intentProp.initializer, scope);
+  const intentTokens = collectTwTokens(intentProp.initializer, scope, exposures);
   for (const token of intentTokens) {
     tokens.add(`${variants.join(':')}:${token}`);
   }
@@ -760,7 +827,7 @@ function isNegativeDataVariant(variant) {
   return /^not-\[data-[a-zA-Z0-9-]+\]$/.test(variant);
 }
 
-function collectTwTokens(node, scope) {
+function collectTwTokens(node, scope, exposures) {
   const found = new Set();
 
   visit(node, scope);
@@ -771,14 +838,9 @@ function collectTwTokens(node, scope) {
       const nextScope = createScope(currentScope);
       if (hasStatements(current)) {
         for (const stmt of current.statements) {
-          if (!ts.isVariableStatement(stmt)) continue;
-          for (const decl of stmt.declarationList.declarations)
-            registerDeclaration(decl, nextScope);
-        }
-        for (const stmt of current.statements) registerExposedState(stmt, nextScope);
-        for (const stmt of current.statements) {
           if (ts.isVariableStatement(stmt)) {
             for (const decl of stmt.declarationList.declarations) {
+              registerDeclaration(decl, nextScope, exposures);
               if (decl.initializer) visit(decl.initializer, nextScope);
             }
             continue;

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -98,13 +98,13 @@ async function loadModuleBindings(file, moduleCache, stack) {
   for (const [name, value] of scope.bindings) bindings.set(name, value);
   return bindings;
 }
-function createScope(parent = null) {
-  return { parent, bindings: new Map() };
+function createScope(parent = null, node = null) {
+  return { parent, bindings: new Map(), node };
 }
 
 function walk(node, scope, tokens, exposures) {
   if (createsScope(node)) {
-    const nextScope = createScope(scope);
+    const nextScope = createScope(scope, node);
 
     if (hasStatements(node)) {
       // Sequential, so a legal redeclaration still registers each binding for
@@ -607,14 +607,24 @@ function collectExposures(root) {
     return edges.flatMap((edge) => rootNames(edge.target, chain, edge.at, next));
   };
 
-  const byHandle = new Map();
+  // An exposure names a binding, and a binding lives in one scope. Recording it
+  // by name alone would let a sibling prototype that reuses the same local name
+  // inherit an exposure its own runtime never registers.
+  const declaringScope = (name, chain) =>
+    chain.find((candidate) => declaredIn.get(candidate)?.has(name)) ?? chain[chain.length - 1];
+
+  const byScope = new Map();
   for (const { handle, key, chain, at } of exposures) {
     // Both the alias and the handle it names carry the same state id.
     for (const name of new Set([handle, ...rootNames(handle, chain, at)])) {
-      if (!byHandle.has(name)) byHandle.set(name, key);
+      const owner = declaringScope(name, chain);
+      if (!owner) continue;
+      const scoped = byScope.get(owner) ?? new Map();
+      if (!scoped.has(name)) scoped.set(name, key);
+      byScope.set(owner, scoped);
     }
   }
-  return byHandle;
+  return byScope;
 }
 
 /**
@@ -625,7 +635,10 @@ function collectExposures(root) {
  */
 function applyExposure(name, binding, scope, exposures) {
   if (!exposures || binding.semantic) return binding;
-  const key = exposures.get(name);
+  let key;
+  for (let current = scope; current && key === undefined; current = current.parent) {
+    if (current.node) key = exposures.get(current.node)?.get(name);
+  }
   if (!key) return binding;
   // `__stateSemantic` wins at runtime, so a declared name this cannot read
   // leaves no safe selector to emit; the expose key would be the wrong one.
@@ -1025,7 +1038,7 @@ function collectTwTokens(node, scope, exposures) {
 
   function visit(current, currentScope) {
     if (createsScope(current)) {
-      const nextScope = createScope(currentScope);
+      const nextScope = createScope(currentScope, current);
       if (hasStatements(current)) {
         for (const stmt of current.statements) {
           if (ts.isVariableStatement(stmt)) {

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -262,6 +262,18 @@ function registerDeclaration(decl, scope, exposures) {
     return;
   }
 
+  if (ts.isArrayBindingPattern(decl.name)) {
+    const value = resolveBinding(decl.initializer, scope);
+    if (!value.semanticMap) return;
+
+    decl.name.elements.forEach((element, index) => {
+      if (ts.isOmittedExpression(element) || !ts.isIdentifier(element.name)) return;
+      const semantic = value.semanticMap.get(String(index));
+      if (semantic) scope.bindings.set(element.name.text, asSemanticValue(semantic));
+    });
+    return;
+  }
+
   if (ts.isObjectBindingPattern(decl.name)) {
     const value = resolveBinding(decl.initializer, scope);
     if (!value.semanticMap) return;
@@ -293,6 +305,19 @@ function resolveExpression(node, scope) {
       parts.push(value.single, span.literal.text);
     }
     return asStringValue([parts.join('')]);
+  }
+
+  // `const [publicFlag] = [flag]` — the index is the member name. Checked
+  // before the token-array reading below, which needs every element to be a
+  // string and so gives up on an array holding a handle.
+  if (ts.isArrayLiteralExpression(node)) {
+    const semantics = new Map();
+    node.elements.forEach((element, index) => {
+      if (ts.isOmittedExpression(element)) return;
+      const held = resolveBinding(element, scope);
+      if (held.semantic) semantics.set(String(index), held.semantic);
+    });
+    if (semantics.size > 0) return asSemanticMapValue(semantics);
   }
 
   if (ts.isArrayLiteralExpression(node)) {

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -127,6 +127,17 @@ function walk(node, scope, tokens, exposures) {
     return;
   }
 
+  if (ts.isVariableStatement(node)) {
+    // A declaration under single-statement control flow — `if (x) var f = …` —
+    // is reached here rather than through a statement list, and the runtime
+    // executes it just the same.
+    for (const decl of node.declarationList.declarations) {
+      registerDeclaration(decl, scope, exposures);
+      if (decl.initializer) walk(decl.initializer, scope, tokens, exposures);
+    }
+    return;
+  }
+
   if (
     ts.isCallExpression(node) &&
     ts.isIdentifier(node.expression) &&
@@ -394,7 +405,31 @@ const UNKNOWN_STATE_NAME = Symbol('unknown-state-name');
  * The same normalization `createExposeStateWebNameMap` applies to an
  * unannotated exposed key before it becomes a data attribute.
  */
+/**
+ * Mirrors `OFFICIAL_EXPOSED_STATE_NAMES` in `@proto.ui/module-expose-state-web`.
+ * Duplicated rather than imported so this analyzer stays free of runtime
+ * dependencies; `prototype-style-tokens.test.ts` asserts the two are identical.
+ */
+const OFFICIAL_EXPOSED_STATE_NAMES = Object.freeze({
+  '@interaction/disabled': 'disabled',
+  '@interaction/hovered': 'hovered',
+  '@interaction/pressed': 'pressed',
+  '@interaction/focused': 'focused',
+  '@focus/focused': 'focused',
+  '@interaction/focusVisible': 'focus-visible',
+  '@focus/focusVisible': 'focus-visible',
+  '@accessibility/expanded': 'expanded',
+  '@accessibility/invalid': 'invalid',
+  '@accessibility/selected': 'selected',
+  '@accessibility/checked': 'checked',
+  '@accessibility/current': 'current',
+});
+
 function exposedDataAttributeName(key) {
+  // The runtime maps an official semantic before it normalizes anything, so
+  // `@accessibility/checked` is `data-checked`, not `data-accessibility-checked`.
+  const official = OFFICIAL_EXPOSED_STATE_NAMES[key];
+  if (official) return official;
   return key
     .trim()
     .replace(/\s+/g, '-')
@@ -482,19 +517,24 @@ function collectExposures(root) {
     return [];
   };
 
+  // Scoped like every other binding: a nested `controls` must not answer for
+  // an outer one of the same name.
   const objectMembers = new Map();
 
-  const resolveHandleIdentifier = (node) => {
+  const resolveHandleIdentifier = (node, chain) => {
     const value = unwrapExpression(node);
     if (ts.isIdentifier(value)) return value.text;
     const owner = memberOwner(value);
     if (!owner) return null;
     const base = unwrapExpression(owner);
     if (!ts.isIdentifier(base)) return null;
-    const members = objectMembers.get(base.text);
-    if (!members) return null;
-    for (const [key, target] of members) {
-      if (memberIs(value, key)) return target;
+    for (const scope of chain) {
+      const members = objectMembers.get(scope)?.get(base.text);
+      if (!members) continue;
+      for (const [key, target] of members) {
+        if (memberIs(value, key)) return target;
+      }
+      return null;
     }
     return null;
   };
@@ -533,7 +573,9 @@ function collectExposures(root) {
               if (ts.isIdentifier(value)) members.set(property.name.text, value.text);
             }
           }
-          objectMembers.set(node.name.text, members);
+          const scoped = objectMembers.get(owner) ?? new Map();
+          scoped.set(node.name.text, members);
+          objectMembers.set(owner, scoped);
         }
         for (const target of aliasTargets(node.initializer)) {
           aliasEdges.push({ owner, name: node.name.text, target, at: node.getStart() });
@@ -565,7 +607,7 @@ function collectExposures(root) {
         namesExpose(unwrapExpression(node.expression)))
     ) {
       const [nameArg, handleArg] = node.arguments;
-      const handle = handleArg && resolveHandleIdentifier(handleArg);
+      const handle = handleArg && resolveHandleIdentifier(handleArg, [...nextChain, root]);
       if (nameArg && handle) {
         exposures.push({
           handle,

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -121,6 +121,12 @@ function isVarList(list) {
   );
 }
 
+/** Every semantic a binding may stand for, the declared one first. */
+function bindingSemantics(binding) {
+  if (!binding) return [];
+  return [binding.semantic, ...(binding.alternatives ?? [])].filter(Boolean);
+}
+
 /** The scope a name is already bound in, so an assignment does not shadow it. */
 function scopeDeclaring(name, scope) {
   for (let current = scope; current; current = current.parent) {
@@ -184,8 +190,17 @@ function walk(node, scope, tokens, exposures) {
     walk(node.right, scope, tokens, exposures);
     const name = node.left.text;
     const owner = scopeDeclaring(name, scope) ?? scope;
-    const binding = resolveBinding(node.right, scope);
-    owner.bindings.set(name, applyExposure(name, binding, owner, exposures));
+    const previous = owner.bindings.get(name);
+    const binding = applyExposure(name, resolveBinding(node.right, scope), owner, exposures);
+    // A write the source may skip leaves the name on either handle, and the
+    // runtime lowers whichever it holds, so both need a selector.
+    const kept = bindingSemantics(previous).filter((candidate) => candidate !== binding.semantic);
+    owner.bindings.set(
+      name,
+      isConditionallyReached(node) && kept.length > 0
+        ? { ...binding, alternatives: [...new Set([...(binding.alternatives ?? []), ...kept])] }
+        : binding
+    );
     return;
   }
 
@@ -308,6 +323,25 @@ function resolveExpression(node, scope) {
   if (ts.isCallExpression(node)) {
     const stateHandles = resolveKnownAsHookStateHandles(node);
     if (stateHandles) return asSemanticMapValue(stateHandles);
+  }
+
+  // `const controls = { ready: flag }` — a plain container of handles reads the
+  // same way an `asHook` bag does, so `w.state(controls.ready)` has a variant.
+  if (ts.isObjectLiteralExpression(node)) {
+    const semantics = new Map();
+    for (const property of node.properties) {
+      if (ts.isShorthandPropertyAssignment(property)) {
+        const held = resolveBinding(property.name, scope);
+        if (held.semantic) semantics.set(property.name.text, held.semantic);
+        continue;
+      }
+      if (!ts.isPropertyAssignment(property)) continue;
+      const key = getPropertyName(property.name);
+      if (!key) continue;
+      const held = resolveBinding(property.initializer, scope);
+      if (held.semantic) semantics.set(key, held.semantic);
+    }
+    if (semantics.size > 0) return asSemanticMapValue(semantics);
   }
 
   if (ts.isPropertyAccessExpression(node) && node.name.text === 'stateHandles') {
@@ -1230,22 +1264,32 @@ function collectRuleVariantTokens(node, scope, tokens, exposures) {
     return;
   }
 
-  const variants = analyzeWhenVariants(whenProp.initializer, scope);
-  if (variants.length === 0) return;
+  const chains = analyzeWhenVariants(whenProp.initializer, scope);
+  if (chains.length === 0) return;
 
   const intentTokens = collectTwTokens(intentProp.initializer, scope, exposures);
-  for (const token of intentTokens) {
-    tokens.add(`${variants.join(':')}:${token}`);
+  for (const chain of chains) {
+    const prefix = chain.join(':');
+    for (const token of intentTokens) tokens.add(`${prefix}:${token}`);
   }
 }
 
+/**
+ * Every selector chain the rule may lower to. A condition whose handle is not
+ * statically single-valued contributes one alternative per candidate, and the
+ * runtime takes exactly one of them, so each combination needs its own tokens.
+ */
 function analyzeWhenVariants(node, scope) {
-  const out = new Set();
+  const groups = [];
 
   visit(node);
-  const variants = canonicalizeLoweredVariants(Array.from(out));
-  if (variants.length > 0 && variants.every(isNegativeDataVariant)) return [];
-  return variants;
+  let chains = [[]];
+  for (const group of groups) {
+    chains = chains.flatMap((chain) => group.map((variant) => [...chain, variant]));
+  }
+  return chains
+    .map((chain) => canonicalizeLoweredVariants(chain))
+    .filter((chain) => chain.length > 0 && !chain.every(isNegativeDataVariant));
 
   function visit(current) {
     if (ts.isArrowFunction(current) || ts.isFunctionExpression(current)) {
@@ -1278,9 +1322,10 @@ function analyzeWhenVariants(node, scope) {
             const firstArg = subject.arguments[0];
             const expected = current.arguments[0];
             if (firstArg) {
-              const semantic = resolveStateHandleSemantic(firstArg, scope);
-              const variant = resolveStateEqVariant(semantic, expected);
-              if (variant) out.add(variant);
+              const variants = resolveStateHandleSemantics(firstArg, scope)
+                .map((semantic) => resolveStateEqVariant(semantic, expected))
+                .filter(Boolean);
+              if (variants.length > 0) groups.push([...new Set(variants)]);
             }
             return;
           }
@@ -1296,7 +1341,7 @@ function analyzeWhenVariants(node, scope) {
               key.text === 'colorScheme' &&
               value.text === 'dark'
             ) {
-              out.add('dark');
+              groups.push(['dark']);
             }
           }
         }
@@ -1333,6 +1378,16 @@ const NATIVE_VARIANT_ATTRIBUTES = Object.freeze({
   hover: 'data-[hovered]',
   active: 'data-[pressed]',
 });
+
+/** Every semantic a `w.state(x)` argument may stand for. */
+function resolveStateHandleSemantics(node, scope) {
+  if (ts.isIdentifier(node)) {
+    const semantics = bindingSemantics(lookup(node.text, scope));
+    if (semantics.length > 0) return semantics;
+  }
+  const single = resolveStateHandleSemantic(node, scope);
+  return single ? [single] : [];
+}
 
 function resolveStateEqVariant(semantic, expected) {
   if (!semantic) return null;

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -350,11 +350,17 @@ function resolveDeclaredStateName(node, scope) {
   if (!ts.isPropertyAccessExpression(owner) || owner.name.text !== 'state') return null;
   const first = node.arguments[0];
   if (!first) return null;
-  // The name may be a constant the runtime resolves to a real string.
-  return ts.isStringLiteralLike(first)
+  // The name may be a constant the runtime resolves to a real string. A name
+  // this cannot evaluate is still a name at runtime, so it is reported as
+  // unknown rather than absent — the expose key must not stand in for it.
+  const resolved = ts.isStringLiteralLike(first)
     ? first.text
-    : (resolveExpression(first, scope).single ?? null);
+    : resolveExpression(first, scope).single;
+  return resolved ?? UNKNOWN_STATE_NAME;
 }
+
+/** A `def.state.*` declaration whose name the extractor cannot evaluate. */
+const UNKNOWN_STATE_NAME = Symbol('unknown-state-name');
 
 /**
  * The same normalization `createExposeStateWebNameMap` applies to an
@@ -382,7 +388,9 @@ function exposedDataAttributeName(key) {
  * Aliases are followed because two references to one handle carry one state id.
  */
 function collectExposures(root) {
-  const aliases = new Map();
+  // Alias edges are keyed by the function they were declared in, so two setups
+  // in one file may each bind the same alias name without colliding.
+  const aliasesByScope = new Map();
   const exposures = [];
 
   const unwrapExpression = (node) =>
@@ -419,36 +427,51 @@ function collectExposures(root) {
     return false;
   };
 
-  const visit = (node) => {
+  const visit = (node, chain) => {
+    const nextChain = ts.isFunctionLike(node) ? [node, ...chain] : chain;
     if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
       const initializer = unwrapExpression(node.initializer);
-      if (ts.isIdentifier(initializer)) aliases.set(node.name.text, initializer.text);
+      if (ts.isIdentifier(initializer)) {
+        const owner = nextChain[0] ?? root;
+        if (!aliasesByScope.has(owner)) aliasesByScope.set(owner, new Map());
+        aliasesByScope.get(owner).set(node.name.text, initializer.text);
+      }
     }
     if (ts.isCallExpression(node) && namesExposeState(unwrapExpression(node.expression))) {
       const [nameArg, handleArg] = node.arguments;
       const handle = handleArg && unwrapExpression(handleArg);
       if (nameArg && handle && ts.isIdentifier(handle)) {
-        exposures.push({ handle: handle.text, key: nameArg });
+        exposures.push({ handle: handle.text, key: nameArg, chain: [...nextChain, root] });
       }
     }
-    ts.forEachChild(node, visit);
+    ts.forEachChild(node, (child) => visit(child, nextChain));
   };
-  visit(root);
+  visit(root, []);
 
-  const rootName = (name) => {
+  const lookupAlias = (name, chain) => {
+    for (const owner of chain) {
+      const scoped = aliasesByScope.get(owner);
+      if (scoped?.has(name)) return scoped.get(name);
+    }
+    return null;
+  };
+
+  const rootName = (name, chain) => {
     const seen = new Set();
     let current = name;
-    while (aliases.has(current) && !seen.has(current)) {
+    for (;;) {
+      if (seen.has(current)) return current;
       seen.add(current);
-      current = aliases.get(current);
+      const next = lookupAlias(current, chain);
+      if (!next) return current;
+      current = next;
     }
-    return current;
   };
 
   const byHandle = new Map();
-  for (const { handle, key } of exposures) {
+  for (const { handle, key, chain } of exposures) {
     // Both the alias and the handle it names carry the same state id.
-    for (const name of new Set([handle, rootName(handle)])) {
+    for (const name of new Set([handle, rootName(handle, chain)])) {
       if (!byHandle.has(name)) byHandle.set(name, key);
     }
   }
@@ -465,6 +488,9 @@ function applyExposure(name, binding, scope, exposures) {
   if (!exposures || binding.semantic) return binding;
   const key = exposures.get(name);
   if (!key) return binding;
+  // `__stateSemantic` wins at runtime, so a declared name this cannot read
+  // leaves no safe selector to emit; the expose key would be the wrong one.
+  if (binding.stateName === UNKNOWN_STATE_NAME) return binding;
   const exposedKey = ts.isStringLiteralLike(key) ? key.text : resolveExpression(key, scope).single;
   const attribute = exposedDataAttributeName(binding.stateName ?? exposedKey ?? '');
   if (!attribute) return binding;
@@ -813,6 +839,13 @@ function resolveStateEqVariant(semantic, expected) {
   if (ts.isStringLiteralLike(expected)) {
     const match = semantic.match(/^data-\[([a-zA-Z0-9-]+)\]$/);
     if (!match || !/^[a-zA-Z0-9_-]+$/.test(expected.text)) return null;
+    return `data-[${match[1]}=${expected.text}]`;
+  }
+  // `number.discrete` bindings lower by stringifying the literal, the same way
+  // enum and string bindings do.
+  if (ts.isNumericLiteral(expected)) {
+    const match = semantic.match(/^data-\[([a-zA-Z0-9-]+)\]$/);
+    if (!match) return null;
     return `data-[${match[1]}=${expected.text}]`;
   }
   return null;

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -343,7 +343,18 @@ function resolveBinding(node, scope) {
  * before it would fall back to the expose key, so this is the name the Web
  * attribute comes from.
  */
-function resolveDeclaredStateName(node, scope) {
+/** Parentheses, `as`, and non-null assertions name the same expression. */
+function unwrapTransparent(node) {
+  return ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isNonNullExpression(node)
+    ? unwrapTransparent(node.expression)
+    : node;
+}
+
+function resolveDeclaredStateName(initializer, scope) {
+  const node = unwrapTransparent(initializer);
   if (!ts.isCallExpression(node)) return null;
   if (!ts.isPropertyAccessExpression(node.expression)) return null;
   const owner = node.expression.expression;
@@ -392,6 +403,7 @@ function collectExposures(root) {
   // may bind the same name and a later redeclaration cannot rewrite what an
   // earlier expose call captured.
   const aliasEdges = [];
+  const declaredIn = new Map();
   const exposures = [];
 
   const unwrapExpression = (node) =>
@@ -441,15 +453,20 @@ function collectExposures(root) {
     // Every scope the extractor itself creates, so two sibling blocks in one
     // setup may reuse an alias name without either edge overwriting the other.
     const nextChain = createsScope(node) ? [node, ...chain] : chain;
-    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
-      const initializer = unwrapExpression(node.initializer);
-      if (ts.isIdentifier(initializer)) {
-        aliasEdges.push({
-          owner: nextChain[0] ?? root,
-          name: node.name.text,
-          target: initializer.text,
-          at: node.getStart(),
-        });
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+      const owner = nextChain[0] ?? root;
+      if (!declaredIn.has(owner)) declaredIn.set(owner, new Set());
+      declaredIn.get(owner).add(node.name.text);
+      if (node.initializer) {
+        const initializer = unwrapExpression(node.initializer);
+        if (ts.isIdentifier(initializer)) {
+          aliasEdges.push({
+            owner,
+            name: node.name.text,
+            target: initializer.text,
+            at: node.getStart(),
+          });
+        }
       }
     }
     // A plain reassignment moves the handle just as a declaration does.
@@ -460,12 +477,16 @@ function collectExposures(root) {
     ) {
       const value = unwrapExpression(node.right);
       if (ts.isIdentifier(value)) {
-        aliasEdges.push({
-          owner: nextChain[0] ?? root,
-          name: node.left.text,
-          target: value.text,
-          at: node.getStart(),
-        });
+        // An assignment does not declare, so it belongs to whichever scope
+        // owns the binding — otherwise a reassignment inside a nested block
+        // would be invisible to an exposure written outside it.
+        const owner =
+          [...nextChain, root].find((candidate) =>
+            declaredIn.get(candidate)?.has(node.left.text)
+          ) ??
+          nextChain[0] ??
+          root;
+        aliasEdges.push({ owner, name: node.left.text, target: value.text, at: node.getStart() });
       }
     }
     if (

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -869,6 +869,50 @@ describe('lowered hook coverage', () => {
     }
   });
 
+  it('keeps the earlier member across a callback, two objects, or an unreadable key', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    for (const [label, lines, read] of [
+      [
+        'callback write',
+        [
+          'const controls = { ready: first };',
+          "def.on('refresh', () => { controls.ready = second; });",
+        ],
+        'controls.ready',
+      ],
+      [
+        'either of two objects',
+        [
+          'const controlsA = { ready: first };',
+          'const controlsB = { ready: first };',
+          'const alias = enabled ? controlsA : controlsB;',
+          'alias.ready = second;',
+        ],
+        'controlsA.ready',
+      ],
+      [
+        'unreadable key',
+        ['const controls = { ready: first };', "const key = 'ready';", 'controls[key] = second;'],
+        'controls.ready',
+      ],
+    ] as const) {
+      const source = [
+        "const first = def.state.bool('firstFlag', false);",
+        "const second = def.state.bool('secondFlag', false);",
+        ...lines,
+        `def.expose.state('visible', ${read});`,
+        `def.rule({ when: (w) => w.state(${read}).eq(true), intent: ${use} });`,
+      ].join('\n');
+      const scan = scanRuleStateReads(source);
+
+      expect(scan.unresolved, label).toEqual([]);
+      expect(scan.exposedLocals.map((local) => local.attribute).sort(), label).toEqual([
+        'first-flag',
+        'second-flag',
+      ]);
+    }
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -295,6 +295,26 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it('sees an alias reassigned inside a nested block', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'let publicFlag = first;',
+      '{',
+      '  publicFlag = second;',
+      '}',
+      "def.expose.state('visible', publicFlag);",
+      `def.rule({ when: (w) => w.state(second).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'second', exposedAs: 'visible', attribute: 'second-flag' },
+    ]);
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -642,6 +642,46 @@ describe('lowered hook coverage', () => {
     }
   });
 
+  it('reports both branches of a conditional alias', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'const current = enabled ? first : second;',
+      "def.expose.state('visible', current);",
+      `def.rule({ when: (w) => w.state(current).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'current', exposedAs: 'visible', attribute: 'first-flag' },
+      { state: 'current', exposedAs: 'visible', attribute: 'second-flag' },
+    ]);
+  });
+
+  it('resolves an alias target where the alias was written', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      'function setup(def) {',
+      "  const flag = def.state.bool('outerFlag', false);",
+      '  const current = flag;',
+      '  {',
+      "    const flag = def.state.bool('innerFlag', false);",
+      '    void flag;',
+      "    def.expose.state('visible', current);",
+      '  }',
+      `  def.rule({ when: (w) => w.state(flag).eq(true), intent: ${use} });`,
+      '}',
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'flag', exposedAs: 'visible', attribute: 'outer-flag' },
+    ]);
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -820,6 +820,30 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it('keeps the earlier handle across an async or generator IIFE', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    for (const [label, iife] of [
+      ['async', '(async () => { await 0; current = second; })();'],
+      ['generator', '(function* () { current = second; })();'],
+    ] as const) {
+      const source = [
+        "const first = def.state.bool('firstFlag', false);",
+        "const second = def.state.bool('secondFlag', false);",
+        'let current = first;',
+        iife,
+        "def.expose.state('visible', current);",
+        `def.rule({ when: (w) => w.state(current).eq(true), intent: ${use} });`,
+      ].join('\n');
+      const scan = scanRuleStateReads(source);
+
+      expect(scan.unresolved, label).toEqual([]);
+      expect(scan.exposedLocals.map((local) => local.attribute).sort(), label).toEqual([
+        'first-flag',
+        'second-flag',
+      ]);
+    }
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -229,7 +229,9 @@ describe('lowered hook coverage', () => {
 
     expect(scan.usages).toEqual([]);
     expect(scan.unresolved).toEqual([]);
-    expect(scan.exposedLocals).toEqual([{ state: 'hidden', exposedAs: 'hidden' }]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'hidden', exposedAs: 'hidden', attribute: 'hidden' },
+    ]);
   });
 
   it('treats a prototype-owned state as neither a hook pair nor a blind spot', () => {
@@ -653,7 +655,8 @@ describe('lowered hook coverage', () => {
   it('resolves every hook state a shipped rule condition reads', async () => {
     const found: Array<{ file: string; hook: string; state: string }> = [];
     const blind: string[] = [];
-    const exposed: Array<{ file: string; state: string; exposedAs: string }> = [];
+    const exposed: Array<{ file: string; state: string; exposedAs: string; attribute: string }> =
+      [];
 
     let scanned = 0;
     for (const absolute of await prototypeSourceFiles()) {
@@ -671,9 +674,11 @@ describe('lowered hook coverage', () => {
 
     // Every exposed prototype-owned state a rule reads has to name an attribute
     // the extractor can emit, or the runtime lowers a variant with no CSS.
+    // `C-EXPOSE-0004-A` admits any non-empty key, and both analyzers normalize
+    // it, so the normalized attribute is what has to be usable — not the key.
     expect(
-      exposed.filter(({ exposedAs }) => !/^[a-zA-Z][a-zA-Z0-9]*$/.test(exposedAs)),
-      'exposed states whose key cannot become a data attribute'
+      exposed.filter(({ attribute }) => !/^[a-z][a-z0-9-]*$/.test(attribute)),
+      'exposed states whose attribute cannot be written as a data selector'
     ).toEqual([]);
     expect(exposed.length, 'exposed prototype-owned states read by a rule').toBeGreaterThan(0);
 

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
+import { createExposeStateWebNameMap } from '../../modules/expose-state-web/src/utils';
 import { scanRuleStateReads } from '../src/services/lowered-hook-coverage';
 import {
   collectProtoStyleTokens,
@@ -48,6 +49,13 @@ const RULE_CALL = /\brule\b/;
 /** A real intent: the variant is a prefix on tokens, so a stub yields nothing. */
 const rule = (condition: string) =>
   `def.rule({ when: (w) => ${condition}, intent: (i) => i.feedback.style.use(tw('bg-primary')) });`;
+
+/**
+ * What the normalized attribute has to satisfy: `data-<attribute>` is writable
+ * and `[data-<attribute>]` selects it. A leading digit satisfies both, so an
+ * identifier rule here would add a naming restriction no contract states.
+ */
+const SELECTABLE_ATTRIBUTE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 describe('lowered hook coverage', () => {
   it('follows every binding shape a prototype uses to reach a state handle', () => {
@@ -467,6 +475,109 @@ describe('lowered hook coverage', () => {
       { state: 'first', exposedAs: 'visible', attribute: 'first-flag' },
       { state: 'second', exposedAs: 'visible', attribute: 'second-flag' },
     ]);
+  });
+
+  it('reads a member at the position it was written', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'let current = first;',
+      'const controls = { ready: current };',
+      'current = second;',
+      "def.expose.state('visible', controls.ready);",
+      `def.rule({ when: (w) => w.state(first).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'first', exposedAs: 'visible', attribute: 'first-flag' },
+    ]);
+  });
+
+  it('keeps the earlier handle when a write may be skipped', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'let current = first;',
+      'if (enabled) current = second;',
+      "def.expose.state('visible', current);",
+      `def.rule({ when: (w) => w.state(first).eq(true), intent: ${use} });`,
+      `def.rule({ when: (w) => w.state(second).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'first', exposedAs: 'visible', attribute: 'first-flag' },
+      { state: 'second', exposedAs: 'visible', attribute: 'second-flag' },
+    ]);
+  });
+
+  it('hoists a nested var redeclaration the rule reads', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      'function setup(def) {',
+      "  const first = def.state.bool('firstFlag', false);",
+      "  const second = def.state.bool('secondFlag', false);",
+      '  var current = first;',
+      '  {',
+      '    var current = second;',
+      '  }',
+      "  def.expose.state('visible', current);",
+      `  def.rule({ when: (w) => w.state(current).eq(true), intent: ${use} });`,
+      '}',
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'current', exposedAs: 'visible', attribute: 'second-flag' },
+    ]);
+  });
+
+  it('accepts an element-access state declaration the extractor reads', () => {
+    // Production resolves `def.state['bool'](…)`, so reporting it unresolved
+    // would fail the gate on code the extractor handles correctly.
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const flag = def.state['bool']('internalFlag', false);",
+      "def.expose.state('visible', flag);",
+      `def.rule({ when: (w) => w.state(flag).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'flag', exposedAs: 'visible', attribute: 'internal-flag' },
+    ]);
+  });
+
+  it('admits every attribute the Web projection can actually write', () => {
+    // The repository tree carries no digit-leading state, so the gate's own
+    // predicate is asserted here rather than only through the shipped scan.
+    for (const attribute of ['1st', 'hidden', 'focus-visible', 'a1', '2-of-3']) {
+      expect(SELECTABLE_ATTRIBUTE.test(attribute), attribute).toBe(true);
+      expect(createExposeStateWebNameMap(attribute).dataAttr, attribute).toBe(`data-${attribute}`);
+    }
+    for (const attribute of ['', '-leading', 'trailing-', 'double--hyphen', 'Upper', 'has space']) {
+      expect(SELECTABLE_ATTRIBUTE.test(attribute), attribute).toBe(false);
+    }
+  });
+
+  it('accepts an attribute that starts with a digit', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const flag = def.state.bool('1st', false);",
+      "def.expose.state('1st', flag);",
+      `def.rule({ when: (w) => w.state(flag).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([{ state: 'flag', exposedAs: '1st', attribute: '1st' }]);
   });
 
   it('reports an exposed state whose declared name it cannot read', () => {
@@ -978,7 +1089,7 @@ describe('lowered hook coverage', () => {
     // `C-EXPOSE-0004-A` admits any non-empty key, and both analyzers normalize
     // it, so the normalized attribute is what has to be usable — not the key.
     expect(
-      exposed.filter(({ attribute }) => !/^[a-z][a-z0-9-]*$/.test(attribute)),
+      exposed.filter(({ attribute }) => !SELECTABLE_ATTRIBUTE.test(attribute)),
       'exposed states whose attribute cannot be written as a data selector'
     ).toEqual([]);
     expect(exposed.length, 'exposed prototype-owned states read by a rule').toBeGreaterThan(0);

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -277,6 +277,24 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it('follows an alias reassigned before the exposure', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'let publicFlag = first;',
+      'publicFlag = second;',
+      "def.expose.state('visible', publicFlag);",
+      `def.rule({ when: (w) => w.state(second).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'second', exposedAs: 'visible', attribute: 'second-flag' },
+    ]);
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -366,6 +366,54 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it('follows a handle written into the container before the exposure', () => {
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'const controls = { ready: first };',
+      'controls.ready = second;',
+      "def.expose.state('visible', controls.ready);",
+      "def.rule({ when: (w) => w.state(second).eq(true), intent: (i) => i.feedback.style.use(tw('bg-accent')) });",
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'second', exposedAs: 'visible', attribute: 'second-flag' },
+    ]);
+  });
+
+  it('leaves a member write after the exposure out of it', () => {
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'const controls = { ready: first };',
+      "def.expose.state('visible', controls.ready);",
+      'controls.ready = second;',
+      "def.rule({ when: (w) => w.state(first).eq(true), intent: (i) => i.feedback.style.use(tw('bg-accent')) });",
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'first', exposedAs: 'visible', attribute: 'first-flag' },
+    ]);
+  });
+
+  it('normalizes a state named after an inherited object key', () => {
+    // The official-name table is a plain object literal, so `constructor` must
+    // not resolve to the function it inherits.
+    const source = [
+      "const flag = def.state.bool('constructor', false);",
+      "def.expose.state('visible', flag);",
+      "def.rule({ when: (w) => w.state(flag).eq(true), intent: (i) => i.feedback.style.use(tw('bg-accent')) });",
+    ].join('\n');
+
+    expect(scanRuleStateReads(source).exposedLocals).toEqual([
+      { state: 'flag', exposedAs: 'visible', attribute: 'constructor' },
+    ]);
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -315,6 +315,28 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it("does not let one prototype's exposure reach a sibling's same-named state", () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      'function exposedSetup(def) {',
+      "  const flag = def.state.bool('firstFlag', false);",
+      "  def.expose.state('visible', flag);",
+      `  def.rule({ when: (w) => w.state(flag).eq(true), intent: ${use} });`,
+      '}',
+      'function internalSetup(def) {',
+      "  const flag = def.state.bool('secondFlag', false);",
+      `  def.rule({ when: (w) => w.state(flag).eq(true), intent: ${use} });`,
+      '}',
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    // Only the exposed one; the sibling's rule stays on the runtime plan.
+    expect(scan.exposedLocals).toEqual([
+      { state: 'flag', exposedAs: 'visible', attribute: 'first-flag' },
+    ]);
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -234,6 +234,45 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it('keeps sibling scopes from sharing an exposure', () => {
+    // A file-wide map would attribute the first exposure to the second handle.
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      'function first(def) {',
+      "  const flag = def.state.bool('firstFlag', false);",
+      '  const publicFlag = flag;',
+      "  def.expose.state('a', publicFlag);",
+      `  def.rule({ when: (w) => w.state(flag).eq(true), intent: ${use} });`,
+      '}',
+      'function second(def) {',
+      "  const other = def.state.bool('secondFlag', false);",
+      '  const publicFlag = other;',
+      "  def.expose.state('b', publicFlag);",
+      '}',
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'flag', exposedAs: 'a', attribute: 'first-flag' },
+    ]);
+  });
+
+  it('reports an exposed state whose declared name it cannot read', () => {
+    // The extractor emits nothing for this, so certifying the expose key would
+    // be the fail-closed mismatch this gate exists to prevent.
+    const source = [
+      'const flag = def.state.bool(makeStateName(), false);',
+      "def.expose.state('visible', flag);",
+      "def.rule({ when: (w) => w.state(flag).eq(true), intent: (i) => i.feedback.style.use(tw('bg-accent')) });",
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.exposedLocals).toEqual([]);
+    expect(scan.usages).toEqual([]);
+    expect(scan.unresolved.map((miss) => miss.reason)).toEqual(['subject']);
+  });
+
   it('treats a prototype-owned state as neither a hook pair nor a blind spot', () => {
     // Base prototypes declare their own states and key rules on them. Those need
     // no resolver entry, so they must not be reported as a hook pair, and they

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -617,6 +617,31 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it('reads a destructured handle the rule uses by its alias', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    for (const [label, container] of [
+      ['object literal', 'const { ready: publicFlag } = { ready: flag };'],
+      ['array literal', 'const [publicFlag] = [flag];'],
+      [
+        'container variable',
+        'const controls = { ready: flag };\nconst { ready: publicFlag } = controls;',
+      ],
+    ] as const) {
+      const source = [
+        "const flag = def.state.bool('internalFlag', false);",
+        container,
+        "def.expose.state('visible', publicFlag);",
+        `def.rule({ when: (w) => w.state(publicFlag).eq(true), intent: ${use} });`,
+      ].join('\n');
+      const scan = scanRuleStateReads(source);
+
+      expect(scan.unresolved, label).toEqual([]);
+      expect(scan.exposedLocals, label).toEqual([
+        { state: 'publicFlag', exposedAs: 'visible', attribute: 'internal-flag' },
+      ]);
+    }
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -580,6 +580,43 @@ describe('lowered hook coverage', () => {
     expect(scan.exposedLocals).toEqual([{ state: 'flag', exposedAs: '1st', attribute: '1st' }]);
   });
 
+  it('reports every state a skippable alias may reach', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'let current = first;',
+      'if (enabled) current = second;',
+      "def.expose.state('visible', current);",
+      `def.rule({ when: (w) => w.state(current).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'current', exposedAs: 'visible', attribute: 'second-flag' },
+      { state: 'current', exposedAs: 'visible', attribute: 'first-flag' },
+    ]);
+  });
+
+  it('reads a state handle held in a plain container', () => {
+    // Production resolves the member, so reporting it unresolved would fail the
+    // gate on code the extractor lowers correctly.
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const flag = def.state.bool('internalFlag', false);",
+      'const controls = { ready: flag };',
+      "def.expose.state('visible', controls.ready);",
+      `def.rule({ when: (w) => w.state(controls.ready).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'flag', exposedAs: 'visible', attribute: 'internal-flag' },
+    ]);
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -258,6 +258,25 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it('resolves each alias hop where that hop was created', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'var current = first;',
+      'const publicFlag = current;',
+      'var current = second;',
+      "def.expose.state('visible', publicFlag);",
+      `def.rule({ when: (w) => w.state(first).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'first', exposedAs: 'visible', attribute: 'first-flag' },
+    ]);
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -682,6 +682,48 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it('reads a container member the rule uses after a write', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    for (const [label, write, read] of [
+      ['property access', 'controls.ready = second;', 'controls.ready'],
+      ['element access', "controls['ready'] = second;", "controls['ready']"],
+    ] as const) {
+      const source = [
+        "const first = def.state.bool('firstFlag', false);",
+        "const second = def.state.bool('secondFlag', false);",
+        'const controls = { ready: first };',
+        write,
+        `def.expose.state('visible', ${read});`,
+        `def.rule({ when: (w) => w.state(${read}).eq(true), intent: ${use} });`,
+      ].join('\n');
+      const scan = scanRuleStateReads(source);
+
+      expect(scan.unresolved, label).toEqual([]);
+      expect(scan.exposedLocals, label).toEqual([
+        { state: 'second', exposedAs: 'visible', attribute: 'second-flag' },
+      ]);
+    }
+  });
+
+  it('keeps the earlier member when the write may be skipped', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'const controls = { ready: first };',
+      'if (enabled) controls.ready = second;',
+      "def.expose.state('visible', controls.ready);",
+      `def.rule({ when: (w) => w.state(controls.ready).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals.map((local) => local.attribute).sort()).toEqual([
+      'first-flag',
+      'second-flag',
+    ]);
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -844,6 +844,31 @@ describe('lowered hook coverage', () => {
     }
   });
 
+  it('keeps the earlier handle when an IIFE may not reach the write', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    for (const [label, iife] of [
+      ['early return', '(() => { return; current = second; })();'],
+      ['early throw', "(() => { throw new Error('x'); current = second; })();"],
+      ['conditional return', '(() => { if (enabled) return; current = second; })();'],
+    ] as const) {
+      const source = [
+        "const first = def.state.bool('firstFlag', false);",
+        "const second = def.state.bool('secondFlag', false);",
+        'let current = first;',
+        iife,
+        "def.expose.state('visible', current);",
+        `def.rule({ when: (w) => w.state(current).eq(true), intent: ${use} });`,
+      ].join('\n');
+      const scan = scanRuleStateReads(source);
+
+      expect(scan.unresolved, label).toEqual([]);
+      expect(scan.exposedLocals.map((local) => local.attribute).sort(), label).toEqual([
+        'first-flag',
+        'second-flag',
+      ]);
+    }
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -913,6 +913,37 @@ describe('lowered hook coverage', () => {
     }
   });
 
+  it('measures a member write against the container, not the alias', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    for (const [label, block, expected] of [
+      [
+        'alias inside a callback',
+        "def.on('refresh', () => { const alias = controls; alias.ready = second; });",
+        ['first-flag', 'second-flag'],
+      ],
+      [
+        'alias in a plain block',
+        '{ const alias = controls; alias.ready = second; }',
+        ['second-flag'],
+      ],
+    ] as const) {
+      const source = [
+        "const first = def.state.bool('firstFlag', false);",
+        "const second = def.state.bool('secondFlag', false);",
+        'const controls = { ready: first };',
+        block,
+        "def.expose.state('visible', controls.ready);",
+        `def.rule({ when: (w) => w.state(controls.ready).eq(true), intent: ${use} });`,
+      ].join('\n');
+      const scan = scanRuleStateReads(source);
+
+      expect(scan.unresolved, label).toEqual([]);
+      expect(scan.exposedLocals.map((local) => local.attribute).sort(), label).toEqual([
+        ...expected,
+      ]);
+    }
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -162,18 +162,18 @@ describe('lowered hook coverage', () => {
     // `resolveStateEqVariant` lowers the two boolean keywords and a string
     // literal. A number or a bound identifier produces no variant, so counting
     // these as covered would hide exactly the rules that emit nothing.
-    const numeric = `const { step } = asSelectItem().stateHandles;\n${rule('w.state(step).eq(1)')}`;
-    const identifier = `const { checked } = asCheckboxRoot().stateHandles;\n${rule('w.state(checked).eq(ENABLED)')}`;
+    const identifierOnly = `const { checked } = asCheckboxRoot().stateHandles;\n${rule('w.state(checked).eq(ENABLED)')}`;
+
     const enumString = `const { orientation } = asSeparatorRoot().stateHandles;\n${rule("w.state(orientation).eq('vertical')")}`;
 
-    expect(scanRuleStateReads(numeric).usages).toEqual([]);
-    expect(scanRuleStateReads(numeric).unresolved).toEqual([
-      { expression: 'w.state(step).eq(1)', reason: 'comparison' },
-    ]);
-    expect(scanRuleStateReads(identifier).usages).toEqual([]);
-    expect(scanRuleStateReads(identifier).unresolved).toEqual([
+    expect(scanRuleStateReads(identifierOnly).usages).toEqual([]);
+    expect(scanRuleStateReads(identifierOnly).unresolved).toEqual([
       { expression: 'w.state(checked).eq(ENABLED)', reason: 'comparison' },
     ]);
+
+    // A numeric literal does lower, for `number.discrete` bindings.
+    const numeric = `const { step } = asSelectItem().stateHandles;\n${rule('w.state(step).eq(1)')}`;
+    expect(scanRuleStateReads(numeric).unresolved).toEqual([]);
     // The string form the extractor does lower stays covered.
     expect(scanRuleStateReads(enumString).usages).toEqual([
       { hook: 'asSeparatorRoot', state: 'orientation' },

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -337,6 +337,35 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it('accepts a constant-backed declared name the extractor resolves', () => {
+    // Production resolves this constant, so reporting it unresolved would fail
+    // the gate on code the extractor handles correctly.
+    const source = [
+      "const name = 'hidden';",
+      'const flag = def.state.bool(name, false);',
+      "def.expose.state('visible', flag);",
+      "def.rule({ when: (w) => w.state(flag).eq(true), intent: (i) => i.feedback.style.use(tw('hidden')) });",
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'flag', exposedAs: 'visible', attribute: 'hidden' },
+    ]);
+  });
+
+  it('maps an official semantic before normalizing the name', () => {
+    const source = [
+      "const flag = def.state.bool('@accessibility/checked', false);",
+      "def.expose.state('visible', flag);",
+      "def.rule({ when: (w) => w.state(flag).eq(true), intent: (i) => i.feedback.style.use(tw('bg-accent')) });",
+    ].join('\n');
+
+    expect(scanRuleStateReads(source).exposedLocals).toEqual([
+      { state: 'flag', exposedAs: 'visible', attribute: 'checked' },
+    ]);
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -216,6 +216,22 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it('reports an exposed prototype-owned state instead of skipping it', () => {
+    // Exposing the state is what gives it a host attribute, so the Web runtime
+    // lowers rules on it. Skipping the read would leave the gate green while
+    // the extractor had no selector to emit.
+    const source = [
+      "const hidden = def.state.bool('hidden', true);",
+      "def.expose.state('hidden', hidden);",
+      "def.rule({ when: (w) => w.state(hidden).eq(true), intent: (i) => i.feedback.style.use(tw('hidden')) });",
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.usages).toEqual([]);
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([{ state: 'hidden', exposedAs: 'hidden' }]);
+  });
+
   it('treats a prototype-owned state as neither a hook pair nor a blind spot', () => {
     // Base prototypes declare their own states and key rules on them. Those need
     // no resolver entry, so they must not be reported as a hook pair, and they
@@ -637,6 +653,7 @@ describe('lowered hook coverage', () => {
   it('resolves every hook state a shipped rule condition reads', async () => {
     const found: Array<{ file: string; hook: string; state: string }> = [];
     const blind: string[] = [];
+    const exposed: Array<{ file: string; state: string; exposedAs: string }> = [];
 
     let scanned = 0;
     for (const absolute of await prototypeSourceFiles()) {
@@ -647,9 +664,18 @@ describe('lowered hook coverage', () => {
       const scan = scanRuleStateReads(text, file);
       for (const usage of scan.usages) found.push({ file, ...usage });
       for (const miss of scan.unresolved) blind.push(`${file}: ${miss.reason} ${miss.expression}`);
+      for (const local of scan.exposedLocals) exposed.push({ file, ...local });
     }
 
     expect(scanned, 'files carrying a rule call').toBeGreaterThan(40);
+
+    // Every exposed prototype-owned state a rule reads has to name an attribute
+    // the extractor can emit, or the runtime lowers a variant with no CSS.
+    expect(
+      exposed.filter(({ exposedAs }) => !/^[a-zA-Z][a-zA-Z0-9]*$/.test(exposedAs)),
+      'exposed states whose key cannot become a data attribute'
+    ).toEqual([]);
+    expect(exposed.length, 'exposed prototype-owned states read by a rule').toBeGreaterThan(0);
 
     expect(found.length).toBeGreaterThan(30);
     // The two-step shape must be reached in the shipped tree, not just fixtures.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -724,6 +724,45 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it('follows a member written through an alias of the container', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'const controls = { ready: first };',
+      'const alias = controls;',
+      'alias.ready = second;',
+      "def.expose.state('visible', controls.ready);",
+      `def.rule({ when: (w) => w.state(controls.ready).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'second', exposedAs: 'visible', attribute: 'second-flag' },
+    ]);
+  });
+
+  it('keeps both members when the alias write may be skipped', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'const controls = { ready: first };',
+      'const alias = controls;',
+      'if (enabled) alias.ready = second;',
+      "def.expose.state('visible', controls.ready);",
+      `def.rule({ when: (w) => w.state(controls.ready).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals.map((local) => local.attribute).sort()).toEqual([
+      'first-flag',
+      'second-flag',
+    ]);
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -571,17 +571,68 @@ describe('lowered hook coverage', () => {
     expect(scan.usages).toEqual([{ hook: 'asCheckboxRoot', state: 'checked' }]);
   });
 
-  it('reports a handle bound where the extractor never registers it', () => {
-    // The extractor registers declarations while iterating the variable
-    // statements of a scope, so a loop initializer never reaches it.
+  it('follows a handle bound by a loop initializer', () => {
+    // Production registers a loop initializer in the loop's own scope, so
+    // reporting this would be a blind spot the extractor does not have.
     const source = [
       'for (const state = asCheckboxRoot().stateHandles; once; )',
       "  def.rule({ when: (w) => w.state(state.checked).eq(true), intent: (i) => i.feedback.style.use(tw('bg-primary')) });",
     ].join('\n');
     const scan = scanRuleStateReads(source);
 
-    expect(scan.usages).toEqual([]);
-    expect(scan.unresolved.map((miss) => miss.reason)).toEqual(['subject']);
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.usages).toEqual([{ hook: 'asCheckboxRoot', state: 'checked' }]);
+  });
+
+  it('binds a loop initializer inside the loop, not over the outer name', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const flag = def.state.bool('outerFlag', false);",
+      "for (let flag = def.state.bool('innerFlag', false); once; ) {",
+      "  def.expose.state('visible', flag);",
+      `  def.rule({ when: (w) => w.state(flag).eq(true), intent: ${use} });`,
+      '}',
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'flag', exposedAs: 'visible', attribute: 'inner-flag' },
+    ]);
+  });
+
+  it('follows a reassigned alias the rule itself reads', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'let current = first;',
+      'current = second;',
+      "def.expose.state('visible', current);",
+      `def.rule({ when: (w) => w.state(current).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'current', exposedAs: 'visible', attribute: 'second-flag' },
+    ]);
+  });
+
+  it('follows a handle aliased through a binding pattern', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const flag = def.state.bool('internalFlag', false);",
+      'const { ready: publicFlag } = { ready: flag };',
+      "def.expose.state('visible', publicFlag);",
+      `def.rule({ when: (w) => w.state(flag).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'flag', exposedAs: 'visible', attribute: 'internal-flag' },
+    ]);
   });
 
   it('reports a condition only one branch of which reaches the runtime', () => {

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -414,6 +414,61 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it('keeps a plain alias of an exposed local resolvable', () => {
+    // Production resolves the alias, so a token binding here would report a
+    // blind spot the extractor does not have.
+    const source = [
+      "const hidden = def.state.bool('hidden', true);",
+      "def.expose.state('hidden', hidden);",
+      'const alias = hidden;',
+      "def.rule({ when: (w) => w.state(alias).eq(true), intent: (i) => i.feedback.style.use(tw('bg-accent')) });",
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'alias', exposedAs: 'hidden', attribute: 'hidden' },
+    ]);
+  });
+
+  it('replaces the member table when a whole container is assigned', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'let controls = { ready: first };',
+      'controls = { ready: second };',
+      "def.expose.state('visible', controls.ready);",
+      `def.rule({ when: (w) => w.state(second).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'second', exposedAs: 'visible', attribute: 'second-flag' },
+    ]);
+  });
+
+  it('gives both branches of a conditional member write an attribute', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'const controls = { ready: first };',
+      'controls.ready = enabled ? first : second;',
+      "def.expose.state('visible', controls.ready);",
+      `def.rule({ when: (w) => w.state(first).eq(true), intent: ${use} });`,
+      `def.rule({ when: (w) => w.state(second).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'first', exposedAs: 'visible', attribute: 'first-flag' },
+      { state: 'second', exposedAs: 'visible', attribute: 'second-flag' },
+    ]);
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -763,6 +763,63 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it('keeps the earlier handle when the write is inside a callback', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'let flag = first;',
+      "def.on('refresh', () => { flag = second; });",
+      "def.expose.state('visible', flag);",
+      `def.rule({ when: (w) => w.state(flag).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals.map((local) => local.attribute).sort()).toEqual([
+      'first-flag',
+      'second-flag',
+    ]);
+  });
+
+  it('treats an immediately invoked write as ordered', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'let flag = first;',
+      '(() => { flag = second; })();',
+      "def.expose.state('visible', flag);",
+      `def.rule({ when: (w) => w.state(flag).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'flag', exposedAs: 'visible', attribute: 'second-flag' },
+    ]);
+  });
+
+  it('accepts an intent reading a container that also holds a handle', () => {
+    // The extractor emits `bg-red` and `data-[internal-flag]:bg-red` for this,
+    // so reporting the intent unresolved reds the gate on working code.
+    const source = [
+      "const flag = def.state.bool('internalFlag', false);",
+      "def.expose.state('visible', flag);",
+      "const controls = { ready: flag, className: 'bg-red' };",
+      'def.rule({',
+      '  when: (w) => w.state(controls.ready).eq(true),',
+      "  intent: (i) => i.feedback.style.use(tw(controls['className'])),",
+      '});',
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals).toEqual([
+      { state: 'flag', exposedAs: 'visible', attribute: 'internal-flag' },
+    ]);
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -2261,4 +2261,55 @@ describe('collectProtoStyleTokens', () => {
       expect(tokens, label).toContain('data-[second-flag]:bg-accent');
     }
   });
+  it('measures a member write against the container, not the alias', async () => {
+    // The alias is declared inside the callback, so its declaring scope is the
+    // callback itself and the write would look ordered against itself. What
+    // decides is the lifetime of the object being mutated.
+    for (const [label, block, keepsFirst] of [
+      [
+        'alias inside a callback',
+        [
+          "def.on('refresh', () => {",
+          '  const alias = controls;',
+          '  alias.ready = second;',
+          '});',
+        ],
+        true,
+      ],
+      [
+        'alias in a plain block',
+        ['{', '  const alias = controls;', '  alias.ready = second;', '}'],
+        false,
+      ],
+    ] as const) {
+      await writeFile(
+        path.join(dir, 'widget.proto.ts'),
+        [
+          "import { definePrototype, tw } from '@proto.ui/core';",
+          '',
+          'const widget = definePrototype({',
+          "  name: 'widget',",
+          '  setup(def) {',
+          "    const first = def.state.bool('firstFlag', false);",
+          "    const second = def.state.bool('secondFlag', false);",
+          '    const controls = { ready: first };',
+          ...block.map((line) => `    ${line}`),
+          "    def.expose.state('visible', controls.ready);",
+          '    def.rule({',
+          '      when: (w) => w.state(controls.ready).eq(true),',
+          "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+          '    });',
+          '  },',
+          '});',
+          '',
+          'export default widget;',
+        ].join('\n')
+      );
+
+      const tokens = await collectProtoStyleTokens(dir);
+      expect(tokens, label).toContain('data-[second-flag]:bg-accent');
+      if (keepsFirst) expect(tokens, label).toContain('data-[first-flag]:bg-accent');
+      else expect(tokens, label).not.toContain('data-[first-flag]:bg-accent');
+    }
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -1841,4 +1841,99 @@ describe('collectProtoStyleTokens', () => {
     expect(tokens).toContain('bg-accent');
     expect(tokens).toContain('text-sm');
   });
+  it('gives both branches of a conditional alias their own selector', async () => {
+    // Falling back to the expose key would emit `data-[visible]`, which the
+    // runtime never sets, while both real selectors stayed missing.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    const current = enabled ? first : second;',
+        "    def.expose.state('visible', current);",
+        '    def.rule({',
+        '      when: (w) => w.state(current).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[first-flag]:bg-accent');
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+    expect(tokens).not.toContain('data-[visible]:bg-accent');
+  });
+
+  it('resolves an alias target where the alias was written', async () => {
+    // The exposure sits in a block that rebinds the target's name; the alias
+    // captured the outer handle, so that is the one exposed.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const flag = def.state.bool('outerFlag', false);",
+        '    const current = flag;',
+        '    {',
+        "      const flag = def.state.bool('innerFlag', false);",
+        '      void flag;',
+        "      def.expose.state('visible', current);",
+        '    }',
+        '    def.rule({',
+        '      when: (w) => w.state(flag).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[outer-flag]:bg-accent');
+  });
+
+  it('keeps token members of a container that also holds a handle', async () => {
+    // Reading the container for its handles must not discard its token data.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const flag = def.state.bool('internalFlag', false);",
+        "    def.expose.state('visible', flag);",
+        "    const controls = { ready: flag, className: 'bg-red' };",
+        // Element access: reading a token map through a property access has
+        // never resolved here, with or without a handle in the container.
+        "    def.feedback.style.use(tw(controls['className']));",
+        '    def.rule({',
+        '      when: (w) => w.state(controls.ready).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('bg-red');
+    expect(tokens).toContain('data-[internal-flag]:bg-accent');
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -258,6 +258,88 @@ describe('collectProtoStyleTokens', () => {
     expect(tokens).not.toContain('dark:bg-input/30');
   });
 
+  it('lowers a rule on an exposed prototype-owned state', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const hidden = def.state.bool('hidden', true);",
+        // The expose call is what gives the state a host attribute, so it is
+        // also what tells the extractor the selector.
+        "    def.expose.state('hidden', hidden);",
+        '    def.rule({',
+        '      when: (w) => w.state(hidden).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('hidden')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[hidden]:hidden');
+  });
+
+  it('normalizes an exposed key the way the Web runtime does', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const dragOver = def.state.bool('dragOver', false);",
+        "    def.expose.state('dragOver', dragOver);",
+        '    def.rule({',
+        '      when: (w) => w.state(dragOver).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    // `createExposeStateWebNameMap` kebab-cases an unannotated key.
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[drag-over]:bg-accent');
+  });
+
+  it('keeps an official semantic when the state is exposed under another key', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const hovered = def.state.fromInteraction('hovered');",
+        // The runtime maps the official semantic before it would fall back to
+        // the exposed key, so the key must not win here either.
+        "    def.expose.state('isHot', hovered);",
+        '    def.rule({',
+        '      when: (w) => w.state(hovered).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('hover:bg-accent');
+    expect(tokens).not.toContain('data-[is-hot]:bg-accent');
+  });
+
   it('lowers the Scroll Area Viewport focus condition into the closure', async () => {
     await writeFile(
       path.join(dir, 'surface.proto.ts'),

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -1781,4 +1781,64 @@ describe('collectProtoStyleTokens', () => {
 
     expect(await collectProtoStyleTokens(dir)).toContain('data-[internal-flag]:bg-accent');
   });
+  it('reads a destructured handle the rule uses by its alias', async () => {
+    // The prepass already traced the pattern for the exposure; the rule reads
+    // the alias, so the alias itself has to carry the state semantic.
+    for (const [label, container] of [
+      ['object literal', 'const { ready: publicFlag } = { ready: flag };'],
+      ['array literal', 'const [publicFlag] = [flag];'],
+      [
+        'container variable',
+        'const controls = { ready: flag };\n    const { ready: publicFlag } = controls;',
+      ],
+    ] as const) {
+      await writeFile(
+        path.join(dir, 'widget.proto.ts'),
+        [
+          "import { definePrototype, tw } from '@proto.ui/core';",
+          '',
+          'const widget = definePrototype({',
+          "  name: 'widget',",
+          '  setup(def) {',
+          "    const flag = def.state.bool('internalFlag', false);",
+          `    ${container}`,
+          "    def.expose.state('visible', publicFlag);",
+          '    def.rule({',
+          '      when: (w) => w.state(publicFlag).eq(true),',
+          "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+          '    });',
+          '  },',
+          '});',
+          '',
+          'export default widget;',
+        ].join('\n')
+      );
+
+      expect(await collectProtoStyleTokens(dir), label).toContain('data-[internal-flag]:bg-accent');
+    }
+  });
+
+  it('still reads a joined token array as tokens', async () => {
+    // The handle-array reading runs first, so an array holding no handle has to
+    // fall through to the element list `join` depends on.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    def.feedback.style.use(tw(['bg-accent', 'text-sm'].join(' ')));",
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('bg-accent');
+    expect(tokens).toContain('text-sm');
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -894,6 +894,44 @@ describe('collectProtoStyleTokens', () => {
     expect(tokens).not.toContain('data-[visible]:bg-accent');
   });
 
+  it("does not let one prototype's exposure reach a sibling's same-named state", async () => {
+    // A sibling that independently declares `flag` and never exposes it must
+    // keep its rule on the runtime plan.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'export const exposed = definePrototype({',
+        "  name: 'exposed',",
+        '  setup(def) {',
+        "    const flag = def.state.bool('firstFlag', false);",
+        "    def.expose.state('visible', flag);",
+        '    def.rule({',
+        '      when: (w) => w.state(flag).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export const internal = definePrototype({',
+        "  name: 'internal',",
+        '  setup(def) {',
+        "    const flag = def.state.bool('secondFlag', false);",
+        '    def.rule({',
+        '      when: (w) => w.state(flag).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-muted')),",
+        '    });',
+        '  },',
+        '});',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[first-flag]:bg-accent');
+    expect(tokens).not.toContain('data-[second-flag]:bg-muted');
+  });
+
   it('serializes a discrete number the way the runtime does', async () => {
     await writeFile(
       path.join(dir, 'widget.proto.ts'),

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -311,6 +311,88 @@ describe('collectProtoStyleTokens', () => {
     expect(await collectProtoStyleTokens(dir)).toContain('data-[drag-over]:bg-accent');
   });
 
+  it('uses the declared state name rather than the expose key', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const flag = def.state.bool('internalFlag', false);",
+        // `StateKernel` stores the declared name as `__stateSemantic`, and
+        // `ExposeStateWebModuleImpl` maps that before the expose key.
+        "    def.expose.state('visible', flag);",
+        '    def.rule({',
+        '      when: (w) => w.state(flag).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[internal-flag]:bg-accent');
+    expect(tokens).not.toContain('data-[visible]:bg-accent');
+  });
+
+  it('registers an exposure declared after the rule that reads it', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const hidden = def.state.bool('hidden', true);",
+        '    def.rule({',
+        '      when: (w) => w.state(hidden).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('hidden')),",
+        '    });',
+        // The runtime builds its exposed-state map after setup returns, so
+        // source order does not decide whether the rule lowers.
+        "    def.expose.state('hidden', hidden);",
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[hidden]:hidden');
+  });
+
+  it('resolves a constant expose key', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const key = 'hidden';",
+        "    const hidden = def.state.bool('hidden', true);",
+        '    def.expose.state(key, hidden);',
+        '    def.rule({',
+        '      when: (w) => w.state(hidden).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('hidden')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[hidden]:hidden');
+  });
+
   it('keeps an official semantic when the state is exposed under another key', async () => {
     await writeFile(
       path.join(dir, 'widget.proto.ts'),

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -1688,4 +1688,97 @@ describe('collectProtoStyleTokens', () => {
 
     expect(await collectProtoStyleTokens(dir)).toContain('data-[1st]:bg-accent');
   });
+  it('gives a rule reading a skippable alias both selectors', async () => {
+    // The exposure already covered both handles; the rule read did not, so an
+    // `enabled === false` build lowered to a variant the closure never carried.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    let current = first;',
+        '    if (enabled) current = second;',
+        "    def.expose.state('visible', current);",
+        '    def.rule({',
+        '      when: (w) => w.state(current).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[first-flag]:bg-accent');
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+  });
+
+  it('combines a skippable alias with the other conditions of its rule', async () => {
+    // One selector per combination the runtime may take, not one selector
+    // carrying both alternatives at once.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        "    const other = def.state.bool('otherFlag', false);",
+        '    let current = first;',
+        '    if (enabled) current = second;',
+        "    def.expose.state('visible', current);",
+        "    def.expose.state('other', other);",
+        '    def.rule({',
+        '      when: (w) => w.all(w.state(current).eq(true), w.state(other).eq(true)),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[first-flag]:data-[other-flag]:bg-accent');
+    expect(tokens).toContain('data-[other-flag]:data-[second-flag]:bg-accent');
+  });
+
+  it('reads a state handle held in a plain container', async () => {
+    // The exposure already resolved through the member; the rule read has to
+    // reach the same handle or the optimized rule has no CSS.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const flag = def.state.bool('internalFlag', false);",
+        '    const controls = { ready: flag };',
+        "    def.expose.state('visible', controls.ready);",
+        '    def.rule({',
+        '      when: (w) => w.state(controls.ready).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[internal-flag]:bg-accent');
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -2064,4 +2064,71 @@ describe('collectProtoStyleTokens', () => {
     expect(tokens).toContain('data-[first-flag]:bg-accent');
     expect(tokens).toContain('data-[second-flag]:bg-accent');
   });
+  it('keeps the earlier handle when the write is inside a callback', async () => {
+    // The callback has not run when `def.rule` registers, so the runtime lowers
+    // the handle the name still holds; the closure has to carry both.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    let flag = first;',
+        "    def.on('refresh', () => {",
+        '      flag = second;',
+        '    });',
+        "    def.expose.state('visible', flag);",
+        '    def.rule({',
+        '      when: (w) => w.state(flag).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[first-flag]:bg-accent');
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+  });
+
+  it('treats an immediately invoked write as ordered', async () => {
+    // An IIFE runs where it is written, so the earlier handle is gone and a
+    // variant for it would be dead CSS the runtime can never match.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    let flag = first;',
+        '    (() => {',
+        '      flag = second;',
+        '    })();',
+        "    def.expose.state('visible', flag);",
+        '    def.rule({',
+        '      when: (w) => w.state(flag).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+    expect(tokens).not.toContain('data-[first-flag]:bg-accent');
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -1459,4 +1459,68 @@ describe('collectProtoStyleTokens', () => {
 
     expect(await collectProtoStyleTokens(dir)).toContain('data-[internal-flag]:bg-accent');
   });
+  it('replaces the member table when a whole container is assigned', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    let controls = { ready: first };',
+        '    controls = { ready: second };',
+        "    def.expose.state('visible', controls.ready);",
+        '    def.rule({',
+        '      when: (w) => w.state(second).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[second-flag]:bg-accent');
+  });
+
+  it('gives both branches of a conditional member write a variant', async () => {
+    // The runtime picks one at the expose call; over-approximating gives each
+    // candidate its variant, while recording neither leaves the chosen one
+    // without CSS.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    const controls = { ready: first };',
+        '    controls.ready = enabled ? first : second;',
+        "    def.expose.state('visible', controls.ready);",
+        '    def.rule({',
+        '      when: (w) => w.state(first).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-muted')),",
+        '    });',
+        '    def.rule({',
+        '      when: (w) => w.state(second).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[first-flag]:bg-muted');
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -671,6 +671,67 @@ describe('collectProtoStyleTokens', () => {
     expect(await collectProtoStyleTokens(dir)).toContain('data-[step=-1]:bg-accent');
   });
 
+  it('resolves each alias hop where that hop was created', async () => {
+    // `publicFlag` captured `current` while `current` still meant `first`; a
+    // later `var current = second` must not retarget the exposure.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    var current = first;',
+        '    const publicFlag = current;',
+        '    var current = second;',
+        "    def.expose.state('visible', publicFlag);",
+        '    def.rule({',
+        '      when: (w) => w.state(first).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[first-flag]:bg-accent');
+    expect(tokens).not.toContain('data-[second-flag]:bg-accent');
+  });
+
+  it('serializes a discrete number the way the runtime does', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const step = def.state.numberDiscrete('step', 0);",
+        "    def.expose.state('step', step);",
+        // The runtime lowers with `String(literal)`, and `String(-0)` is `0`.
+        '    def.rule({',
+        '      when: (w) => w.state(step).eq(-0),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[step=0]:bg-accent');
+    expect(tokens).not.toContain('data-[step=-0]:bg-accent');
+  });
+
   it('keeps every binding a legal redeclaration installs', async () => {
     // The exposure pre-pass must not flatten sequential declaration scope.
     await writeFile(

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -793,6 +793,107 @@ describe('collectProtoStyleTokens', () => {
     expect(await collectProtoStyleTokens(dir)).toContain('data-[second-flag]:bg-accent');
   });
 
+  it('records every branch of a conditional alias', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    const publicFlag = enabled ? first : second;',
+        "    def.expose.state('visible', publicFlag);",
+        "    def.rule({ when: (w) => w.state(second).eq(true), intent: (i) => i.feedback.style.use(tw('bg-accent')) });",
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+  });
+
+  it('treats a var alias as function scoped', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    var publicFlag = first;',
+        '    {',
+        '      var publicFlag = second;',
+        '    }',
+        "    def.expose.state('visible', publicFlag);",
+        "    def.rule({ when: (w) => w.state(second).eq(true), intent: (i) => i.feedback.style.use(tw('bg-accent')) });",
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+  });
+
+  it('reads a handle exposed through a property', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const ready = def.state.bool('ready', false);",
+        '    const controls = { ready };',
+        "    def.expose.state('ready', controls.ready);",
+        "    def.rule({ when: (w) => w.state(ready).eq(true), intent: (i) => i.feedback.style.use(tw('bg-accent')) });",
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[ready]:bg-accent');
+  });
+
+  it('reads a state declared through element access', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const flag = def.state['bool']('internalFlag', false);",
+        "    def.expose.state('visible', flag);",
+        "    def.rule({ when: (w) => w.state(flag).eq(true), intent: (i) => i.feedback.style.use(tw('bg-accent')) });",
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[internal-flag]:bg-accent');
+    expect(tokens).not.toContain('data-[visible]:bg-accent');
+  });
+
   it('serializes a discrete number the way the runtime does', async () => {
     await writeFile(
       path.join(dir, 'widget.proto.ts'),

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -2207,4 +2207,58 @@ describe('collectProtoStyleTokens', () => {
       expect(tokens, label).toContain('data-[second-flag]:bg-accent');
     }
   });
+  it('keeps the earlier member across a callback, two objects, or an unreadable key', async () => {
+    for (const [label, lines, read] of [
+      [
+        'callback write',
+        [
+          'const controls = { ready: first };',
+          "def.on('refresh', () => { controls.ready = second; });",
+        ],
+        'controls.ready',
+      ],
+      [
+        'either of two objects',
+        [
+          'const controlsA = { ready: first };',
+          'const controlsB = { ready: first };',
+          'const alias = enabled ? controlsA : controlsB;',
+          'alias.ready = second;',
+        ],
+        'controlsA.ready',
+      ],
+      [
+        'unreadable key',
+        ['const controls = { ready: first };', "const key = 'ready';", 'controls[key] = second;'],
+        'controls.ready',
+      ],
+    ] as const) {
+      await writeFile(
+        path.join(dir, 'widget.proto.ts'),
+        [
+          "import { definePrototype, tw } from '@proto.ui/core';",
+          '',
+          'const widget = definePrototype({',
+          "  name: 'widget',",
+          '  setup(def) {',
+          "    const first = def.state.bool('firstFlag', false);",
+          "    const second = def.state.bool('secondFlag', false);",
+          ...lines.map((line) => `    ${line}`),
+          `    def.expose.state('visible', ${read});`,
+          '    def.rule({',
+          `      when: (w) => w.state(${read}).eq(true),`,
+          "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+          '    });',
+          '  },',
+          '});',
+          '',
+          'export default widget;',
+        ].join('\n')
+      );
+
+      const tokens = await collectProtoStyleTokens(dir);
+      expect(tokens, label).toContain('data-[first-flag]:bg-accent');
+      expect(tokens, label).toContain('data-[second-flag]:bg-accent');
+    }
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -2131,4 +2131,41 @@ describe('collectProtoStyleTokens', () => {
     expect(tokens).toContain('data-[second-flag]:bg-accent');
     expect(tokens).not.toContain('data-[first-flag]:bg-accent');
   });
+  it('keeps the earlier handle across an async or generator IIFE', async () => {
+    // An async function may suspend before the write and a generator does not
+    // run its body on the call at all, so neither has happened when the rule
+    // registers — being directly invoked is not enough.
+    for (const [label, iife] of [
+      ['async', ['(async () => {', '  await 0;', '  current = second;', '})();']],
+      ['generator', ['(function* () {', '  current = second;', '})();']],
+    ] as const) {
+      await writeFile(
+        path.join(dir, 'widget.proto.ts'),
+        [
+          "import { definePrototype, tw } from '@proto.ui/core';",
+          '',
+          'const widget = definePrototype({',
+          "  name: 'widget',",
+          '  setup(def) {',
+          "    const first = def.state.bool('firstFlag', false);",
+          "    const second = def.state.bool('secondFlag', false);",
+          '    let current = first;',
+          ...iife.map((line) => `    ${line}`),
+          "    def.expose.state('visible', current);",
+          '    def.rule({',
+          '      when: (w) => w.state(current).eq(true),',
+          "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+          '    });',
+          '  },',
+          '});',
+          '',
+          'export default widget;',
+        ].join('\n')
+      );
+
+      const tokens = await collectProtoStyleTokens(dir);
+      expect(tokens, label).toContain('data-[first-flag]:bg-accent');
+      expect(tokens, label).toContain('data-[second-flag]:bg-accent');
+    }
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -2168,4 +2168,43 @@ describe('collectProtoStyleTokens', () => {
       expect(tokens, label).toContain('data-[second-flag]:bg-accent');
     }
   });
+  it('keeps the earlier handle when an IIFE may not reach the write', async () => {
+    // Running in place proves the function starts, not that this write runs.
+    for (const [label, iife] of [
+      ['early return', ['(() => {', '  return;', '  current = second;', '})();']],
+      ['early throw', ['(() => {', "  throw new Error('x');", '  current = second;', '})();']],
+      [
+        'conditional return',
+        ['(() => {', '  if (enabled) return;', '  current = second;', '})();'],
+      ],
+    ] as const) {
+      await writeFile(
+        path.join(dir, 'widget.proto.ts'),
+        [
+          "import { definePrototype, tw } from '@proto.ui/core';",
+          '',
+          'const widget = definePrototype({',
+          "  name: 'widget',",
+          '  setup(def) {',
+          "    const first = def.state.bool('firstFlag', false);",
+          "    const second = def.state.bool('secondFlag', false);",
+          '    let current = first;',
+          ...iife.map((line) => `    ${line}`),
+          "    def.expose.state('visible', current);",
+          '    def.rule({',
+          '      when: (w) => w.state(current).eq(true),',
+          "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+          '    });',
+          '  },',
+          '});',
+          '',
+          'export default widget;',
+        ].join('\n')
+      );
+
+      const tokens = await collectProtoStyleTokens(dir);
+      expect(tokens, label).toContain('data-[first-flag]:bg-accent');
+      expect(tokens, label).toContain('data-[second-flag]:bg-accent');
+    }
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -704,6 +704,36 @@ describe('collectProtoStyleTokens', () => {
     expect(tokens).not.toContain('data-[second-flag]:bg-accent');
   });
 
+  it('follows an alias reassigned before the exposure', async () => {
+    // The runtime captured whatever `publicFlag` held at the expose call, and a
+    // plain assignment moves the handle just as a declaration does.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    let publicFlag = first;',
+        '    publicFlag = second;',
+        "    def.expose.state('visible', publicFlag);",
+        '    def.rule({',
+        '      when: (w) => w.state(second).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[second-flag]:bg-accent');
+  });
+
   it('serializes a discrete number the way the runtime does', async () => {
     await writeFile(
       path.join(dir, 'widget.proto.ts'),

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -554,6 +554,41 @@ describe('collectProtoStyleTokens', () => {
     expect(await collectProtoStyleTokens(dir)).toContain('data-[step=1]:bg-accent');
   });
 
+  it('keeps sibling blocks from sharing an alias', async () => {
+    // Two blocks in one setup may legally reuse `publicFlag` for different
+    // handles; a function-scoped map would let the later one overwrite.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    {',
+        '      const publicFlag = first;',
+        "      def.expose.state('a', publicFlag);",
+        '    }',
+        '    {',
+        '      const publicFlag = second;',
+        "      def.expose.state('b', publicFlag);",
+        '    }',
+        '    def.rule({',
+        '      when: (w) => w.state(first).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[first-flag]:bg-accent');
+  });
+
   it('keeps every binding a legal redeclaration installs', async () => {
     // The exposure pre-pass must not flatten sequential declaration scope.
     await writeFile(

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -1936,4 +1936,69 @@ describe('collectProtoStyleTokens', () => {
     expect(tokens).toContain('bg-red');
     expect(tokens).toContain('data-[internal-flag]:bg-accent');
   });
+  it('reads a container member the rule uses after a write', async () => {
+    // The exposure prepass already followed the write; the rule reads the
+    // member itself, so the ordinary walk has to follow it too.
+    for (const [label, write, read] of [
+      ['property access', 'controls.ready = second;', 'controls.ready'],
+      ['element access', "controls['ready'] = second;", "controls['ready']"],
+    ] as const) {
+      await writeFile(
+        path.join(dir, 'widget.proto.ts'),
+        [
+          "import { definePrototype, tw } from '@proto.ui/core';",
+          '',
+          'const widget = definePrototype({',
+          "  name: 'widget',",
+          '  setup(def) {',
+          "    const first = def.state.bool('firstFlag', false);",
+          "    const second = def.state.bool('secondFlag', false);",
+          '    const controls = { ready: first };',
+          `    ${write}`,
+          `    def.expose.state('visible', ${read});`,
+          '    def.rule({',
+          `      when: (w) => w.state(${read}).eq(true),`,
+          "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+          '    });',
+          '  },',
+          '});',
+          '',
+          'export default widget;',
+        ].join('\n')
+      );
+
+      const tokens = await collectProtoStyleTokens(dir);
+      expect(tokens, label).toContain('data-[second-flag]:bg-accent');
+    }
+  });
+
+  it('keeps the earlier member when the write may be skipped', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    const controls = { ready: first };',
+        '    if (enabled) controls.ready = second;',
+        "    def.expose.state('visible', controls.ready);",
+        '    def.rule({',
+        '      when: (w) => w.state(controls.ready).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[first-flag]:bg-accent');
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -1523,4 +1523,169 @@ describe('collectProtoStyleTokens', () => {
     expect(tokens).toContain('data-[first-flag]:bg-muted');
     expect(tokens).toContain('data-[second-flag]:bg-accent');
   });
+  it('reads a member at the position it was written', async () => {
+    // The object captured whatever `current` named then; a later reassignment
+    // moves the alias, not what the container already holds.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    let current = first;',
+        '    const controls = { ready: current };',
+        '    current = second;',
+        "    def.expose.state('visible', controls.ready);",
+        '    def.rule({',
+        '      when: (w) => w.state(first).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[first-flag]:bg-accent');
+  });
+
+  it('keeps the earlier handle when a write may be skipped', async () => {
+    // The runtime takes one path; whichever it takes, that rule is optimized
+    // away, so both candidates need a variant.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    let current = first;',
+        '    if (enabled) current = second;',
+        "    def.expose.state('visible', current);",
+        '    def.rule({',
+        '      when: (w) => w.state(first).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-muted')),",
+        '    });',
+        '    def.rule({',
+        '      when: (w) => w.state(second).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[first-flag]:bg-muted');
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+  });
+
+  it('drops the earlier handle when the branch is statically taken', async () => {
+    // `if (true)` executes exactly as written, so retaining the earlier handle
+    // would emit a variant for a state the runtime never exposes.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    let current = first;',
+        '    if (true) current = second;',
+        "    def.expose.state('visible', current);",
+        '    def.rule({',
+        '      when: (w) => w.state(first).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-muted')),",
+        '    });',
+        '    def.rule({',
+        '      when: (w) => w.state(second).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+    expect(tokens).not.toContain('data-[first-flag]:bg-muted');
+  });
+
+  it('hoists a nested var redeclaration the rule reads', async () => {
+    // One function-scoped binding, so the block's declaration is the same one
+    // the statements after it see.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    var current = first;',
+        '    {',
+        '      var current = second;',
+        '    }',
+        "    def.expose.state('visible', current);",
+        '    def.rule({',
+        '      when: (w) => w.state(current).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+    expect(tokens).not.toContain('data-[first-flag]:bg-accent');
+  });
+
+  it('normalizes a state name that starts with a digit', async () => {
+    // `createExposeStateWebNameMap('1st')` is `data-1st`, and `[data-1st]` is a
+    // legal attribute selector, so nothing here may reject it.
+    expect(createExposeStateWebNameMap('1st').dataAttr).toBe('data-1st');
+
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const flag = def.state.bool('1st', false);",
+        "    def.expose.state('1st', flag);",
+        '    def.rule({',
+        '      when: (w) => w.state(flag).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[1st]:bg-accent');
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -734,6 +734,65 @@ describe('collectProtoStyleTokens', () => {
     expect(await collectProtoStyleTokens(dir)).toContain('data-[second-flag]:bg-accent');
   });
 
+  it('reads the declared name through a wrapped initializer', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const flag = (def.state.bool('internalFlag', false)) as never;",
+        "    def.expose.state('visible', flag);",
+        '    def.rule({',
+        '      when: (w) => w.state(flag).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[internal-flag]:bg-accent');
+    expect(tokens).not.toContain('data-[visible]:bg-accent');
+  });
+
+  it('sees an alias reassigned inside a nested block', async () => {
+    // The assignment targets the outer binding, so an exposure written after
+    // the block has to see it.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    let publicFlag = first;',
+        '    {',
+        '      publicFlag = second;',
+        '    }',
+        "    def.expose.state('visible', publicFlag);",
+        '    def.rule({',
+        '      when: (w) => w.state(second).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[second-flag]:bg-accent');
+  });
+
   it('serializes a discrete number the way the runtime does', async () => {
     await writeFile(
       path.join(dir, 'widget.proto.ts'),

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -1289,4 +1289,174 @@ describe('collectProtoStyleTokens', () => {
 
     expect(await collectProtoStyleTokens(dir)).toContain('data-[constructor]:bg-accent');
   });
+  it('negates a native interaction variant through its attribute', async () => {
+    // `buildSemanticVariant` only answers a true comparison, so the optimizer
+    // falls back to `not-[data-hovered]` and still removes the rule. Emitting
+    // only the positive condition would apply the style while hovered.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const hovered = def.state.bool('@interaction/hovered', false);",
+        "    const other = def.state.bool('otherFlag', false);",
+        "    def.expose.state('hovered', hovered);",
+        "    def.expose.state('other', other);",
+        '    def.rule({',
+        '      when: (w) => w.all(w.state(hovered).eq(false), w.state(other).eq(true)),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[other-flag]:not-[data-hovered]:bg-accent');
+  });
+
+  it('negates a hook-sourced native variant the same way', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const hovered = def.state.fromInteraction('hovered');",
+        "    const pressed = def.state.fromInteraction('pressed');",
+        '    def.rule({',
+        '      when: (w) => w.all(w.state(hovered).eq(false), w.state(pressed).eq(true)),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('active:not-[data-hovered]:bg-accent');
+  });
+
+  it('binds a loop initializer inside the loop, not over the outer name', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const flag = def.state.bool('outerFlag', false);",
+        '    void flag;',
+        "    for (let flag = def.state.bool('innerFlag', false); once; ) {",
+        "      def.expose.state('visible', flag);",
+        '      def.rule({',
+        '        when: (w) => w.state(flag).eq(true),',
+        "        intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '      });',
+        '    }',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[inner-flag]:bg-accent');
+    expect(tokens).not.toContain('data-[outer-flag]:bg-accent');
+  });
+
+  it('follows a reassigned alias the rule itself reads', async () => {
+    // The exposure prepass already followed the assignment; the ordinary walk
+    // left the alias frozen at its declaration.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    let current = first;',
+        '    current = second;',
+        "    def.expose.state('visible', current);",
+        '    def.rule({',
+        '      when: (w) => w.state(current).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+    expect(tokens).not.toContain('data-[first-flag]:bg-accent');
+  });
+
+  it('follows a handle aliased through a binding pattern', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const flag = def.state.bool('internalFlag', false);",
+        '    const { ready: publicFlag } = { ready: flag };',
+        "    def.expose.state('visible', publicFlag);",
+        '    def.rule({',
+        '      when: (w) => w.state(flag).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[internal-flag]:bg-accent');
+  });
+
+  it('follows a handle aliased through an array pattern', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const flag = def.state.bool('internalFlag', false);",
+        '    const [publicFlag] = [flag];',
+        "    def.expose.state('visible', publicFlag);",
+        '    def.rule({',
+        '      when: (w) => w.state(flag).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[internal-flag]:bg-accent');
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { OFFICIAL_EXPOSED_STATE_NAMES } from '../../modules/expose-state-web/src/utils';
+import {
+  createExposeStateWebNameMap,
+  createExposeStateWebNativeVariantPolicy,
+  OFFICIAL_EXPOSED_STATE_NAMES,
+} from '../../modules/expose-state-web/src/utils';
 import { collectProtoStyleTokens } from '../src/services/prototype-style-tokens';
 
 describe('collectProtoStyleTokens', () => {
@@ -1117,5 +1121,172 @@ describe('collectProtoStyleTokens', () => {
     // variant, and the ring reaches the closure unconditional.
     expect(tokens).toContain('data-[focus-visible]:ring-2');
     expect(tokens).toContain('data-[focus-visible]:ring-inset');
+  });
+  it('lowers an owned interaction semantic to its native variant', async () => {
+    // `buildSemanticVariant` runs before the attribute, so the optimizer emits
+    // `hover:` and nothing ever renders `data-[hovered]:`.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const hovered = def.state.bool('@interaction/hovered', false);",
+        "    def.expose.state('hovered', hovered);",
+        '    def.rule({',
+        '      when: (w) => w.state(hovered).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('hover:bg-accent');
+    expect(tokens).not.toContain('data-[hovered]:bg-accent');
+  });
+
+  it('keeps the attribute for an official semantic the policy refuses', async () => {
+    // `@interaction/disabled` has a native variant the Web policy rejects, and
+    // `@accessibility/checked` has none at all; both stay on the attribute.
+    expect(createExposeStateWebNativeVariantPolicy({ semantic: '@interaction/hovered' })).toBe(
+      true
+    );
+    expect(createExposeStateWebNativeVariantPolicy({ semantic: '@interaction/pressed' })).toBe(
+      true
+    );
+    expect(createExposeStateWebNativeVariantPolicy({ semantic: '@interaction/disabled' })).toBe(
+      false
+    );
+
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const off = def.state.bool('@interaction/disabled', false);",
+        "    const ticked = def.state.bool('@accessibility/checked', false);",
+        "    def.expose.state('off', off);",
+        "    def.expose.state('ticked', ticked);",
+        '    def.rule({',
+        '      when: (w) => w.state(off).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('opacity-50')),",
+        '    });',
+        '    def.rule({',
+        '      when: (w) => w.state(ticked).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[disabled]:opacity-50');
+    expect(tokens).toContain('data-[checked]:bg-accent');
+  });
+
+  it('follows a handle written into the container before the exposure', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    const controls = { ready: first };',
+        '    controls.ready = second;',
+        "    def.expose.state('visible', controls.ready);",
+        '    def.rule({',
+        '      when: (w) => w.state(second).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+  });
+
+  it('leaves a member write after the exposure out of it', async () => {
+    // The exposure captured the member as it read, so the later write moves
+    // nothing; only the handle in effect at the call has a variant.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    const controls = { ready: first };',
+        "    def.expose.state('visible', controls.ready);",
+        '    controls.ready = second;',
+        '    def.rule({',
+        '      when: (w) => w.state(first).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '    def.rule({',
+        '      when: (w) => w.state(second).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-muted')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[first-flag]:bg-accent');
+    expect(tokens).not.toContain('data-[second-flag]:bg-muted');
+  });
+
+  it('normalizes a state named after an inherited object key', async () => {
+    // The official-name table is a plain object literal, so `constructor` must
+    // not resolve to the function it inherits.
+    expect(createExposeStateWebNameMap('constructor').dataAttr).toBe('data-constructor');
+
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const flag = def.state.bool('constructor', false);",
+        "    def.expose.state('constructor', flag);",
+        '    def.rule({',
+        '      when: (w) => w.state(flag).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[constructor]:bg-accent');
   });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -465,6 +465,95 @@ describe('collectProtoStyleTokens', () => {
     }
   });
 
+  it('keeps sibling alias names apart', async () => {
+    // Two setups in one file may each bind `publicFlag`; a file-wide alias map
+    // would attribute the first exposure to the second handle.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'export const first = definePrototype({',
+        "  name: 'first',",
+        '  setup(def) {',
+        "    const flag = def.state.bool('firstFlag', false);",
+        '    const publicFlag = flag;',
+        "    def.expose.state('visible', publicFlag);",
+        '    def.rule({',
+        '      when: (w) => w.state(flag).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export const second = definePrototype({',
+        "  name: 'second',",
+        '  setup(def) {',
+        "    const other = def.state.bool('secondFlag', false);",
+        '    const publicFlag = other;',
+        "    def.expose.state('shown', publicFlag);",
+        '  },',
+        '});',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[first-flag]:bg-accent');
+  });
+
+  it('emits nothing for a declared name it cannot evaluate', async () => {
+    // `__stateSemantic` is the call's result at runtime and takes precedence,
+    // so the expose key would be the wrong selector rather than a safe default.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        "import { makeStateName } from './names';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        '    const flag = def.state.bool(makeStateName(), false);',
+        "    def.expose.state('visible', flag);",
+        '    def.rule({',
+        '      when: (w) => w.state(flag).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).not.toContain('data-[visible]:bg-accent');
+  });
+
+  it('lowers a discrete-number comparison on an exposed state', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const step = def.state.numberDiscrete('step', 0);",
+        "    def.expose.state('step', step);",
+        '    def.rule({',
+        '      when: (w) => w.state(step).eq(1),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    // The Web runtime stringifies the literal the way it does for enums.
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[step=1]:bg-accent');
+  });
+
   it('keeps every binding a legal redeclaration installs', async () => {
     // The exposure pre-pass must not flatten sequential declaration scope.
     await writeFile(

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { OFFICIAL_EXPOSED_STATE_NAMES } from '../../modules/expose-state-web/src/utils';
 import { collectProtoStyleTokens } from '../src/services/prototype-style-tokens';
 
 describe('collectProtoStyleTokens', () => {
@@ -930,6 +931,109 @@ describe('collectProtoStyleTokens', () => {
     const tokens = await collectProtoStyleTokens(dir);
     expect(tokens).toContain('data-[first-flag]:bg-accent');
     expect(tokens).not.toContain('data-[second-flag]:bg-muted');
+  });
+
+  it('mirrors the official exposed-state names the Web projection uses', async () => {
+    // The extractor duplicates this map to stay free of runtime dependencies,
+    // so the copy has to be provably identical.
+    const { readFile } = await import('node:fs/promises');
+    const source = await readFile(
+      path.join(process.cwd(), 'packages/cli/src/services/prototype-style-tokens.ts'),
+      'utf8'
+    );
+    const block = source.match(
+      /const OFFICIAL_EXPOSED_STATE_NAMES = Object\.freeze\(\{([\s\S]*?)\}\);/
+    );
+    if (!block) throw new Error('the extractor must carry an official-name map');
+
+    const mirrored: Record<string, string> = {};
+    for (const [, key, value] of block[1].matchAll(/'([^']+)':\s*'([^']+)'/g)) {
+      mirrored[key] = value;
+    }
+    expect(mirrored).toEqual({ ...OFFICIAL_EXPOSED_STATE_NAMES });
+  });
+
+  it('maps an official semantic before normalizing the name', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const flag = def.state.bool('@accessibility/checked', false);",
+        "    def.expose.state('visible', flag);",
+        '    def.rule({',
+        '      when: (w) => w.state(flag).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[checked]:bg-accent');
+    expect(tokens).not.toContain('data-[accessibility-checked]:bg-accent');
+  });
+
+  it('keeps a shadowed object from answering for an outer one', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    const controls = { ready: first };',
+        '    {',
+        '      const controls = { ready: second };',
+        '      void controls;',
+        '    }',
+        "    def.expose.state('visible', controls.ready);",
+        '    def.rule({',
+        '      when: (w) => w.state(first).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[first-flag]:bg-accent');
+  });
+
+  it('registers a declaration under single-statement control flow', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    if (true) var flag = def.state.bool('gated', false);",
+        "    def.expose.state('gated', flag);",
+        '    def.rule({',
+        '      when: (w) => w.state(flag).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[gated]:bg-accent');
   });
 
   it('serializes a discrete number the way the runtime does', async () => {

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -2001,4 +2001,67 @@ describe('collectProtoStyleTokens', () => {
     expect(tokens).toContain('data-[first-flag]:bg-accent');
     expect(tokens).toContain('data-[second-flag]:bg-accent');
   });
+  it('follows a member written through an alias of the container', async () => {
+    // `alias` and `controls` are one object at runtime, so a write through
+    // either has to move the member a read through the other sees.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    const controls = { ready: first };',
+        '    const alias = controls;',
+        '    alias.ready = second;',
+        "    def.expose.state('visible', controls.ready);",
+        '    def.rule({',
+        '      when: (w) => w.state(controls.ready).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+    expect(tokens).not.toContain('data-[first-flag]:bg-accent');
+  });
+
+  it('keeps both members when the alias write may be skipped', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    const controls = { ready: first };',
+        '    const alias = controls;',
+        '    if (enabled) alias.ready = second;',
+        "    def.expose.state('visible', controls.ready);",
+        '    def.rule({',
+        '      when: (w) => w.state(controls.ready).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[first-flag]:bg-accent');
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -589,6 +589,88 @@ describe('collectProtoStyleTokens', () => {
     expect(await collectProtoStyleTokens(dir)).toContain('data-[first-flag]:bg-accent');
   });
 
+  it('keeps an exposure bound to the alias in effect where it was written', async () => {
+    // The runtime captured `first` at the expose call; a later `var` rebinding
+    // must not retarget it.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    var publicFlag = first;',
+        "    def.expose.state('visible', publicFlag);",
+        '    var publicFlag = second;',
+        '    def.rule({',
+        '      when: (w) => w.state(first).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[first-flag]:bg-accent');
+  });
+
+  it('lowers a state exposed through the generic entry', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const ready = def.state.bool('ready', false);",
+        // `ExposeStateModuleImpl` recognizes a state handle here as well.
+        "    def.expose('ready', ready);",
+        '    def.rule({',
+        '      when: (w) => w.state(ready).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[ready]:bg-accent');
+  });
+
+  it('lowers a signed discrete-number comparison', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const step = def.state.numberDiscrete('step', 0);",
+        "    def.expose.state('step', step);",
+        // `-1` parses as a prefix unary expression, not a numeric literal.
+        '    def.rule({',
+        '      when: (w) => w.state(step).eq(-1),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[step=-1]:bg-accent');
+  });
+
   it('keeps every binding a legal redeclaration installs', async () => {
     // The exposure pre-pass must not flatten sequential declaration scope.
     await writeFile(

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -422,6 +422,75 @@ describe('collectProtoStyleTokens', () => {
     expect(tokens).not.toContain('data-[is-hot]:bg-accent');
   });
 
+  it('registers an exposure however it is written', async () => {
+    // Each of these reaches the same runtime exposure, so each must lower.
+    const shapes: Record<string, string[]> = {
+      wrapped: ["    def.expose.state('visible', flag as never);"],
+      elementAccess: ["    def.expose['state']('visible', flag);"],
+      aliased: ['    const publicFlag = flag;', "    def.expose.state('visible', publicFlag);"],
+      nested: ['    if (enabled) {', "      def.expose.state('visible', flag);", '    }'],
+      constantName: [],
+    };
+
+    for (const [label, exposeLines] of Object.entries(shapes)) {
+      const declaration =
+        label === 'constantName'
+          ? [
+              "    const name = 'internalFlag';",
+              '    const flag = def.state.bool(name, false);',
+              "    def.expose.state('visible', flag);",
+            ]
+          : ["    const flag = def.state.bool('internalFlag', false);", ...exposeLines];
+      await writeFile(
+        path.join(dir, 'widget.proto.ts'),
+        [
+          "import { definePrototype, tw } from '@proto.ui/core';",
+          '',
+          'const widget = definePrototype({',
+          "  name: 'widget',",
+          '  setup(def) {',
+          ...declaration,
+          '    def.rule({',
+          '      when: (w) => w.state(flag).eq(true),',
+          "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+          '    });',
+          '  },',
+          '});',
+          '',
+          'export default widget;',
+        ].join('\n')
+      );
+
+      expect(await collectProtoStyleTokens(dir), label).toContain('data-[internal-flag]:bg-accent');
+    }
+  });
+
+  it('keeps every binding a legal redeclaration installs', async () => {
+    // The exposure pre-pass must not flatten sequential declaration scope.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    var T = 'bg-red';",
+        '    def.feedback.style.use(tw(T));',
+        "    var T = 'bg-blue';",
+        '    def.feedback.style.use(tw(T));',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('bg-red');
+    expect(tokens).toContain('bg-blue');
+  });
+
   it('lowers the Scroll Area Viewport focus condition into the closure', async () => {
     await writeFile(
       path.join(dir, 'surface.proto.ts'),

--- a/packages/modules/expose-state-web/src/utils.ts
+++ b/packages/modules/expose-state-web/src/utils.ts
@@ -1,30 +1,26 @@
+/**
+ * Semantics the Web projection names directly instead of normalizing. Exported
+ * so a static analyzer can reproduce the same attribute without depending on
+ * this module at runtime; `packages/cli/test/prototype-style-tokens.test.ts`
+ * asserts the two stay identical.
+ */
+export const OFFICIAL_EXPOSED_STATE_NAMES: Readonly<Record<string, string>> = Object.freeze({
+  '@interaction/disabled': 'disabled',
+  '@interaction/hovered': 'hovered',
+  '@interaction/pressed': 'pressed',
+  '@interaction/focused': 'focused',
+  '@focus/focused': 'focused',
+  '@interaction/focusVisible': 'focus-visible',
+  '@focus/focusVisible': 'focus-visible',
+  '@accessibility/expanded': 'expanded',
+  '@accessibility/invalid': 'invalid',
+  '@accessibility/selected': 'selected',
+  '@accessibility/checked': 'checked',
+  '@accessibility/current': 'current',
+});
+
 function mapOfficialSemanticName(semantic: string): string | null {
-  switch (semantic) {
-    case '@interaction/disabled':
-      return 'disabled';
-    case '@interaction/hovered':
-      return 'hovered';
-    case '@interaction/pressed':
-      return 'pressed';
-    case '@interaction/focused':
-    case '@focus/focused':
-      return 'focused';
-    case '@interaction/focusVisible':
-    case '@focus/focusVisible':
-      return 'focus-visible';
-    case '@accessibility/expanded':
-      return 'expanded';
-    case '@accessibility/invalid':
-      return 'invalid';
-    case '@accessibility/selected':
-      return 'selected';
-    case '@accessibility/checked':
-      return 'checked';
-    case '@accessibility/current':
-      return 'current';
-    default:
-      return null;
-  }
+  return OFFICIAL_EXPOSED_STATE_NAMES[semantic] ?? null;
 }
 
 export function createExposeStateWebNameMap(semantic: string) {

--- a/packages/modules/expose-state-web/src/utils.ts
+++ b/packages/modules/expose-state-web/src/utils.ts
@@ -20,7 +20,11 @@ export const OFFICIAL_EXPOSED_STATE_NAMES: Readonly<Record<string, string>> = Ob
 });
 
 function mapOfficialSemanticName(semantic: string): string | null {
-  return OFFICIAL_EXPOSED_STATE_NAMES[semantic] ?? null;
+  // The table inherits `Object.prototype`, so a semantic spelled `constructor`
+  // or `toString` would otherwise resolve to the inherited function.
+  return Object.hasOwn(OFFICIAL_EXPOSED_STATE_NAMES, semantic)
+    ? OFFICIAL_EXPOSED_STATE_NAMES[semantic]
+    : null;
 }
 
 export function createExposeStateWebNameMap(semantic: string) {


### PR DESCRIPTION
Fixes #600 under the bounded authorization there. Follows the five recommended steps; adds no Host Capability and no spec semantic.

## The fix

`def.expose.state(name, handle)` is what gives a prototype-owned state a host attribute, so it is also what tells the extractor the selector. `registerExposedState` runs on the statements of each scope in both walks — the expose call precedes the rule in every current prototype — and gives an otherwise semantic-less handle `data-[<key>]`.

**Precedence matches the runtime, not the key.** `createExposeStateWebNameMap` maps an official semantic first and only falls back to the exposed key, so a handle that already carries one keeps it. A `def.state.fromInteraction('hovered')` exposed as `isHot` still lowers to `hover:` and never `data-[is-hot]:`.

**Normalization matches too.** The runtime kebab-cases an unannotated key, so `dragOver` becomes `data-drag-over`, and the extractor now applies the same transform rather than the raw key.

## Evidence

Base-only closure, before and after:

```
collectProtoStyleTokens('packages/prototypes/base')
  before:  size 14, bare `hidden` true, `data-[hidden]:hidden` false
  after:   size 15, bare `hidden` true, `data-[hidden]:hidden` true
```

The bare token stays, as the issue directed — nothing here justifies removing that over-approximation.

**Both preset manifests are byte-identical**: `check:styles:preset` reports 246 and 234 tokens, unchanged. That is the outcome the ruling anticipated, because the shadcn and Brutalist Tabs Content each already contribute `data-[hidden]:hidden` through `asTabsContent()`. The Base rule was masked by its projections rather than working, which is exactly why nothing was visibly broken.

Three extractor regressions: the Tabs-shaped bool fallback, the `dragOver` → `data-[drag-over]` normalization, and the precedence case. Mutation-checked by removing the registration again:

```
AssertionError: expected [ 'hidden' ] to include 'data-[hidden]:hidden'
```

## The gate side

Step 3 of the ruling. `scanRuleStateReads` no longer blanket-skips a prototype-owned state. An **exposed** one is reported in a new `exposedLocals` result rather than pretended to be an `asHook` pair; an unexposed one is still skipped, because neither analyzer lowers it.

The repository-wide gate now asserts that every exposed state a rule reads carries a key that can become a data attribute, and that the set is non-empty — so this path cannot quietly stop finding anything. It currently finds the Tabs Content case.

`packages` 1531 passed, `check:types` and `check:styles:preset` clean.
