### PR TITLE
test(brutalist): measure Dialog overlay geometry in a real browser (#539)

### DIFF
--- a/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts
@@ -381,6 +381,23 @@ async function setFittingContent(page: Page, rows: number): Promise<void> {
  * with or without the focus slice, so a missing tab stop fails on the assertion
  * that names it instead of on a readiness timeout that does not.
  */
+/**
+ * A wheel notch is delivered asynchronously and the scroll may be smoothed, so
+ * a fixed pause races the browser under load. Wait for the offset instead.
+ */
+async function waitForScrolled(page: Page, index: number): Promise<void> {
+  await page.waitForFunction(
+    ({ selector, index: at }) => {
+      const viewport = document.querySelectorAll<HTMLElement>(`[data-previewer-id] ${selector}`)[
+        at
+      ];
+      return Boolean(viewport && viewport.scrollTop > 0);
+    },
+    { selector: VIEWPORT_SELECTOR, index },
+    { timeout: 10_000 }
+  );
+}
+
 async function waitForCanScroll(page: Page, index: number, expected: boolean): Promise<void> {
   await page.waitForFunction(
     ({ selector, index: at, expected: want }) => {
@@ -606,7 +623,7 @@ describe.sequential('Base control documentation browser regressions', () => {
 
         await viewport.hover();
         await page.mouse.wheel(0, 120);
-        await page.waitForTimeout(200);
+        await waitForScrolled(page, SCROLLING);
         expect(
           (await viewportFacts(page))[SCROLLING].scrollTop,
           `${runtime}/wheel`

--- a/apps/www/src/content/docs/zh-cn/demo-brutalist-dialog.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-brutalist-dialog.browser.test.ts
@@ -1,0 +1,219 @@
+// @vitest-environment node
+
+import type { Browser, Page } from 'playwright-core';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  RUNTIMES,
+  launchBrowser,
+  openRoute,
+  selectRuntime,
+  startServer,
+  stopServer,
+} from './browser-harness';
+
+const DIALOG_ROUTE = '/en/ui-libraries/brutalist/components/dialog/';
+
+const VIEWPORT = { width: 1280, height: 900 } as const;
+
+/** A second viewport, so a panel centred once cannot pass by standing still. */
+const RESIZED_VIEWPORT = { width: 900, height: 640 } as const;
+
+/** Half a device pixel: a centred panel may land on a subpixel boundary. */
+const GEOMETRY_EPSILON = 0.5;
+
+/** `BRUTALIST_PANEL_TOKENS` carries `shadow-[3px_3px_0_0_#000]`. */
+const HARD_PANEL_SHADOW = 'rgb(0, 0, 0) 3px 3px 0px 0px';
+
+/** The mask and the content, both portalled out of the demo host. */
+const PRESENT_ROOT_COUNT = 2;
+
+type OverlayGeometry = {
+  viewport: { width: number; height: number };
+  mask: {
+    rect: { x: number; y: number; width: number; height: number };
+    backdropFilter: string;
+    boxShadow: string;
+    borderTopWidth: string;
+    zIndex: number;
+  };
+  content: {
+    rect: { x: number; y: number; width: number; height: number };
+    boxShadow: string;
+    borderRadius: string;
+    zIndex: number;
+  };
+  presentRoots: number;
+  centreHitInsideContent: boolean;
+};
+
+let browser: Browser;
+let baseUrl = '';
+
+/**
+ * The mask and the content are the only prototype roots the open Dialog holds
+ * present in the document body, and the content carries the dialog role.
+ *
+ * Presence rather than membership: Vue 2 keeps a closed Dialog's portalled
+ * nodes in the body and they outlive the app that mounted them, so a body
+ * child count reads a previous runtime's residue as this runtime's overlay.
+ */
+async function readOverlayGeometry(page: Page): Promise<OverlayGeometry> {
+  return page.evaluate(() => {
+    const roots = Array.from(document.body.children).filter(
+      (element) => element.hasAttribute('data-pui-root') && element.hasAttribute('data-is-present')
+    );
+    const content = roots.find((element) => element.getAttribute('role') === 'dialog');
+    const mask = roots.find((element) => element !== content);
+    if (!content || !mask) throw new Error('The open Dialog portalled no mask/content pair.');
+
+    const measure = (element: Element) => {
+      const rect = element.getBoundingClientRect();
+      return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+    };
+    const maskStyle = getComputedStyle(mask);
+    const contentStyle = getComputedStyle(content);
+    const contentRect = measure(content);
+    const hit = document.elementFromPoint(
+      contentRect.x + contentRect.width / 2,
+      contentRect.y + contentRect.height / 2
+    );
+
+    return {
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+      mask: {
+        rect: measure(mask),
+        backdropFilter: maskStyle.backdropFilter,
+        boxShadow: maskStyle.boxShadow,
+        borderTopWidth: maskStyle.borderTopWidth,
+        zIndex: Number(maskStyle.zIndex),
+      },
+      content: {
+        rect: contentRect,
+        boxShadow: contentStyle.boxShadow,
+        borderRadius: contentStyle.borderRadius,
+        zIndex: Number(contentStyle.zIndex),
+      },
+      presentRoots: roots.length,
+      centreHitInsideContent: Boolean(hit && content.contains(hit)),
+    };
+  });
+}
+
+function expectNear(actual: number, expected: number, label: string): void {
+  expect(Math.abs(actual - expected), label).toBeLessThanOrEqual(GEOMETRY_EPSILON);
+}
+
+/** The panel is centred by transform, so the centres are what must agree. */
+function expectCentred(geometry: OverlayGeometry, label: string): void {
+  const { rect } = geometry.content;
+  expectNear(rect.x + rect.width / 2, geometry.viewport.width / 2, `${label}/centre-x`);
+  expectNear(rect.y + rect.height / 2, geometry.viewport.height / 2, `${label}/centre-y`);
+}
+
+async function openDialog(page: Page): Promise<void> {
+  const trigger = page.locator('[data-previewer-id] [aria-haspopup="dialog"]').first();
+  const contentId = await trigger.getAttribute('aria-controls');
+  expect(contentId, 'trigger names its content').toBeTruthy();
+  await trigger.click();
+  // The panel animates in; a measurement taken mid-transition reads the
+  // zoom-in-95 scale rather than the resting geometry the criterion states.
+  await page.waitForFunction(
+    (id) => {
+      const content = id ? document.getElementById(id) : null;
+      return Boolean(content && content.dataset.transitionState === 'entered');
+    },
+    contentId,
+    { timeout: 20_000 }
+  );
+}
+
+async function closeDialog(page: Page): Promise<void> {
+  await page
+    .locator(
+      'body > [data-pui-root][role="dialog"][data-is-present] [data-pui-a11y-actions="activate"]'
+    )
+    .first()
+    .click();
+  await page.waitForFunction(
+    () => document.querySelectorAll('body > [data-pui-root][data-is-present]').length === 0,
+    undefined,
+    { timeout: 20_000 }
+  );
+}
+
+describe('Brutalist Dialog overlay geometry', () => {
+  beforeAll(async () => {
+    baseUrl = await startServer(DIALOG_ROUTE);
+    browser = await launchBrowser();
+  }, 240_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    await stopServer();
+  });
+
+  it('covers the viewport and centres the hard-shadowed panel in all runtimes', async () => {
+    const { context, page, previewer } = await openRoute(browser, baseUrl, DIALOG_ROUTE, VIEWPORT);
+
+    try {
+      for (const runtime of RUNTIMES) {
+        await selectRuntime(page, previewer, runtime, '[aria-haspopup="dialog"]', 1);
+        await page.setViewportSize({ ...VIEWPORT });
+        await openDialog(page);
+
+        const geometry = await readOverlayGeometry(page);
+        // The module test reads the token string. Everything below is what the
+        // token string is supposed to produce, and happy-dom lays out nothing.
+        expect(geometry.presentRoots, `${runtime}/present-roots`).toBe(PRESENT_ROOT_COUNT);
+
+        // P-BRUTALIST-DIALOG-MASK-VISUAL-GRAMMAR: a flat scrim over the viewport.
+        expectNear(geometry.mask.rect.x, 0, `${runtime}/mask-x`);
+        expectNear(geometry.mask.rect.y, 0, `${runtime}/mask-y`);
+        expectNear(geometry.mask.rect.width, geometry.viewport.width, `${runtime}/mask-width`);
+        expectNear(geometry.mask.rect.height, geometry.viewport.height, `${runtime}/mask-height`);
+        // "No blur" as the browser resolves it, rather than as an absent token.
+        expect(geometry.mask.backdropFilter, `${runtime}/mask-no-blur`).toBe('none');
+        expect(geometry.mask.boxShadow, `${runtime}/mask-flat`).toBe('none');
+        expect(geometry.mask.borderTopWidth, `${runtime}/mask-borderless`).toBe('0px');
+
+        // P-BRUTALIST-DIALOG-CONTENT-VISUAL-GRAMMAR: centred square hard-shadowed panel.
+        expectCentred(geometry, `${runtime}/initial`);
+        // Square corners as rendered. A radius the closure never generated also
+        // resolves to `0px`, so this states the result rather than separating a
+        // conforming `rounded-none` from a token that failed to reach the CSS.
+        expect(geometry.content.borderRadius, `${runtime}/square`).toBe('0px');
+        // The arbitrary-value shadow has to survive the token closure to render
+        // at all; Tailwind composes it after two empty ring layers.
+        expect(geometry.content.boxShadow, `${runtime}/hard-shadow`).toContain(HARD_PANEL_SHADOW);
+
+        // The panel is the surface a reader interacts with, so it has to be the
+        // one under the pointer at its own centre, not the scrim above it.
+        expect(geometry.content.zIndex, `${runtime}/stacking`).toBeGreaterThan(
+          geometry.mask.zIndex
+        );
+        expect(geometry.centreHitInsideContent, `${runtime}/centre-hit`).toBe(true);
+
+        // A panel positioned once at mount would still satisfy everything above.
+        await page.setViewportSize({ ...RESIZED_VIEWPORT });
+        const resized = await readOverlayGeometry(page);
+        expect(resized.viewport.width, `${runtime}/resized-viewport`).toBe(RESIZED_VIEWPORT.width);
+        expectCentred(resized, `${runtime}/resized`);
+        expectNear(
+          resized.mask.rect.width,
+          RESIZED_VIEWPORT.width,
+          `${runtime}/resized-mask-width`
+        );
+        expectNear(
+          resized.mask.rect.height,
+          RESIZED_VIEWPORT.height,
+          `${runtime}/resized-mask-height`
+        );
+
+        // Leave the document as the next runtime expects to find it.
+        await closeDialog(page);
+      }
+    } finally {
+      await context.close();
+    }
+  }, 300_000);
+});

--- a/scripts/test/run-runtime-tests.mjs
+++ b/scripts/test/run-runtime-tests.mjs
@@ -25,6 +25,7 @@ const READY_ROUTES = [
   '/en/ui-libraries/brutalist/components/switch/',
   '/en/ui-libraries/brutalist/components/tabs/',
   '/en/ui-libraries/brutalist/components/tooltip/',
+  '/en/ui-libraries/brutalist/components/dialog/',
   '/en/ui-libraries/brutalist/components/select/',
   '/en/ui-libraries/shadcn/checkbox/',
   '/en/ui-libraries/shadcn/dropdown-menu/',

--- a/scripts/test/runtime-test-plan.mjs
+++ b/scripts/test/runtime-test-plan.mjs
@@ -1,6 +1,7 @@
 export const BROWSER_SUITES = Object.freeze([
   'apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts',
   'apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts',
+  'apps/www/src/content/docs/zh-cn/demo-brutalist-dialog.browser.test.ts',
   'apps/www/src/content/docs/zh-cn/demo-composed-style-isolation.browser.test.ts',
   'apps/www/src/content/docs/zh-cn/demo-ring-offset-default.browser.test.ts',
   'apps/www/src/content/docs/zh-cn/demo-shadcn-controls.browser.test.ts',

--- a/spec/tests/T-BRUTALIST-DIALOG-0001.yaml
+++ b/spec/tests/T-BRUTALIST-DIALOG-0001.yaml
@@ -87,6 +87,12 @@ cases:
       - P-BRUTALIST-DIALOG-FOOTER-ANATOMY
       - P-BRUTALIST-DIALOG-FOOTER-VISUAL-GRAMMAR
     expectation: p-brutalist-dialog-footer-anatomy
+  - id: T-BRUTALIST-DIALOG-0001-CASE-OVERLAY-GEOMETRY-BROWSER
+    title: The mask covers the viewport and the hard-shadowed panel stays centred in a real browser, in every runtime
+    covers:
+      - P-BRUTALIST-DIALOG-MASK-VISUAL-GRAMMAR
+      - P-BRUTALIST-DIALOG-CONTENT-VISUAL-GRAMMAR
+    expectation: p-brutalist-dialog-overlay-geometry-browser
 implementations:
   - id: prototypes-brutalist-dialog-contract
     kind: module-test
@@ -122,6 +128,28 @@ implementations:
       - P-BRUTALIST-DIALOG-MASK
       - P-BRUTALIST-DIALOG-TITLE
       - P-BRUTALIST-DIALOG-TRIGGER
+  - id: www-brutalist-dialog-overlay-geometry-browser
+    kind: runtime-test
+    status: passing
+    path: apps/www/src/content/docs/zh-cn/demo-brutalist-dialog.browser.test.ts
+    required: true
+    consumesCases:
+      - T-BRUTALIST-DIALOG-0001-CASE-OVERLAY-GEOMETRY-BROWSER
+    exercises:
+      - P-BASE-DIALOG
+      - P-BASE-DIALOG-CONTENT
+      - P-BASE-DIALOG-MASK
+      - P-BASE-DIALOG-TRIGGER
+      - P-BRUTALIST-DIALOG
+      - P-BRUTALIST-DIALOG-CONTENT
+      - P-BRUTALIST-DIALOG-MASK
+      - P-BRUTALIST-DIALOG-TRIGGER
+    notes:
+      - The module test asserts the token strings these two criteria name. happy-dom lays nothing out, so "covers the viewport", "centred" and "above the mask" hold nowhere in the repository; this case reads them in Chromium, in Web Components, React, Vue and Vue 2.
+      - The panel is measured only once its transition reports `entered`, because a measurement taken during `zoom-in-95` reads the animating scale rather than the resting geometry the criterion states.
+      - The viewport is then changed and the panel re-measured, so a projection that positioned it once at mount cannot pass on the first measurement alone.
+      - The hard offset shadow is asserted as the browser composes it, which also states that the arbitrary-value token reached the generated CSS; removing it from `BRUTALIST_PANEL_TOKENS` fails this case.
+      - Overlays are selected by `data-is-present` rather than by body membership, because Vue 2 leaves a closed Dialog's portalled nodes in the body and they outlive the app that mounted them; a body-child count would read the previous runtime's residue as this runtime's overlay.
 verifies:
   prototypes:
     - id: P-BRUTALIST-DIALOG


### PR DESCRIPTION
Closes the last #539 slice with no carrier. Badge / Card / Hover Card / Separator / Skeleton / Toggle stay on #571; this touches only Dialog.

## What was missing

`T-BRUTALIST-DIALOG-0001`'s ten cases are all consumed by one happy-dom module test that asserts token strings with `styleContains`. Two criteria say more than a token string can:

- `P-BRUTALIST-DIALOG-MASK-VISUAL-GRAMMAR` — a flat scrim over the viewport, no blur.
- `P-BRUTALIST-DIALOG-CONTENT-VISUAL-GRAMMAR` — a centred, square, hard-shadowed panel.

happy-dom lays nothing out, so "covers the viewport", "centred" and "above the mask" hold nowhere in the repository. The existing browser coverage for Dialog is `demo-matrix.browser.test.ts`, which exercises **Base** Dialog's `aria-haspopup`/`aria-controls` and focus, never the Brutalist projection and never any geometry.

## What this adds

One case, `T-BRUTALIST-DIALOG-0001-CASE-OVERLAY-GEOMETRY-BROWSER`, in a new suite on the existing `/en/ui-libraries/brutalist/components/dialog/` route and the existing `demo-brutalist-dialog.demo.ts` carrier — no new demo. It runs in Web Components, React, Vue and Vue 2, and per runtime asserts the mask rect equals the viewport, the panel centre equals the viewport centre, the panel outranks the mask and is the element under its own centre, `backdrop-filter` resolves to `none`, and the composed `box-shadow` carries `rgb(0, 0, 0) 3px 3px 0px 0px`. It then changes the viewport and re-measures, so a projection that positioned the panel once at mount cannot pass on the first measurement.

Each of those was checked against a mutation of the **source**, not of the test:

| mutation | fails on |
| --- | --- |
| drop `-translate-x-1/2 -translate-y-1/2` from Content | `wc/initial/centre-x` |
| drop `inset-0` from Mask | `wc/mask-y` |
| add `backdrop-blur-sm` to Mask | `wc/mask-no-blur` |
| `shadow-[3px_3px_0_0_#000]` → `shadow-none` in `BRUTALIST_PANEL_TOKENS` | `wc/hard-shadow` |

The square-corner assertion is deliberately not in that table: a radius the token closure never generated also computes to `0px`, so it states the rendered result without separating those two causes. The comment says so.

## One thing found on the way

Overlays are selected by `data-is-present`, not by body membership, because **Vue 2 leaves a closed Dialog's portalled mask and content in `document.body`, and they outlive the app that mounted them** — they are still there after switching the previewer to another runtime. Web Components, React and Vue 3 all remove them on close. The residue is inert (`display: none`, `visibility: hidden`, `0×0`), so nothing renders wrong, but a body-child count reads a previous runtime's leftovers as the current runtime's overlay. Filed as #606; I did not touch the adapter here, since where a non-present overlay parks is a teardown decision rather than something this test should settle.

## Checks

`packages/spec` 44 passed — including `catalog-evidence-integrity`, which caught the new file before it was tracked. `check:types` clean, `check:prototype-catalog` OK. The suite passes all four runtimes in ~6s.
