### PR TITLE
fix(cli): keep the container a conditional replacement may not install (#609)

### DIFF
--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -91,6 +91,8 @@ type Binding =
       initializer: ts.Expression;
       /** Members written after the declaration, latest candidates first. */
       members?: Map<string, ts.Expression[]>;
+      /** Containers the name may still hold because a write may be skipped. */
+      alternates?: ts.Expression[];
     }
   /** A named import; only a relative one is something the extractor follows. */
   | { kind: 'tokenImport'; specifier: string; imported: string; from?: string }
@@ -394,6 +396,19 @@ export function scanRuleStateReads(
   type MemberEdge = { target: string; at: number; conditional: boolean };
   const objectMembers = new Map<ts.Node, Map<string, Map<string, MemberEdge[]>>>();
 
+  /**
+   * Every object literal an initializer may yield. A conditional selects one at
+   * runtime, so both are recorded for the same reason `aliasTargets` fans out.
+   */
+  const objectLiteralTargets = (node: ts.Node): ts.ObjectLiteralExpression[] => {
+    const value = unwrap(node);
+    if (ts.isObjectLiteralExpression(value)) return [value];
+    if (ts.isConditionalExpression(value)) {
+      return [...objectLiteralTargets(value.whenTrue), ...objectLiteralTargets(value.whenFalse)];
+    }
+    return [];
+  };
+
   /** Every member an object literal names, at the position it was written. */
   const recordObjectLiteral = (
     owner: ts.Node,
@@ -627,10 +642,16 @@ export function scanRuleStateReads(
       names.add(node.name.text);
       declaredIn.set(owner, names);
       if (node.initializer) {
-        const literal = unwrap(node.initializer);
         const conditional = isConditionallyReached(node);
-        if (ts.isObjectLiteralExpression(literal)) {
-          recordObjectLiteral(owner, node.name.text, literal, node.getStart(), conditional);
+        const literals = objectLiteralTargets(node.initializer);
+        for (const literal of literals) {
+          recordObjectLiteral(
+            owner,
+            node.name.text,
+            literal,
+            node.getStart(),
+            conditional || literals.length > 1
+          );
         }
         for (const target of aliasTargets(node.initializer)) {
           aliasEdges.push({
@@ -721,9 +742,17 @@ export function scanRuleStateReads(
         nextChain[0] ??
         source;
       const conditional = isConditionallyReached(node);
-      const replacement = unwrap(node.right);
-      if (ts.isObjectLiteralExpression(replacement)) {
-        recordObjectLiteral(assignOwner, left, replacement, node.getStart(), conditional);
+      const replacements = objectLiteralTargets(node.right);
+      for (const replacement of replacements) {
+        recordObjectLiteral(
+          assignOwner,
+          left,
+          replacement,
+          node.getStart(),
+          // Either literal may be the one the runtime took, and the name may
+          // still hold the container it replaced.
+          conditional || replacements.length > 1
+        );
       }
       for (const target of aliasTargets(node.right)) {
         aliasEdges.push({
@@ -1163,7 +1192,11 @@ export function scanRuleStateReads(
         // A write through the container replaces what the declaration named.
         const written = binding.members?.get(key);
         if (written && written.length > 0) return written;
-        return containerMembers(binding.initializer, key, scope, new Set([...seen, value.text]));
+        const next = new Set([...seen, value.text]);
+        // A container that replaced another conditionally still answers for it.
+        return [binding.initializer, ...(binding.alternates ?? [])].flatMap((held) =>
+          containerMembers(held, key, scope, next)
+        );
       }
     }
     return [];
@@ -1807,7 +1840,21 @@ export function scanRuleStateReads(
     ) {
       const name = node.left.text;
       const owner = scopeBinding(current, name) ?? current;
+      const replaced = owner.bindings.get(name);
       declareConditionally(owner, name, node.left, current, node.right);
+      const next = owner.bindings.get(name);
+      const uncertain =
+        isConditionallyReached(node) || isDeferredWrite(node, enclosingFunction(owner.node));
+      if (uncertain && replaced?.kind === 'token' && next?.kind === 'token') {
+        declare(owner, name, {
+          ...next,
+          alternates: [
+            ...(next.alternates ?? []),
+            replaced.initializer,
+            ...(replaced.alternates ?? []),
+          ],
+        });
+      }
     }
 
     if (

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -996,12 +996,23 @@ export function scanRuleStateReads(
           declaredAs: binding.declaredAs,
           exposedAs: binding.exposedAs,
         });
+        // A branch may itself be a conditional, so its own alternatives are
+        // lifted here; `head.alternatives` would otherwise be overwritten by
+        // this key and `bare` would strip the rest's.
+        const seen = new Set([head.declaredAs]);
+        const alternatives: LocalStateBinding[] = [];
+        for (const candidate of [
+          ...(head.alternatives ?? []),
+          ...rest.flatMap((branch) => [bare(branch), ...(branch.alternatives ?? [])]),
+        ]) {
+          if (seen.has(candidate.declaredAs)) continue;
+          seen.add(candidate.declaredAs);
+          alternatives.push(bare(candidate));
+        }
         declare(scope, name.text, {
           ...head,
           exposedAs: exposureFor(name.text, scope) ?? head.exposedAs,
-          alternatives: rest
-            .map(bare)
-            .filter((candidate) => candidate.declaredAs !== head.declaredAs),
+          alternatives,
         });
         return;
       }

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -449,12 +449,14 @@ export function scanRuleStateReads(
       const visible = visibleEdges(candidates, at);
       if (visible.length === 0) return [name];
       const next = new Set([...seen, name]);
-      // A base that may be either of two objects writes to both tables.
-      return [
-        ...new Set(
-          visible.flatMap((edge) => containerRoots(edge.target, edge.chain ?? chain, edge.at, next))
-        ),
-      ];
+      // A base that may be either of two objects writes to both tables, and
+      // reads consult both; recording under the alias would reach neither. If
+      // every edge out of the name may not have been taken, the name's own
+      // table stays a candidate — a literal branch was recorded under it.
+      const roots = visible.flatMap((edge) =>
+        containerRoots(edge.target, edge.chain ?? chain, edge.at, next)
+      );
+      return [...new Set(visible.every((edge) => edge.conditional) ? [name, ...roots] : roots)];
     }
     return [name];
   };
@@ -743,6 +745,9 @@ export function scanRuleStateReads(
         source;
       const conditional = isConditionallyReached(node);
       const replacements = objectLiteralTargets(node.right);
+      // A conditional may mix a literal with a name; when it can yield more
+      // than one value neither outcome is certain.
+      const valueCount = replacements.length + aliasTargets(node.right).length;
       for (const replacement of replacements) {
         recordObjectLiteral(
           assignOwner,
@@ -751,7 +756,7 @@ export function scanRuleStateReads(
           node.getStart(),
           // Either literal may be the one the runtime took, and the name may
           // still hold the container it replaced.
-          conditional || replacements.length > 1
+          conditional || valueCount > 1
         );
       }
       for (const target of aliasTargets(node.right)) {
@@ -760,7 +765,7 @@ export function scanRuleStateReads(
           name: left,
           target,
           at: node.getStart(),
-          conditional,
+          conditional: conditional || valueCount > 1,
           chain: [...nextChain, source],
           node,
         });
@@ -1822,9 +1827,13 @@ export function scanRuleStateReads(
               : [member];
           const members = new Map(container.members ?? []);
           for (const key of keys) {
-            // Before the first write the member still lives in the declaration.
+            // Before the first write the member still lives in the declaration —
+            // or in a container this one replaced but may not have.
             const previous =
-              container.members?.get(key) ?? containerMembers(container.initializer, key, current);
+              container.members?.get(key) ??
+              [container.initializer, ...(container.alternates ?? [])].flatMap((held) =>
+                containerMembers(held, key, current)
+              );
             members.set(key, [node.right, ...(uncertain ? previous : [])]);
           }
           declare(target.scope, target.name, { ...container, members });
@@ -1846,8 +1855,16 @@ export function scanRuleStateReads(
       const uncertain =
         isConditionallyReached(node) || isDeferredWrite(node, enclosingFunction(owner.node));
       if (uncertain && replaced?.kind === 'token' && next?.kind === 'token') {
+        // Members written into the replaced container are candidates too; its
+        // initializer alone does not carry them.
+        const members = new Map(next.members ?? []);
+        for (const [key, held] of replaced.members ?? []) {
+          const kept = members.get(key) ?? containerMembers(next.initializer, key, current);
+          members.set(key, [...kept, ...held]);
+        }
         declare(owner, name, {
           ...next,
+          ...(members.size > 0 ? { members } : {}),
           alternates: [
             ...(next.alternates ?? []),
             replaced.initializer,

--- a/packages/cli/src/services/lowered-hook-coverage.ts
+++ b/packages/cli/src/services/lowered-hook-coverage.ts
@@ -93,6 +93,11 @@ type Binding =
       members?: Map<string, ts.Expression[]>;
       /** Containers the name may still hold because a write may be skipped. */
       alternates?: ts.Expression[];
+      /**
+       * Some branch of this container's value is not a form the scanner can
+       * resolve, so its member set is known to be incomplete.
+       */
+      opaque?: boolean;
     }
   /** A named import; only a relative one is something the extractor follows. */
   | { kind: 'tokenImport'; specifier: string; imported: string; from?: string }
@@ -264,6 +269,20 @@ function isDeferredWrite(node: ts.Node, readFunction: ts.Node | null): boolean {
   if (writing === readFunction) return false;
   if (!writing || !runsInPlace(writing)) return true;
   return !reachedInPlace(node, writing);
+}
+
+/** Every runtime branch of a conditional, whether or not this recognizes it. */
+function conditionalLeafCount(node: ts.Node): number {
+  const value =
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isNonNullExpression(node)
+      ? conditionalLeafCount(node.expression)
+      : null;
+  if (value !== null) return value;
+  if (!ts.isConditionalExpression(node)) return 1;
+  return conditionalLeafCount(node.whenTrue) + conditionalLeafCount(node.whenFalse);
 }
 
 /** `var` binds to the function however deeply the declaration is nested. */
@@ -747,7 +766,8 @@ export function scanRuleStateReads(
       const replacements = objectLiteralTargets(node.right);
       // A conditional may mix a literal with a name; when it can yield more
       // than one value neither outcome is certain.
-      const valueCount = replacements.length + aliasTargets(node.right).length;
+      // Every branch counts, not only the ones this recognizes.
+      const valueCount = conditionalLeafCount(node.right);
       for (const replacement of replacements) {
         recordObjectLiteral(
           assignOwner,
@@ -1076,7 +1096,16 @@ export function scanRuleStateReads(
     // the same scope chain means two blocks may each declare `TOKENS` without
     // either becoming ambiguous, which is what the extractor's scopes do.
     if (ts.isIdentifier(name)) {
-      declare(scope, name.text, { kind: 'token', initializer });
+      // A conditional whose branches are only partly recognized would otherwise
+      // read as if the recognized ones were all of them.
+      const recognized =
+        objectLiteralTargets(initializer).length + aliasTargets(initializer).length;
+      const partial = recognized > 0 && recognized < conditionalLeafCount(initializer);
+      declare(scope, name.text, {
+        kind: 'token',
+        initializer,
+        ...(partial ? { opaque: true } : {}),
+      });
     }
   };
 
@@ -1143,6 +1172,10 @@ export function scanRuleStateReads(
       }
       // `const controls = { ready: flag }` — production reads the container the
       // same way it reads an `asHook` bag, so this is not a blind spot.
+      // A container with an unresolvable branch is: certifying the members it
+      // does show would vouch for a set the runtime can step outside of.
+      const owner = ownerOf(argument);
+      if (owner && containerIsOpaque(owner, scope)) return null;
       const held = memberOfHandleObject(argument, scope);
       if (held.length === 0) return null;
       const reads = held.map((expression) => readState(expression, scope));
@@ -1252,6 +1285,25 @@ export function scanRuleStateReads(
       if (next.length > 0) return next;
     }
     return [{ scope: owner, name: value.text }];
+  };
+
+  /** Whether any container this base may name has an unresolvable branch. */
+  const containerIsOpaque = (node: ts.Node, scope: Scope, seen = new Set<string>()): boolean => {
+    const value = unwrap(node);
+    if (ts.isConditionalExpression(value)) {
+      return (
+        containerIsOpaque(value.whenTrue, scope, seen) ||
+        containerIsOpaque(value.whenFalse, scope, seen)
+      );
+    }
+    if (!ts.isIdentifier(value) || seen.has(value.text)) return false;
+    const binding = lookup(scope, value.text);
+    if (binding?.kind !== 'token') return false;
+    if (binding.opaque) return true;
+    const next = new Set([...seen, value.text]);
+    return [binding.initializer, ...(binding.alternates ?? [])].some((held) =>
+      containerIsOpaque(held, scope, next)
+    );
   };
 
   const memberOfHandleObject = (node: ts.Node, scope: Scope): ts.Expression[] => {

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -632,7 +632,11 @@ function resolveBinding(node, scope) {
     }
     // Neither branch is a handle, but the name may still be either object, so
     // it carries both and a member write through it reaches both tables.
-    const containers = branches.filter((branch) => branch.semanticMap);
+    // Flattened, because a branch may itself be a conditional: the candidates
+    // are the leaves the runtime can land on, not the composites above them.
+    const containers = branches.flatMap(
+      (branch) => branch.containers ?? (branch.semanticMap ? [branch] : [])
+    );
     if (containers.length > 0) return { ...branches[0], containers };
   }
 

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -963,12 +963,13 @@ function collectExposures(root) {
       if (visible.length === 0) return [name];
       const next = new Set([...seen, name]);
       // A base that may be either of two objects writes to both tables, and
-      // reads consult both; recording under the alias would reach neither.
-      return [
-        ...new Set(
-          visible.flatMap((edge) => containerRoots(edge.target, edge.chain ?? chain, edge.at, next))
-        ),
-      ];
+      // reads consult both; recording under the alias would reach neither. If
+      // every edge out of the name may not have been taken, the name's own
+      // table stays a candidate — a literal branch was recorded under it.
+      const roots = visible.flatMap((edge) =>
+        containerRoots(edge.target, edge.chain ?? chain, edge.at, next)
+      );
+      return [...new Set(visible.every((edge) => edge.conditional) ? [name, ...roots] : roots)];
     }
     return [name];
   };
@@ -1201,6 +1202,9 @@ function collectExposures(root) {
         root;
       const conditional = isConditionallyReached(node);
       const replacements = objectLiteralTargets(node.right);
+      // A conditional may mix a literal with a name; when it can yield more
+      // than one value neither outcome is certain.
+      const valueCount = replacements.length + aliasTargets(node.right).length;
       for (const replacement of replacements) {
         recordObjectLiteral(
           owner,
@@ -1209,7 +1213,7 @@ function collectExposures(root) {
           node.getStart(),
           // Either literal may be the one the runtime took, and the name may
           // still hold the container it replaced.
-          conditional || replacements.length > 1
+          conditional || valueCount > 1
         );
       }
       for (const target of aliasTargets(node.right)) {
@@ -1218,7 +1222,7 @@ function collectExposures(root) {
           name: node.left.text,
           target,
           at: node.getStart(),
-          conditional,
+          conditional: conditional || valueCount > 1,
           chain: [...nextChain, root],
           node,
         });

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -213,7 +213,11 @@ function readMemberSemantics(node, scope) {
   const owner = memberOwner(node);
   const name = memberName(node);
   if (!owner || name === null) return [];
-  return memberSemantics(resolveExpression(owner, scope).semanticMap?.get(name));
+  const resolved = resolveExpression(owner, scope);
+  // A name that may be either of two objects answers for both, and a container
+  // that replaced another conditionally still answers for what it replaced.
+  const values = resolved.containers ?? [resolved];
+  return [...new Set(values.flatMap((value) => memberSemantics(value.semanticMap?.get(name))))];
 }
 
 /**
@@ -348,12 +352,17 @@ function walk(node, scope, tokens, exposures) {
     const kept = bindingSemantics(previous).filter((candidate) => candidate !== binding.semantic);
     const uncertain =
       isConditionallyReached(node) || isDeferredWrite(node, enclosingFunction(owner.node));
-    owner.bindings.set(
-      name,
-      uncertain && kept.length > 0
-        ? { ...binding, alternatives: [...new Set([...(binding.alternatives ?? []), ...kept])] }
-        : binding
-    );
+    let next = binding;
+    if (uncertain && kept.length > 0) {
+      next = { ...next, alternatives: [...new Set([...(next.alternatives ?? []), ...kept])] };
+    }
+    // Replacing a container keeps its members too: on the branch the source may
+    // not take, the name still holds the object it held before.
+    if (uncertain && previous && (previous.semanticMap || previous.containers)) {
+      const held = [...(next.containers ?? [next]), ...(previous.containers ?? [previous])];
+      next = { ...next, containers: [...new Set(held)] };
+    }
+    owner.bindings.set(name, next);
     return;
   }
 
@@ -908,6 +917,19 @@ function collectExposures(root) {
   const objectMembers = new Map();
 
   /** Every member an object literal names, at the position it was written. */
+  /**
+   * Every object literal an initializer may yield. A conditional selects one at
+   * runtime, so both are recorded for the same reason `aliasTargets` fans out.
+   */
+  const objectLiteralTargets = (node) => {
+    const value = unwrapExpression(node);
+    if (ts.isObjectLiteralExpression(value)) return [value];
+    if (ts.isConditionalExpression(value)) {
+      return [...objectLiteralTargets(value.whenTrue), ...objectLiteralTargets(value.whenFalse)];
+    }
+    return [];
+  };
+
   const recordObjectLiteral = (owner, base, literal, at, conditional) => {
     for (const property of literal.properties) {
       if (ts.isShorthandPropertyAssignment(property)) {
@@ -1072,9 +1094,17 @@ function collectExposures(root) {
       if (node.initializer) {
         const literal = unwrapExpression(node.initializer);
         const conditional = isConditionallyReached(node);
-        if (ts.isObjectLiteralExpression(literal)) {
-          recordObjectLiteral(owner, node.name.text, literal, node.getStart(), conditional);
+        const literals = objectLiteralTargets(node.initializer);
+        for (const held of literals) {
+          recordObjectLiteral(
+            owner,
+            node.name.text,
+            held,
+            node.getStart(),
+            conditional || literals.length > 1
+          );
         }
+        void literal;
         for (const target of aliasTargets(node.initializer)) {
           aliasEdges.push({
             owner,
@@ -1166,9 +1196,17 @@ function collectExposures(root) {
         nextChain[0] ??
         root;
       const conditional = isConditionallyReached(node);
-      const replacement = unwrapExpression(node.right);
-      if (ts.isObjectLiteralExpression(replacement)) {
-        recordObjectLiteral(owner, node.left.text, replacement, node.getStart(), conditional);
+      const replacements = objectLiteralTargets(node.right);
+      for (const replacement of replacements) {
+        recordObjectLiteral(
+          owner,
+          node.left.text,
+          replacement,
+          node.getStart(),
+          // Either literal may be the one the runtime took, and the name may
+          // still hold the container it replaced.
+          conditional || replacements.length > 1
+        );
       }
       for (const target of aliasTargets(node.right)) {
         aliasEdges.push({

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -196,6 +196,13 @@ function isVarList(list) {
   );
 }
 
+/** Every runtime branch of a conditional, whether or not this recognizes it. */
+function conditionalLeafCount(node) {
+  const value = unwrapTransparent(node);
+  if (!ts.isConditionalExpression(value)) return 1;
+  return conditionalLeafCount(value.whenTrue) + conditionalLeafCount(value.whenFalse);
+}
+
 /** Every semantic a binding may stand for, the declared one first. */
 function bindingSemantics(binding) {
   if (!binding) return [];
@@ -1204,7 +1211,9 @@ function collectExposures(root) {
       const replacements = objectLiteralTargets(node.right);
       // A conditional may mix a literal with a name; when it can yield more
       // than one value neither outcome is certain.
-      const valueCount = replacements.length + aliasTargets(node.right).length;
+      // Every branch counts, not only the ones this recognizes: an
+      // unrecognized branch is still a value the name may end up holding.
+      const valueCount = conditionalLeafCount(node.right);
       for (const replacement of replacements) {
         recordObjectLiteral(
           owner,

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -1085,6 +1085,33 @@ describe('lowered hook coverage', () => {
     expect(scan.unresolved.map((miss) => miss.reason)).toEqual(['subject']);
   });
 
+  it('reports every leaf of a nested local-state conditional', () => {
+    // The gate is the oracle for the extractor, so a blind spot here would let
+    // a future extractor regression on this shape through unnoticed.
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    for (const [label, initializer] of [
+      ['nested on the left', 'a ? (b ? first : second) : third'],
+      ['nested on the right', 'a ? third : (b ? first : second)'],
+    ] as const) {
+      const source = [
+        "const first = def.state.bool('firstFlag', false);",
+        "const second = def.state.bool('secondFlag', false);",
+        "const third = def.state.bool('thirdFlag', false);",
+        `const current = ${initializer};`,
+        "def.expose.state('visible', current);",
+        `def.rule({ when: (w) => w.state(current).eq(true), intent: ${use} });`,
+      ].join('\n');
+      const scan = scanRuleStateReads(source);
+
+      expect(scan.unresolved, label).toEqual([]);
+      expect(scan.exposedLocals.map((local) => local.attribute).sort(), label).toEqual([
+        'first-flag',
+        'second-flag',
+        'third-flag',
+      ]);
+    }
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -1091,7 +1091,7 @@ describe('lowered hook coverage', () => {
     const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
     for (const [label, initializer] of [
       ['nested on the left', 'a ? (b ? first : second) : third'],
-      ['nested on the right', 'a ? third : (b ? first : second)'],
+      ['nested on the right', 'a ? first : (b ? second : third)'],
     ] as const) {
       const source = [
         "const first = def.state.bool('firstFlag', false);",
@@ -1110,6 +1110,22 @@ describe('lowered hook coverage', () => {
         'third-flag',
       ]);
     }
+
+    // The ordinary two-branch merge is unchanged.
+    const flat = scanRuleStateReads(
+      [
+        "const first = def.state.bool('firstFlag', false);",
+        "const second = def.state.bool('secondFlag', false);",
+        'const current = a ? first : second;',
+        "def.expose.state('visible', current);",
+        `def.rule({ when: (w) => w.state(current).eq(true), intent: ${use} });`,
+      ].join('\n')
+    );
+    expect(flat.unresolved).toEqual([]);
+    expect(flat.exposedLocals.map((local) => local.attribute).sort()).toEqual([
+      'first-flag',
+      'second-flag',
+    ]);
   });
 
   it('reports an exposed state whose declared name it cannot read', () => {

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -1003,6 +1003,68 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it('keeps the literal branch of a mixed conditional replacement', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      "const third = def.state.bool('thirdFlag', false);",
+      'const otherControls = { ready: third };',
+      'let controls = { ready: first };',
+      'controls = enabled ? { ready: second } : otherControls;',
+      "def.expose.state('visible', controls.ready);",
+      `def.rule({ when: (w) => w.state(controls.ready).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals.map((local) => local.attribute).sort()).toEqual([
+      'second-flag',
+      'third-flag',
+    ]);
+  });
+
+  it('records every candidate when a member write meets a skippable replacement', () => {
+    // Whichever order they are written in, the gate has to record the same set
+    // the extractor emits, or it certifies an incomplete one.
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    for (const [label, lines, expected] of [
+      [
+        'write after replace',
+        [
+          'let controls = { ready: first };',
+          'if (enabled) controls = { ready: second };',
+          'if (other) controls.ready = third;',
+        ],
+        ['first-flag', 'second-flag', 'third-flag'],
+      ],
+      [
+        'write before replace',
+        [
+          'let controls = { ready: first };',
+          'controls.ready = third;',
+          'if (enabled) controls = { ready: second };',
+        ],
+        ['second-flag', 'third-flag'],
+      ],
+    ] as const) {
+      const source = [
+        "const first = def.state.bool('firstFlag', false);",
+        "const second = def.state.bool('secondFlag', false);",
+        "const third = def.state.bool('thirdFlag', false);",
+        ...lines,
+        "def.expose.state('visible', controls.ready);",
+        `def.rule({ when: (w) => w.state(controls.ready).eq(true), intent: ${use} });`,
+      ].join('\n');
+      const scan = scanRuleStateReads(source);
+
+      expect(scan.unresolved, label).toEqual([]);
+      expect(scan.exposedLocals.map((local) => local.attribute).sort(), label).toEqual([
+        ...expected,
+      ]);
+    }
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -1065,6 +1065,26 @@ describe('lowered hook coverage', () => {
     }
   });
 
+  it('refuses to certify a container with an unresolvable branch', () => {
+    // `enabled ? { … } : makeControls()` can leave the member on a handle this
+    // never sees. Certifying the branch it does see would vouch for a set the
+    // runtime can step outside of, so the shape has to go unresolved instead.
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const second = def.state.bool('secondFlag', false);",
+      "const third = def.state.bool('thirdFlag', false);",
+      'const makeControls = () => ({ ready: third });',
+      'let controls = { ready: second };',
+      'controls = enabled ? { ready: second } : makeControls();',
+      "def.expose.state('visible', controls.ready);",
+      `def.rule({ when: (w) => w.state(controls.ready).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.exposedLocals).toEqual([]);
+    expect(scan.unresolved.map((miss) => miss.reason)).toEqual(['subject']);
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -983,6 +983,26 @@ describe('lowered hook coverage', () => {
     ]);
   });
 
+  it('reaches every leaf of a nested conditional replacement', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      "const third = def.state.bool('thirdFlag', false);",
+      'let controls = a ? (b ? { ready: first } : { ready: second }) : { ready: third };',
+      "def.expose.state('visible', controls.ready);",
+      `def.rule({ when: (w) => w.state(controls.ready).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals.map((local) => local.attribute).sort()).toEqual([
+      'first-flag',
+      'second-flag',
+      'third-flag',
+    ]);
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/lowered-hook-coverage.test.ts
+++ b/packages/cli/test/lowered-hook-coverage.test.ts
@@ -944,6 +944,45 @@ describe('lowered hook coverage', () => {
     }
   });
 
+  it('keeps the replaced container when the replacement may be skipped', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      'let controls = { ready: first };',
+      'if (enabled) controls = { ready: second };',
+      "def.expose.state('visible', controls.ready);",
+      `def.rule({ when: (w) => w.state(controls.ready).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals.map((local) => local.attribute).sort()).toEqual([
+      'first-flag',
+      'second-flag',
+    ]);
+  });
+
+  it('reads both containers a conditional replacement may install', () => {
+    const use = "(i) => i.feedback.style.use(tw('bg-accent'))";
+    const source = [
+      "const first = def.state.bool('firstFlag', false);",
+      "const second = def.state.bool('secondFlag', false);",
+      "const third = def.state.bool('thirdFlag', false);",
+      'let controls = { ready: first };',
+      'controls = enabled ? { ready: second } : { ready: third };',
+      "def.expose.state('visible', controls.ready);",
+      `def.rule({ when: (w) => w.state(controls.ready).eq(true), intent: ${use} });`,
+    ].join('\n');
+    const scan = scanRuleStateReads(source);
+
+    expect(scan.unresolved).toEqual([]);
+    expect(scan.exposedLocals.map((local) => local.attribute).sort()).toEqual([
+      'second-flag',
+      'third-flag',
+    ]);
+  });
+
   it('reports an exposed state whose declared name it cannot read', () => {
     // The extractor emits nothing for this, so certifying the expose key would
     // be the fail-closed mismatch this gate exists to prevent.

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -2375,4 +2375,36 @@ describe('collectProtoStyleTokens', () => {
     expect(tokens).toContain('data-[third-flag]:bg-accent');
     expect(tokens).not.toContain('data-[first-flag]:bg-accent');
   });
+  it('reaches every leaf of a nested conditional replacement', async () => {
+    // A branch may itself be a conditional, so the candidates are the leaves
+    // the runtime can land on rather than the composites above them.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        "    const third = def.state.bool('thirdFlag', false);",
+        '    let controls = a ? (b ? { ready: first } : { ready: second }) : { ready: third };',
+        "    def.expose.state('visible', controls.ready);",
+        '    def.rule({',
+        '      when: (w) => w.state(controls.ready).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[first-flag]:bg-accent');
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+    expect(tokens).toContain('data-[third-flag]:bg-accent');
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -2312,4 +2312,67 @@ describe('collectProtoStyleTokens', () => {
       else expect(tokens, label).not.toContain('data-[first-flag]:bg-accent');
     }
   });
+  it('keeps the replaced container when the replacement may be skipped', async () => {
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        '    let controls = { ready: first };',
+        '    if (enabled) controls = { ready: second };',
+        "    def.expose.state('visible', controls.ready);",
+        '    def.rule({',
+        '      when: (w) => w.state(controls.ready).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[first-flag]:bg-accent');
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+  });
+
+  it('reads both containers a conditional replacement may install', async () => {
+    // The assignment itself always runs, so the replaced container is gone and
+    // only the two the conditional may install have variants.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        "    const third = def.state.bool('thirdFlag', false);",
+        '    let controls = { ready: first };',
+        '    controls = enabled ? { ready: second } : { ready: third };',
+        "    def.expose.state('visible', controls.ready);",
+        '    def.rule({',
+        '      when: (w) => w.state(controls.ready).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+    expect(tokens).toContain('data-[third-flag]:bg-accent');
+    expect(tokens).not.toContain('data-[first-flag]:bg-accent');
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -2440,4 +2440,35 @@ describe('collectProtoStyleTokens', () => {
     expect(tokens).toContain('data-[second-flag]:bg-accent');
     expect(tokens).toContain('data-[third-flag]:bg-accent');
   });
+  it('still emits what it can prove when a conditional branch is opaque', async () => {
+    // The extractor cannot see through `makeControls()`, so it emits the branch
+    // it can prove and the coverage gate refuses to certify the shape at all —
+    // that pairing is what keeps the unseen branch from shipping without CSS.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const second = def.state.bool('secondFlag', false);",
+        "    const third = def.state.bool('thirdFlag', false);",
+        '    const makeControls = () => ({ ready: third });',
+        '    let controls = { ready: second };',
+        '    controls = enabled ? { ready: second } : makeControls();',
+        "    def.expose.state('visible', controls.ready);",
+        '    def.rule({',
+        '      when: (w) => w.state(controls.ready).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    expect(await collectProtoStyleTokens(dir)).toContain('data-[second-flag]:bg-accent');
+  });
 });

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -2407,4 +2407,37 @@ describe('collectProtoStyleTokens', () => {
     expect(tokens).toContain('data-[second-flag]:bg-accent');
     expect(tokens).toContain('data-[third-flag]:bg-accent');
   });
+  it('keeps the literal branch of a mixed conditional replacement', async () => {
+    // `enabled ? { … } : otherControls` yields two values, so following the
+    // name edge alone abandons the table the literal branch was recorded under.
+    await writeFile(
+      path.join(dir, 'widget.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        '',
+        'const widget = definePrototype({',
+        "  name: 'widget',",
+        '  setup(def) {',
+        "    const first = def.state.bool('firstFlag', false);",
+        "    const second = def.state.bool('secondFlag', false);",
+        "    const third = def.state.bool('thirdFlag', false);",
+        '    const otherControls = { ready: third };',
+        '    let controls = { ready: first };',
+        '    controls = enabled ? { ready: second } : otherControls;',
+        "    def.expose.state('visible', controls.ready);",
+        '    def.rule({',
+        '      when: (w) => w.state(controls.ready).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('bg-accent')),",
+        '    });',
+        '  },',
+        '});',
+        '',
+        'export default widget;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+    expect(tokens).toContain('data-[second-flag]:bg-accent');
+    expect(tokens).toContain('data-[third-flag]:bg-accent');
+  });
 });


### PR DESCRIPTION
Closes #609. Both shapes reproduced on `main@30ca6ef6` before anything was changed, and both had the signature #601 exists to eliminate: extractor and gate agreeing on a state identity the runtime does not use, with nothing reported.

## R-01 — a conditional replacement dropped what it replaced

`if (enabled) controls = { ready: second }` emitted `data-[second-flag]:…` alone. The assignment was already treated as uncertain, but only the binding's own *semantic* carried over — the replaced container's member table did not, so the read path saw the new members only. A container replaced under uncertainty now keeps the one it replaced among the values a member read consults, in both analyzers.

## R-02 — a conditional of two literals was recorded by neither prepass

`controls = enabled ? { ready: second } : { ready: third }` emitted **no variant at all** and reported nothing unresolved. `aliasTargets` fans out over conditional branches that are *identifiers*, and `recordObjectLiteral` ran only when the right-hand side was *directly* an object literal, so a conditional of two literals fell between them. Both prepasses now take every object literal an initializer may yield, each recorded conditionally.

Note what this deliberately does not add: `first` gets no variant here, because that assignment always runs and the container it replaced is genuinely gone. Only R-01's skippable replacement retains the prior container. The two regressions assert opposite things on that point, so the fix cannot degrade into "always keep everything".

## Verification

Four new regressions across both analyzers, each mutation-checked: dropping the replaced container turns two red, and restricting the prepasses to a direct literal turns two red.

Repository sweep unchanged at **118 usages, 1 exposed local, zero unresolved** — both shapes are latent, as #609 records. `packages` 1644 passed, `check:types` clean, preset manifests still 246 / 236.

## Provenance

These are the reviewer's R-01 and R-02 from its independent review of `55d0fb5d` during #601. That submission failed closed on PR-state drift and the findings were discarded, so #601 was approved and merged on a later head without them; the review noted it had not re-verified whether the later head folded them in. It had not.
