### PR TITLE
fix(vue2): return a portalled overlay host when the mount unwinds (#606)

### DIFF
--- a/packages/adapters/vue2/src/runtime/modules.ts
+++ b/packages/adapters/vue2/src/runtime/modules.ts
@@ -124,8 +124,18 @@ export function createVue2OverlayGlobalMount(
       anchors.set(hostEl, anchor);
     },
     unmount(hostEl: HTMLElement) {
-      anchors.get(hostEl)?.remove();
+      const anchor = anchors.get(hostEl);
       anchors.delete(hostEl);
+      // Only a host this mount moved is ours to put back. Returning it to the
+      // anchor hands it to the position Vue owns, so ordinary teardown removes
+      // it; if the anchor's parent is gone there is nowhere to return it to and
+      // detaching is the only way not to leave an adapter-owned body node.
+      if (anchor) {
+        const parent = anchor.parentNode;
+        if (parent) parent.insertBefore(hostEl, anchor);
+        else hostEl.remove();
+        anchor.remove();
+      }
       // The retained Proto instance stays in its logical tree while its Vue2
       // view epoch is torn down and will receive a fresh projection on remount.
       clearProtoParentProjection(hostEl);

--- a/packages/adapters/vue2/test/overlay-portal-ownership.test.ts
+++ b/packages/adapters/vue2/test/overlay-portal-ownership.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { definePrototype } from '@proto.ui/core';
+import {
+  dialogContent,
+  dialogMask,
+  dialogRoot,
+  dialogTrigger,
+} from '../../../prototypes/base/src/dialog';
 
+import { createVue2Adapter } from '../src/adapt';
 import { createVue2OverlayGlobalMount } from '../src/runtime/modules';
 import {
   bindLogicalParent,
@@ -8,6 +15,24 @@ import {
   getProtoParent,
   markProtoInstance,
 } from '../src/platform/instance-tree';
+import { flushVue2, Vue2Any, Vue2RuntimeAny } from './utils/vue2';
+
+/** The comment `createVue2OverlayGlobalMount` leaves where the host stood. */
+const PORTAL_ANCHOR = 'pui-vue2-portal';
+
+function portalAnchors(root: Node): Comment[] {
+  const found: Comment[] = [];
+  const walk = (node: Node): void => {
+    for (const child of Array.from(node.childNodes)) {
+      if (child.nodeType === Node.COMMENT_NODE && child.textContent === PORTAL_ANCHOR) {
+        found.push(child as Comment);
+      }
+      walk(child);
+    }
+  };
+  walk(root);
+  return found;
+}
 
 describe('adapter-vue2: overlay portal ownership', () => {
   it('moves the Vue2 overlay host to body while retaining its logical parent projection', () => {
@@ -25,8 +50,10 @@ describe('adapter-vue2: overlay portal ownership', () => {
 
     const parentRoot = document.createElement('div');
     const vueContainer = document.createElement('div');
+    const before = document.createElement('span');
     const childRoot = document.createElement('div');
-    vueContainer.appendChild(childRoot);
+    const after = document.createElement('span');
+    vueContainer.append(before, childRoot, after);
     document.body.append(parentRoot, vueContainer);
     markProtoInstance(parentRoot, parentProto as any, parentToken);
     markProtoInstance(childRoot, childProto as any, childToken);
@@ -38,15 +65,113 @@ describe('adapter-vue2: overlay portal ownership', () => {
 
       expect(childRoot.parentNode).toBe(document.body);
       expect(getProtoParent(childRoot)).toBe(parentRoot);
-      expect(vueContainer.childNodes).toHaveLength(1);
+      expect(portalAnchors(vueContainer)).toHaveLength(1);
 
       globalMount.unmount(childRoot);
 
-      expect(vueContainer.childNodes).toHaveLength(0);
+      // Returned to the position Vue owns, so ordinary teardown removes it —
+      // and returned between the same siblings, not appended at the end.
+      expect(childRoot.parentNode).toBe(vueContainer);
+      expect(Array.from(vueContainer.childNodes)).toEqual([before, childRoot, after]);
+      expect(portalAnchors(vueContainer)).toHaveLength(0);
+      expect(Array.from(document.body.childNodes)).not.toContain(childRoot);
+
+      // Unmounting again owns nothing and must not move or remove anything.
+      globalMount.unmount(childRoot);
+      expect(Array.from(vueContainer.childNodes)).toEqual([before, childRoot, after]);
     } finally {
       childRoot.remove();
       parentRoot.remove();
       vueContainer.remove();
+    }
+  });
+
+  it('detaches the portalled host when its anchor has no parent left', () => {
+    const childProto = definePrototype({
+      name: 'vue2-overlay-orphan-child',
+      setup: () => (r) => r.el('div'),
+    });
+    const childToken = createLogicalInstance(childProto as any);
+
+    const vueContainer = document.createElement('div');
+    const childRoot = document.createElement('div');
+    vueContainer.appendChild(childRoot);
+    document.body.appendChild(vueContainer);
+    markProtoInstance(childRoot, childProto as any, childToken);
+
+    const globalMount = createVue2OverlayGlobalMount(childToken);
+
+    try {
+      globalMount.mount(childRoot);
+      expect(childRoot.parentNode).toBe(document.body);
+
+      // The position the host came from is gone, so there is nowhere to put it
+      // back; leaving it in the body would be the leak this guards.
+      vueContainer.remove();
+      globalMount.unmount(childRoot);
+
+      expect(childRoot.isConnected).toBe(false);
+      expect(portalAnchors(document.body)).toHaveLength(0);
+    } finally {
+      childRoot.remove();
+      vueContainer.remove();
+    }
+  });
+
+  it('leaves no portalled node behind when the Vue2 app is destroyed', async () => {
+    const adapt = createVue2Adapter(Vue2RuntimeAny);
+    const Root = adapt(dialogRoot);
+    const Trigger = adapt(dialogTrigger);
+    const Mask = adapt(dialogMask);
+    const Content = adapt(dialogContent, { rootTag: 'section' });
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const App = Vue2Any.extend({
+      render(h: any) {
+        return h(Root, { attrs: { defaultOpen: false }, ref: 'root' }, [
+          h(Trigger, { ref: 'trigger' }, ['Open dialog']),
+          h(Mask, { ref: 'mask' }),
+          h(Content, { ref: 'content' }, [h('p', ['Dialog body'])]),
+        ]);
+      },
+    });
+    const vm = new App().$mount();
+    host.appendChild(vm.$el);
+
+    try {
+      await flushVue2();
+      await flushVue2();
+      const refs = vm.$refs as Record<string, any>;
+      refs.trigger?.$el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushVue2();
+      await flushVue2();
+
+      // The overlay is portalled out of the app's own subtree.
+      // `:scope >` is not supported by the test DOM, so the children are
+      // filtered rather than selected.
+      const portalled = Array.from(document.body.children).filter(
+        (element): element is HTMLElement =>
+          element instanceof HTMLElement && element.hasAttribute('data-pui-root')
+      );
+      expect(portalled.length).toBeGreaterThan(0);
+      expect(portalled.every((element) => !host.contains(element))).toBe(true);
+
+      vm.$destroy();
+      host.remove();
+      await flushVue2();
+
+      // Destroying the app has to reclaim what the adapter portalled out of it.
+      // A close-only assertion would not prove this: nothing here closes the
+      // dialog first, and where a merely closed overlay parks is a separate
+      // question this does not decide.
+      for (const element of portalled) {
+        expect(element.isConnected, element.tagName.toLowerCase()).toBe(false);
+      }
+      expect(portalAnchors(document.body)).toHaveLength(0);
+    } finally {
+      vm.$destroy();
+      host.remove();
     }
   });
 });


### PR DESCRIPTION
Closes #606, within the bounds you set: Vue 2 adapter only, no change to Dialog/Presence semantics, the Overlay contract, or where a merely closed overlay parks.

## The repair

`createVue2OverlayGlobalMount().unmount()` removed the anchor and cleared the logical projection but never moved the host back, so the body-owned node had no owner left to remove it. It now takes the reversible route you preferred: while the anchor still has a parent, the host is inserted back **before the anchor** — its original position, not merely its original container — and only then is the anchor removed, so Vue's ordinary teardown removes the restored node. If the anchor's parent is gone there is nowhere to return it to, and the host is detached rather than left behind.

Only a host this mount actually moved is touched: `mount()` records an anchor only when it moves something, so the early-return cases (no parent, already in `body`) own nothing and `unmount()` leaves them alone. That also makes repeated unmounts inert.

## Evidence

You were right that the existing test masked the gap — it asserted the original container was empty, which the leak satisfied trivially, and then removed the host by hand. That assertion is now the opposite: the container holds the host again.

Three tests, all three of which fail against the old `unmount` and pass against the new one:

- **Anchor valid.** Mount moves the host to `body` and leaves one anchor; unmount returns it *between the same siblings* (`[before, childRoot, after]`), removes the anchor, and leaves nothing of it in `body`. A second unmount moves nothing.
- **Anchor orphaned.** The original container is removed while the host is portalled; unmount detaches the host rather than leaving an adapter-owned body node, and leaves no anchor.
- **App teardown.** A real adapted Dialog opens, both the Mask and the Content are asserted to be portalled out of the app's subtree, then `vm.$destroy()`; every node that was portalled is asserted disconnected and no portal anchor remains. Nothing closes the dialog first, deliberately — a close-only assertion would not prove teardown reclaimed the DOM, and this does not decide where a non-present overlay parks.

`:scope > …` is not supported by the test DOM, so the body children are filtered rather than selected; the comment says so.

`packages` 1642 passed, `check:types` clean.
