### PR TITLE
test(docs): assert the Tooltip Group through the runtime host

### DIFF
--- a/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
@@ -753,15 +753,16 @@ describe.sequential('Brutalist control documentation browser regressions', () =>
     };
 
     try {
-      expect(
-        await previewer
-          .locator('select.adapter-select option')
-          .evaluateAll((options) => options.map((option) => (option as HTMLOptionElement).value))
-      ).toEqual([...RUNTIMES]);
+      // Choosing each declared runtime is the evidence: `selectRuntime` waits
+      // for `[data-adapter-select-root].dataset.value` to equal it before the
+      // host is accepted. Reading an option inventory would retest the
+      // previewer's own Select, whose items exist only while it is open.
       for (const runtime of RUNTIMES) {
         await applyColorScheme(page, 'light');
         await selectRuntime(page, previewer, runtime, '[data-pui-root]', 7);
-        const roots = previewer.locator('[data-pui-root]');
+        // Scoped to the rendered host: the previewer chrome is Proto UI too, so
+        // a previewer-wide count is not evidence about this demo.
+        const roots = previewer.locator('.host [data-pui-root]');
         expect(await roots.count(), runtime).toBe(7);
         expect(await roots.nth(0).getAttribute('data-pui-root'), runtime).toBe('');
         const firstTrigger = roots.filter({ hasText: 'Hover or focus for details' }).last();

--- a/scripts/test/run-runtime-tests.mjs
+++ b/scripts/test/run-runtime-tests.mjs
@@ -24,6 +24,7 @@ const READY_ROUTES = [
   '/en/ui-libraries/brutalist/components/button/',
   '/en/ui-libraries/brutalist/components/switch/',
   '/en/ui-libraries/brutalist/components/tabs/',
+  '/en/ui-libraries/brutalist/components/tooltip/',
   '/en/ui-libraries/brutalist/components/select/',
   '/en/ui-libraries/shadcn/checkbox/',
   '/en/ui-libraries/shadcn/dropdown-menu/',


### PR DESCRIPTION
Fixes #603 under the bounded repair decided there. Test and harness only — no Tooltip, Previewer, Adapter, spec, or runtime change.

## The three changes

**1. Removed the option-inventory assertion.** The case opened with

```ts
await previewer.locator('select.adapter-select option').evaluateAll(…)
```

There is no native `<select>` in the previewer: the adapter selector is `wc-shadcn-select-root[data-adapter-select-root]`, `.adapter-select` is a class on its `wc-shadcn-select-trigger`, and the items live in a popover that only exists while it is open. So the expression matched nothing, returned `[]`, and the case aborted before exercising a single runtime.

Per the decision I did not teach it to open the selector. Choosing each runtime is the stronger evidence and the loop already does it — `selectRuntime` waits for `[data-adapter-select-root].dataset.value` to equal the runtime before accepting the host, so a runtime that cannot be chosen fails there rather than in an inventory read.

**2. Scoped the demo-root count to the host.** `previewer.locator('[data-pui-root]')` spans the previewer chrome, which is itself Proto UI, so the count included selector roots. It is now `.host [data-pui-root]`, matching what `selectRuntime` counts, and the same locator carries the trigger lookups below it. The `7` expectation holds under that scope — verified now that the first assertion no longer aborts.

**3. Added the tooltip route to `READY_ROUTES`.** `run-runtime-tests.mjs` warms every route the browser suites wait on, and this one was missing since #502.

## Evidence

The case passes across Web Components, React, and Vue, and the whole Brutalist browser suite is green:

```
✓ composes the transparent Tooltip Group across Web Components, React, and Vue  5310ms
  Tests  10 passed (10)
```

`check:types` clean. Found while diagnosing a red `test` job on #601, which this failure was blocking along with every other open PR.
