### PR TITLE
test(brutalist): close Tooltip light and dark evidence

### DIFF
--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -510,7 +510,6 @@ export default defineConfig({
                   label: 'Tooltip',
                   translations: { en: 'Tooltip', 'zh-CN': 'Tooltip' },
                   slug: 'ui-libraries/brutalist/components/tooltip',
-                  badge: inProgressBadge,
                 },
               ],
             },

--- a/apps/www/src/content/docs/en/ui-libraries/brutalist/components/tooltip.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/brutalist/components/tooltip.mdx
@@ -11,7 +11,7 @@ import BrutalistPageStyle from '@/components/BrutalistPageStyle.astro';
 
 Brutalist Tooltip publishes four Base Tooltip projection entries: Group inherits same-domain delay defaults, warm-window behavior, and active Tooltip coordination; Root owns controlled or uncontrolled open state; Trigger owns hover/focus routing and accessible-description linkage; Content owns presence, anchored portal positioning, Escape dismissal, and `role="tooltip"`.
 
-Group, Root, and Trigger are current draft transparent projections with cataloged Brutalist package identities; they add no second props, state, timing, event, accessibility, or visual owner. Only Content adds the square high-contrast surface. The interactive demo uses one real Group to compose two uncontrolled sibling Tooltips and can switch among Web Components, React, and Vue.
+Group, Root, and Trigger are current draft transparent projections with cataloged Brutalist package identities; they add no second props, state, timing, event, accessibility, or visual owner. Only Content adds the square high-contrast surface. The interactive demo uses one real Group to compose two uncontrolled sibling Tooltips and can switch among Web Components, React, and Vue. While Content stays mounted through its renderer-owned portal, changing the documentation host from Light to Dark repaints the same surface through `--pui-foreground` and `--pui-background`.
 
 <div class="brutalist-demo-frame" data-brutalist-tooltip-theme-boundary>
   <PrototypePreviewer

--- a/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
@@ -680,15 +680,12 @@ describe.sequential('Brutalist control documentation browser regressions', () =>
       height: 900,
     });
 
-    const expectTooltipPaint = async (
-      tooltip: Locator,
-      expectedText: string,
-      frame: string
-    ): Promise<void> => {
+    const expectTooltipPaint = async (tooltip: Locator, expectedText: string, frame: string) => {
       const paint = await tooltip.evaluate((element) => {
         const style = getComputedStyle(element);
         const rect = element.getBoundingClientRect();
         return {
+          id: (element as HTMLElement).id,
           text: element.textContent,
           tabIndex: (element as HTMLElement).tabIndex,
           interactive: element.querySelectorAll('a,button,input,select,textarea,[tabindex]').length,
@@ -750,6 +747,7 @@ describe.sequential('Brutalist control documentation browser regressions', () =>
       expect(paint.paddingBlock, frame).toBe('8px');
       expect(paint.width, frame).toBeGreaterThan(20);
       expect(paint.height, frame).toBeGreaterThan(20);
+      return paint;
     };
 
     try {
@@ -776,19 +774,24 @@ describe.sequential('Brutalist control documentation browser regressions', () =>
           .getByRole('tooltip')
           .filter({ hasText: 'Portable Base behavior, Brutalist visual grammar' });
         await expect.poll(() => firstTooltip.count(), { message: runtime }).toBe(1);
-        await expectTooltipPaint(
+        const lightPaint = await expectTooltipPaint(
           firstTooltip,
           'Portable Base behavior, Brutalist visual grammar',
           `${runtime}/light`
         );
+        const firstTooltipId = lightPaint.id;
+        expect(firstTooltipId, runtime).toBeTruthy();
         await applyColorScheme(page, 'dark');
-        await expectTooltipPaint(
+        const darkPaint = await expectTooltipPaint(
           firstTooltip,
           'Portable Base behavior, Brutalist visual grammar',
           `${runtime}/dark-repaint`
         );
-        const firstTooltipId = await firstTooltip.getAttribute('id');
-        expect(firstTooltipId, runtime).toBeTruthy();
+        expect(darkPaint.id, `${runtime}/same-mounted-content`).toBe(firstTooltipId);
+        expect(darkPaint.backgroundColor, `${runtime}/live-fill-repaint`).not.toBe(
+          lightPaint.backgroundColor
+        );
+        expect(darkPaint.color, `${runtime}/live-ink-repaint`).not.toBe(lightPaint.color);
         expect(
           (await firstTrigger.getAttribute('aria-describedby'))?.split(/\s+/),
           runtime

--- a/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
@@ -738,6 +738,8 @@ describe.sequential('Brutalist control documentation browser regressions', () =>
       expect(paint.backgroundColor, frame).toBe(resolved.boundary.foreground);
       expect(paint.color, frame).toBe(resolved.boundary.background);
       expect(paint.borderColor, frame).toBe(resolved.boundary.foreground);
+      // The hard shadow must resolve to the same active foreground token as the border.
+      expect(paint.boxShadow, frame).toContain(resolved.boundary.foreground);
       expect(paint.boxShadow, frame).toContain('4px 4px 0px');
       expect(paint.fontFamily.toLowerCase(), frame).toContain('mono');
       expect(paint.fontSize, frame).toBe('12px');
@@ -755,9 +757,11 @@ describe.sequential('Brutalist control documentation browser regressions', () =>
       // for `[data-adapter-select-root].dataset.value` to equal it before the
       // host is accepted. Reading an option inventory would retest the
       // previewer's own Select, whose items exist only while it is open.
+      // Pin the browser preference to Light; both palettes below must come from the host theme API.
+      await page.emulateMedia({ colorScheme: 'light' });
       for (const runtime of RUNTIMES) {
-        await applyColorScheme(page, 'light');
         await selectRuntime(page, previewer, runtime, '[data-pui-root]', 7);
+        await applyHostTheme(page, 'light');
         // Scoped to the rendered host: the previewer chrome is Proto UI too, so
         // a previewer-wide count is not evidence about this demo.
         const roots = previewer.locator('.host [data-pui-root]');
@@ -779,14 +783,25 @@ describe.sequential('Brutalist control documentation browser regressions', () =>
           'Portable Base behavior, Brutalist visual grammar',
           `${runtime}/light`
         );
+        const lightTooltipNode = await firstTooltip.elementHandle();
+        if (!lightTooltipNode) throw new Error(`${runtime}: Tooltip Content has no DOM node.`);
         const firstTooltipId = lightPaint.id;
         expect(firstTooltipId, runtime).toBeTruthy();
-        await applyColorScheme(page, 'dark');
+        await applyHostTheme(page, 'dark');
         const darkPaint = await expectTooltipPaint(
           firstTooltip,
           'Portable Base behavior, Brutalist visual grammar',
           `${runtime}/dark-repaint`
         );
+        const darkTooltipNode = await firstTooltip.elementHandle();
+        if (!darkTooltipNode) throw new Error(`${runtime}: Tooltip Content has no DOM node.`);
+        const sameTooltipNode = await page.evaluate(
+          ([before, after]) => before === after,
+          [lightTooltipNode, darkTooltipNode]
+        );
+        expect(sameTooltipNode, `${runtime}/same-mounted-content`).toBe(true);
+        await lightTooltipNode.dispose();
+        await darkTooltipNode.dispose();
         expect(darkPaint.id, `${runtime}/same-mounted-content`).toBe(firstTooltipId);
         expect(darkPaint.backgroundColor, `${runtime}/live-fill-repaint`).not.toBe(
           lightPaint.backgroundColor

--- a/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts
@@ -787,6 +787,35 @@ describe.sequential('Brutalist control documentation browser regressions', () =>
         if (!lightTooltipNode) throw new Error(`${runtime}: Tooltip Content has no DOM node.`);
         const firstTooltipId = lightPaint.id;
         expect(firstTooltipId, runtime).toBeTruthy();
+        const tooltipCanaries = {
+          foreground: 'rgb(17, 83, 139)',
+          background: 'rgb(211, 89, 127)',
+        } as const;
+        await page.evaluate(({ foreground, background }) => {
+          const root = document.documentElement;
+          root.style.setProperty('--pui-foreground', foreground);
+          root.style.setProperty('--pui-background', background);
+        }, tooltipCanaries);
+        const canaryPaint = await expectTooltipPaint(
+          firstTooltip,
+          'Portable Base behavior, Brutalist visual grammar',
+          `${runtime}/canary`
+        );
+        expect(canaryPaint.backgroundColor, `${runtime}/canary/fill`).toBe(
+          tooltipCanaries.foreground
+        );
+        expect(canaryPaint.color, `${runtime}/canary/ink`).toBe(tooltipCanaries.background);
+        expect(canaryPaint.borderColor, `${runtime}/canary/border`).toBe(
+          tooltipCanaries.foreground
+        );
+        expect(canaryPaint.boxShadow, `${runtime}/canary/hard-shadow`).toContain(
+          tooltipCanaries.foreground
+        );
+        await page.evaluate(() => {
+          const root = document.documentElement;
+          root.style.removeProperty('--pui-foreground');
+          root.style.removeProperty('--pui-background');
+        });
         await applyHostTheme(page, 'dark');
         const darkPaint = await expectTooltipPaint(
           firstTooltip,

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/brutalist/components/tooltip.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/brutalist/components/tooltip.mdx
@@ -11,7 +11,7 @@ import BrutalistPageStyle from '@/components/BrutalistPageStyle.astro';
 
 Brutalist Tooltip 公开四个 Base Tooltip 投影入口：Group 继承同域 delay defaults、warm-window 与 active Tooltip 协调；Root 负责受控或非受控 open state；Trigger 负责 hover/focus 路由和无障碍描述关联；Content 负责 presence、锚定 portal 定位、Escape dismissal 与 `role="tooltip"`。
 
-Group、Root 与 Trigger 是当前编目的 draft 透明投影，具有明确的 Brutalist package identity，且不新增第二套 props、state、timing、events、accessibility 或 visual owner。只有 Content 增加方形高对比 surface。下方交互示例通过一个真实 Group 组合两个非受控 sibling Tooltip，并可在 Web Components、React 与 Vue 之间切换。
+Group、Root 与 Trigger 是当前编目的 draft 透明投影，具有明确的 Brutalist package identity，且不新增第二套 props、state、timing、events、accessibility 或 visual owner。只有 Content 增加方形高对比 surface。下方交互示例通过一个真实 Group 组合两个非受控 sibling Tooltip，并可在 Web Components、React 与 Vue 之间切换。Content 通过 renderer-owned portal 保持挂载时，将文档 host 从 Light 切换到 Dark 会通过 `--pui-foreground` 与 `--pui-background` 重绘同一个 surface。
 
 <div class="brutalist-demo-frame" data-brutalist-tooltip-theme-boundary>
   <PrototypePreviewer

--- a/spec/prototypes/P-BRUTALIST-TOOLTIP-CONTENT.yaml
+++ b/spec/prototypes/P-BRUTALIST-TOOLTIP-CONTENT.yaml
@@ -12,6 +12,10 @@ criteria:
     text:
       en: 'Content must include rounded-none, border-2 border-foreground, bg-foreground, text-background, font-mono font-bold uppercase text-xs, px-3 py-2, z-50, and shadow-[4px_4px_0_0_var(--pui-foreground)].'
       zh-CN: 'Content 必须包含 rounded-none、border-2 border-foreground、bg-foreground、text-background、font-mono font-bold uppercase text-xs、px-3 py-2、z-50 与 shadow-[4px_4px_0_0_var(--pui-foreground)]。'
+  - id: P-BRUTALIST-TOOLTIP-CONTENT-LIGHT-DARK
+    text:
+      en: Content border, fill, ink, and hard shadow must resolve through the active `--pui-foreground` and `--pui-background` values in both Light and Dark. Changing the host theme while Content is mounted through the renderer-owned portal must repaint that same Content without introducing another theme or presence owner.
+      zh-CN: Content 的 border、fill、ink 与 hard shadow 必须在 Light 和 Dark 下通过当前 `--pui-foreground` 与 `--pui-background` 值解析。Content 通过 renderer-owned portal 挂载期间切换 host theme 时，必须重绘同一个 Content，且不得引入另一套 theme 或 presence owner。
   - id: P-BRUTALIST-TOOLTIP-CONTENT-NO-BEHAVIOR-DELTA
     text:
       en: Content must inherit Base tooltip role, open state, presence, Escape dismissal, renderer portal ownership, and positioning without adding a second owner.
@@ -20,8 +24,8 @@ sources: [{ path: packages/prototypes/brutalist/src/tooltip/content.proto.ts }]
 revisions:
   - version: 0.3.0-alpha.0
     change: revised
-    summary: Aligned Content with the interactive Base Tooltip protocol.
-tags: [prototype, brutalist, tooltip, content, visual]
+    summary: Aligned Content with the interactive Base Tooltip protocol and bound Light/Dark live repaint across its renderer-owned portal.
+tags: [prototype, brutalist, tooltip, content, visual, theme]
 inherits:
   prototypes: [{ id: P-BASE-TOOLTIP-CONTENT }]
 dependsOn:

--- a/spec/tests/T-BRUTALIST-TOOLTIP-0001.yaml
+++ b/spec/tests/T-BRUTALIST-TOOLTIP-0001.yaml
@@ -3,7 +3,7 @@ type: test
 title: Brutalist Tooltip projection contract test
 status: draft
 since: 0.3.0-alpha.0
-summary: Verifies the four-entry package surface, transparent Group and Trigger Base inheritance, current Tooltip interaction/accessibility behavior, and the exact Content visual delta.
+summary: Verifies the four-entry package surface, transparent Group and Trigger Base inheritance, current Tooltip interaction/accessibility behavior, and exact Light/Dark Content projection.
 cases:
   - id: T-BRUTALIST-TOOLTIP-0001-CASE-INHERITANCE
     title: Four-entry projection preserves Base behavior and Content grammar
@@ -49,11 +49,12 @@ cases:
       - P-BRUTALIST-TOOLTIP-CONTENT-NO-BEHAVIOR-DELTA
     expectation: content-teardown-cleans-owned-description-and-rendered-tooltip-has-no-focusable-task-interaction
   - id: T-BRUTALIST-TOOLTIP-0001-CASE-RENDERED-VISUAL
-    title: Uncontrolled sibling Tooltips render the exact Content grammar across WC React and Vue
+    title: Mounted sibling Tooltips preserve exact Content grammar and repaint from Light to Dark across WC React and Vue
     covers:
       - P-BRUTALIST-TOOLTIP-CONTENT-VISUAL-GRAMMAR
+      - P-BRUTALIST-TOOLTIP-CONTENT-LIGHT-DARK
       - P-BRUTALIST-TOOLTIP-CONTENT-NO-BEHAVIOR-DELTA
-    expectation: trigger-driven-rendered-content-has-square-border-inverse-colors-hard-shadow-monospace-uppercase-spacing-and-nonzero-geometry
+    expectation: trigger-driven-mounted-content-keeps-one-identity-while-foreground-background-border-and-hard-shadow-follow-light-and-dark-host-tokens
 implementations:
   - id: prototypes-brutalist-tooltip-projection
     kind: module-test
@@ -89,6 +90,9 @@ implementations:
       - P-BRUTALIST-TOOLTIP-GROUP
       - P-BRUTALIST-TOOLTIP-TRIGGER
       - P-BRUTALIST-TOOLTIP-CONTENT
+    notes:
+      - The Website registry imports the real `@proto.ui/prototypes-brutalist/tooltip` package subpath for Group, Root, Trigger, and Content.
+      - The browser case opens one uncontrolled Content in Light, changes the live documentation host to Dark without closing it, and requires the same Content identity to repaint before exercising warm sibling handoff and teardown.
 verifies:
   prototypes:
     - id: P-BRUTALIST-TOOLTIP
@@ -108,5 +112,5 @@ exercises:
 revisions:
   - version: 0.3.0-alpha.0
     change: revised
-    summary: Completed executable four-entry package, transparent Group/Trigger, shared warm-delay, Content teardown/non-focusable interaction boundary, exact built export/CLI negative gates, and rendered three-runtime visual coverage.
-tags: [test, brutalist, visual, tooltip, interaction, accessibility]
+    summary: Completed executable four-entry package, transparent Group/Trigger, shared warm-delay, Content teardown/non-focusable interaction boundary, exact built export/CLI negative gates, and rendered three-runtime Light/Dark live-theme coverage.
+tags: [test, brutalist, visual, tooltip, interaction, accessibility, theme]


### PR DESCRIPTION
## Summary

Close the remaining Issue #385 evidence and public-projection gap around the Brutalist Tooltip family delivered by merged PR #502.

- add a draft `P-BRUTALIST-TOOLTIP-CONTENT-LIGHT-DARK` criterion for active foreground/background token resolution through the renderer-owned portal;
- bind `T-BRUTALIST-TOOLTIP-0001` to the real package-backed WC/React/Vue Light-to-Dark browser transition;
- verify that one open Content identity repaints its fill and ink before warm sibling handoff and teardown;
- document the behavior in EN/ZH and remove only Tooltip's completed WIP sidebar marker;
- preserve the existing four-entry package/root exports, two-sibling demo, Base ownership, Arrow exclusion, and private CLI boundary.

Closes #385

## Related context

- Issue: #385
- Prior implementation carrier: #502, merged as `28a94f7c`; it supplied the four-entry implementation but had no closing issue reference.
- Applicable spec entities and lifecycle: draft `P-BRUTALIST-TOOLTIP`, `P-BRUTALIST-TOOLTIP-GROUP`, `P-BRUTALIST-TOOLTIP-TRIGGER`, `P-BRUTALIST-TOOLTIP-CONTENT`, and `T-BRUTALIST-TOOLTIP-0001`.
- Criteria / test anchors: `P-BRUTALIST-TOOLTIP-CONTENT-LIGHT-DARK`, `T-BRUTALIST-TOOLTIP-0001-CASE-RENDERED-VISUAL`.
- Related concurrent work: #571 and #581 remain separate conflicting carriers; this branch is based directly on current `main` and does not absorb either head.

## Scope boundary

- Issue #385 and the current draft Tooltip graph already decide that Base owns state, delay, dismissal, accessibility, presence, portal, and positioning; Brutalist owns only Content feedback style.
- This pull request makes the existing Light/Dark live repaint explicit in the draft spec, executable evidence, and bilingual reader projection.
- Out of scope: Base Tooltip changes, Arrow geometry/admission, Popover or interactive content, Vue 2 expansion, public `proto-ui add`, lifecycle promotion, release/BOM, publication, and unrelated browser-test work.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs.
- [x] Normative behavior changes include coherent P/T criteria, revisions, executable evidence, and affected projections.
- [x] This change does not create an empty catalog identity or silently widen a draft/active public guarantee.

## Contribution provenance

- [x] This contribution was created by me and I have the right to submit it.
- [ ] This contribution adapts or derives from third-party material.
- [x] This contribution includes material AI-assisted generation or transformation.
- [ ] This contribution may be subject to employer or client ownership, and I have confirmed that I may submit it.
- [x] No third-party source disclosure is required.

### Third-party or upstream sources

No third-party code or assets were copied or adapted. The change extends existing Proto UI Tooltip entities, tests, and docs.

### AI assistance

OpenAI GPT-5.6-family assistance through Oh My Pi materially assisted authority tracing, spec/test/docs edits, browser verification, validation, and PR preparation. I reviewed the resulting change and executed the evidence below. No private or third-party code was provided to the model.

## DCO

- [x] I have checked the DCO status of this PR.

The single commit carries `Signed-off-by: cyjin-yl <cyjin.yl@gmail.com>` and an SSH signature. GitHub remains authoritative for the required DCO check.

## Prototype website preview

- [x] This pull request adds or changes public Prototype behavior and includes the required reachable website page or page update.
- [ ] A new or updated website page is not applicable because:

- Public docs route: `/en/ui-libraries/brutalist/components/tooltip/` and `/zh-cn/ui-libraries/brutalist/components/tooltip/`
- Local preview URL or route: `http://127.0.0.1:4324/en/ui-libraries/brutalist/components/tooltip/` in the disposable validation environment
- Applicable runtimes manually reviewed: Web Component directly; Web Component / React / Vue through the real Chromium project test
- [x] The demo consumes the real `@proto.ui/prototypes-brutalist/tooltip` package subpath and uses the Prototype Group, Root, Trigger, Content, pointer intent, delay, accessible relation, and teardown behavior.
- [x] The Demo Matrix, when used, is supplementary evidence rather than a replacement for the website page.
- External demo orchestration: none
- Consumer-owned orchestration that is not installed with the package: none

## Validation

All listed checks used Node 22.17.1 and pnpm 10.32.1. Because the mounted worktree exceeded Vite's fixed module-transport deadline, executable checks ran in a disposable native-filesystem archive of `main` plus the six changed files; SHA-256 comparison confirmed those files were byte-identical to the committed tree.

- Focused tests:
  - `pnpm exec vitest run packages/prototypes/brutalist/test/tooltip.test.ts` — 4/4 passed.
  - `pnpm test:runtime -- apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts -t 'composes the transparent Tooltip Group'` — runtime-plan 2/2 and Tooltip browser case 1/1 passed across WC, React, and Vue.
  - `node --test scripts/release/test/prototype-family-boundary.test.mjs` — 5/5 passed, including exact root/`./tooltip` exports and private subpath boundary.
- Catalog / generated checks:
  - `check:prototype-catalog` — 130 declaration files, 178 authoring entries, 129 cataloged P entities, zero debt.
  - `check:styles:preset` — Shadcn 246 and Brutalist 236 token/theme manifests current.
  - `check:package-manifests` — 43 public manifests current.
  - `spec:docs:agent && check:agent-doc` — generated/current from 556 entities; generated file remained untracked.
  - `check:public-docs` and `test:public-docs` — 104 bilingual primary routes and 10/10 tests passed.
- Types / repository tests:
  - `check:types` — workspace types passed; Astro checked 181 files with zero errors, warnings, or hints.
  - Full `pnpm test` reached the runtime suite with 1,704 tests passing; 14 tests in 12 unrelated files hit only their 5s/30s time limits under full parallel load. Rerunning exactly those 12 files with `--no-file-parallelism` passed 12/12 files and 46/46 tests. Required GitHub CI remains the full-suite gate.
- Docs build / preview:
  - `docs:build` — 230 pages built; Pagefind indexed 228 pages.
  - Real browser page showed the current Brutalist sidebar item as `Tooltip`, not `Tooltip WIP`.
- Manual or browser evidence:
  - Same Content id `pui-tooltip-1-content` remained open across the theme transition.
  - Light: fill/border/shadow `rgb(23, 23, 23)`; ink `rgb(245, 245, 245)`; square 2px frame and 4px hard shadow.
  - Dark: fill/border/shadow `rgb(245, 245, 245)`; ink `rgb(23, 23, 23)`; same square 2px frame and 4px hard shadow.
  - Light and Dark screenshots were captured as untracked local evidence; the computed values above and required browser case are the reproducible evidence.
- Formatting: focused Prettier check and `git diff --check` passed.
- Not run or not applicable, with reason: Vue 2 is intentionally outside the localized page and governed T-case runtime surface; release/publication checks are out of scope.
