### PR TITLE
feat(context): catalog M/HC/A slice and verify Vue 2 conformance

### DIFF
--- a/internal/contracts/context/README.md
+++ b/internal/contracts/context/README.md
@@ -1,60 +1,12 @@
 # Context Contract Index
 
-This directory defines **context** contracts for Proto UI.
+This directory is a readable legacy projection. Applicable `spec/**` entities take precedence; the Context catalog remains **draft**, not a stable release guarantee.
 
-Context is the **component-to-component** communication channel that is:
+- [Context module](../../../spec/modules/M-CONTEXT-0001.yaml): author facade, privileged port, instance-owned resources and standard Runtime composition.
+- [Identity capability](../../../spec/host-caps/HC-CONTEXT-IDENTITY-0001.yaml) and [ancestry capability](../../../spec/host-caps/HC-CONTEXT-ANCESTRY-0001.yaml): opaque owner identity and current logical parent facts.
+- [Read authority](../../../spec/contracts/C-CONTEXT-0007.yaml), [update authority](../../../spec/contracts/C-CONTEXT-0008.yaml), and [lifetime](../../../spec/contracts/C-CONTEXT-0012.yaml).
+- [Vertical evidence](../../../spec/tests/T-CONTEXT-0003.yaml): Module, Runtime, React, Vue 3, Vue 2 and Web Component scope journeys.
 
-- **tree-based** (logical tree; WC uses DOM tree)
-- **provider → consumer** (single direction in v0)
-- **nearest provider wins**
-- **setup-only** for subscription intent
-- **runtime-only** for reads and updates
-- **JSON-serializable object values** in v0
+Context carries component-to-component values in the nearest self-inclusive provider scope. A subscribed consumer may update that scope; a provider may `update` its own value without subscription. Reads and `tryUpdate` retain their separate subscription requirements. Host ownership determines ancestry; DOM containment is not a universal rule.
 
-These contracts define semantics and phase rules. Integration tests may verify composition (e.g. context → rule → style), but MUST NOT introduce new semantics beyond referenced contracts.
-
----
-
-## Contract Set (v0)
-
-- `with-tree.v0.md`
-- The normative contract for v0 context covers:
-- ContextKey identity and debug name
-- provider resolution (nearest wins)
-- provide/subscribe/trySubscribe phase rules
-- read/tryRead/update/tryUpdate phase rules
-- tree rebind behavior (no notifications in v0)
-- value constraints and portability scope
-- subscription callback semantics
-- error model (codes or equivalent)
-
-- `with-tree.v0.impl-notes.md`
-- Non-normative implementation notes include:
-- recommended internal data structures
-- validation and performance tradeoffs
-- suggested guard strategy and error codes
-
----
-
-## Naming Convention
-
-- Contract docs: `<topic>.v0.md` or `<topic>.v0.impl-notes.md`
-- Contract tests (recommended): `packages/<pkg>/test/contract/context.<topic>.v0.contract.test.ts`
-
----
-
-## Out of Scope (v0)
-
-- Bidirectional/peer communication channels outside context
-- Connection-change notifications (e.g. onConnected/onDisconnected callbacks)
-- Compiler-stage portability and AST-based extraction
-- Host-specific capabilities (e.g. `def.host`)
-
----
-
-## Related Contracts
-
-Context often composes with:
-
-- `rule` (when/then evaluation)
-- adapter realization contracts (host tree representation, lifecycle)
+`with-tree.v0.md` retains the readable topic layout and examples. `with-tree.v0.impl-notes.md` is non-normative implementation background. Connection-change notifications and compiler-stage extraction remain outside this slice.

--- a/internal/contracts/context/with-tree.v0.md
+++ b/internal/contracts/context/with-tree.v0.md
@@ -1,6 +1,6 @@
 # internal/contracts/context/with-tree.v0.md
 
-> Status: Draft – implementation-ready (contract-first) This contract specifies Proto UI **context**: tree-based provider resolution, setup-only subscription intent, runtime reads and updates, and strict value constraints for v0 portability.
+> Legacy readable projection. Current draft authority: [M-CONTEXT-0001](../../../spec/modules/M-CONTEXT-0001.yaml), [C-CONTEXT-0001](../../../spec/contracts/C-CONTEXT-0001.yaml) through [C-CONTEXT-0012](../../../spec/contracts/C-CONTEXT-0012.yaml). These entities supersede this prose; see [the index](./README.md) for host capability and evidence links.
 
 ---
 
@@ -10,7 +10,7 @@
 
 Context provides:
 
-- A **tree-based** communication channel between components (provider → consumer).
+- A **tree-based** communication channel between components within a provider-owned scope (subscribed consumers may update).
 - Setup-only **subscription intent** with runtime **reads** and **updates**.
 - Deterministic provider resolution: **nearest provider wins**.
 - v0 portability constraints: context values are JSON-serializable **objects**.
@@ -29,8 +29,8 @@ Context provides:
 - **ContextKey<T>**: a unique token (symbol-like) identifying a context channel.
 - **Provider**: a component instance that provides a value for a ContextKey.
 - **Consumer**: a component instance that subscribes/reads/updates a ContextKey.
-- **Logical tree**: the runtime component tree (for WC it matches DOM tree).
-- **Nearest provider wins**: the consumer binds to the closest ancestor provider for the key.
+- **Logical tree**: host-translated logical ownership; Web Component derives it from its supported DOM ownership boundary.
+- **Nearest provider wins**: the consumer binds to the closest provider, starting with the consumer itself for the key.
 
 ---
 
@@ -57,7 +57,7 @@ Core MUST provide a ContextKey factory, e.g.:
 ## 3. Provider resolution
 
 - Provider resolution MUST be based on the logical tree.
-- For a given (consumer instance, key), the bound provider is the **nearest ancestor provider** of that key.
+- For a given (consumer instance, key), the bound provider is the **nearest self-inclusive provider** of that key.
 - Different component instances may provide the same key simultaneously; binding is per consumer and depends on tree position.
 
 ---
@@ -96,13 +96,13 @@ Read APIs are runtime-only:
 
 ### 5.1 read (required)
 
-- `read(key)` MUST be callable only during runtime callback phase.
+- `read(key)` MUST be callable during runtime callback or readonly render phase.
 - `read(key)` MUST require prior `subscribe(key, onChange?)` in setup.
 - If the subscription is disconnected at runtime (provider removed / tree changed), `read` MUST throw.
 
 ### 5.2 tryRead (optional)
 
-- `tryRead(key)` MUST be callable only during runtime callback phase.
+- `tryRead(key)` MUST be callable during runtime callback or readonly render phase.
 - `tryRead(key)` MUST require prior `trySubscribe(key, onChange?)` in setup.
 - If the subscription is disconnected or provider is absent, `tryRead` MUST return `null`.
 
@@ -118,17 +118,17 @@ Read APIs are runtime-only:
 
 - `provide` MUST NOT return a provider-side `update` function.
 - A provider that needs to update its own context MUST use the unified runtime context update surface.
-- Provider-side updates therefore follow the same subscription and phase rules as `run.context.update` or `run.context.tryUpdate`.
+- Provider `update` of its own key needs no subscription, but remains callback-only. This exception grants neither read authority nor `tryUpdate` authority; see C-CONTEXT-0008-C.
 
 ### 6.3 Unified runtime update
 
-- `run.context.update(key, next)` is runtime-only.
-- A participant MUST have previously subscribed to the key (via `subscribe` or `trySubscribe`) to call `update`.
+- `run.context.update(key, next)` is callback-only.
+- A consumer must have previously subscribed to the key (via `subscribe` or `trySubscribe`) to call `update`; the provider itself is exempt for its own key.
 - The `run.context.update` signature accepts a next value or updater function: `update(key, prev => next)`.
 
 ### 6.4 tryUpdate (optional)
 
-- `run.context.tryUpdate(key, next)` is runtime-only and MUST require prior `trySubscribe`.
+- `run.context.tryUpdate(key, next)` is callback-only and MUST require prior `trySubscribe`.
 - If the context is unavailable (no provider or disconnected), `tryUpdate` MUST return `false` and perform no update.
 - If the update succeeds, `tryUpdate` MUST return `true`.
 
@@ -173,9 +173,9 @@ Read APIs are runtime-only:
 - `subscribe/trySubscribe` callbacks fire during runtime when context updates.
 - Callback signature: `(run, next, prev)`.
 - `next` and `prev` are JSON objects, or `null` if context is unavailable.
-- Update notifications are synchronous and MUST NOT be merged: every update enqueues exactly one notification.
+- Every successful update remains observable as a distinct semantic transition; delivery preserves its next/prev values.
 
-> v0 does not mandate async scheduling. Ordering MUST be deterministic.
+> [D-CONTEXT-NOTIFICATION-SCHEDULING-0001](../../../spec/decisions/D-CONTEXT-NOTIFICATION-SCHEDULING-0001.md) allows host scheduling without dropping or incorrectly merging transitions; ordering within a dispatch window is deterministic.
 
 ---
 
@@ -187,13 +187,17 @@ Read APIs are runtime-only:
 
 ---
 
+## Lifecycle
+
+Provider values, subscription intent and callbacks belong to the instance. Repeatable view detach/remount preserves them; terminal disposal removes them. Unsubscribe stops later delivery. See C-CONTEXT-0012 and C-LIFECYCLE-0006/0007.
+
 ## 10. Error model
 
 Implementations MUST throw for:
 
 - Phase violations (setup-only/runtime-only misuse)
 - Missing provider for required `subscribe`
-- Missing prior subscription intent (`read` without `subscribe`, `tryRead` without `trySubscribe`, `update` without subscribe)
+- Missing prior subscription intent (`read` without `subscribe`, `tryRead` without `trySubscribe`, consumer `update` without subscription)
 - Duplicate provide for the same key on the same instance
 - Disconnected required read
 - Invalid provided values

--- a/internal/records/2026-09-07-context-module-host-cap-adapter-audit.zh-CN.md
+++ b/internal/records/2026-09-07-context-module-host-cap-adapter-audit.zh-CN.md
@@ -1,0 +1,41 @@
+# Context 编目与 Vue 2 Adapter 跟进审计
+
+日期：2026-09-07。基线：`main` 的 `f8f98d22`；工作分支：`codex/context-module-host-adapter-catalog`。这是本轮工程观察与验证记录，不替代 spec。
+
+## Context 语义切片
+
+新增 draft `M-CONTEXT-0001`、`HC-CONTEXT-IDENTITY-0001`、`HC-CONTEXT-ANCESTRY-0001`，并在四个既有 Adapter profile 中增加 Context 支持关系。共享 Context coordinator 不意味着应用全局资源；provider、subscription 和 callback 归 instance 所有，跨 repeatable view epoch 保留。
+
+当前用户明确确认：provider 可以不订阅而 `update` 自己提供的值；consumer 仍须先订阅。`read`、`tryRead`、`tryUpdate` 不获得此例外。`C-CONTEXT-0008-C` 已与该决定及现有实现对齐。`C-CONTEXT-0012` 的旧 unmount 文案与既有 `C-LIFECYCLE-0006/0007` 对齐，区分 view detach 与 terminal disposal，没有引入新的销毁行为。
+
+`T-CONTEXT-0003` 连接以下证据：
+
+- `packages/modules/context/test/catalog-boundary.test.ts`：facade/port 分离、provider 写权限例外、opaque identity、当前 ancestry、缺失 capability 诊断。
+- `packages/runtime/test/contract/context-lifecycle.v1.contract.test.ts`：真实 Runtime callback scope、重复 mount epoch、terminal 清理。
+- `packages/adapters/{react,vue,vue2,web-component}/test/context.integration.test.ts`：共用真实 owner 场景，覆盖嵌套 scope、同名 Key 隔离、consumer 更新、缺失 optional provider、销毁后重建。
+
+## Vue 2 既有编目的实际跟进
+
+Vue 2 admission 已为 Props、Event、State、Expose、Expose State、Expose Event 建立 M/HC/A 关系，并有基础 executable evidence；但部分宽泛 case 映射只有基础场景支撑。本轮增加直接证据，并校准 T 映射：
+
+| 领域 | 原有证据的局限 | 本轮补充 |
+| --- | --- | --- |
+| Props | `props-update.test.ts` 主要证明值更新 | `contract/props-host-source.v0.contract.test.ts` 验证 source invalidation、callback-safe sync 与显式 render；`props-normalization.v0.contract.test.ts` 验证分类排除与自定义 getProps 替换 |
+| Event / Default Action | root commit gate 与 terminal root cleanup | `catalog-conformance.test.ts` 验证 default-action cancellation、global key delivery 与 destroy 后停止 |
+| State / Expose State | 基础 readonly handle 与显式 render | keep-alive 中 State 和 handle identity 保留；subscription 可用；terminal outward record 清空 |
+| Expose | 既有测试未直接证明 Vue 2 keep-alive 的顶层方法 identity | 新增可复现失败并修复 shared Adapter reader；保留 callback scope 与 terminal invalidation |
+| Expose Event | 初始 listener route 可用 | typed listener 更换、Vue listener、无 replay、raw Props 和 public record 中不泄漏 listener/declaration |
+
+对应 T：`T-PROPS-0012`、`T-EVENT-0003`、`T-STATE-0005`、`T-EXPOSE-0002`、`T-EXPOSE-STATE-0002`、`T-EXPOSE-EVENT-0002`。
+
+## 已修复的共用 reader 漂移
+
+Vue 2 keep-alive detach 前后顶层 expose method 引用不同，违反 `C-EXPOSE-0008-B`。根因是 `packages/adapters/base/src/host/exposes.ts` 按 replacement record 的 receiver 身份缓存 wrapper。修复将同一 instance 的顶层 callable 缓存与 record replacement 解耦；调用时使用当前原始 record 作为 receiver。嵌套 callable 仍按自身对象区分 receiver，保留对象方法语义。
+
+`packages/adapters/base/test/contract/expose-record.v0.contract.test.ts` 新增 replacement snapshot、当前 root receiver、不同 nested receiver 与 terminal invalidation 回归证据。Vue 2 原始失败场景修复后通过。
+
+## 边界与后续
+
+本轮没有 lifecycle promotion，也没有宣称所有 HC 条件在每个 Adapter 上都有完整独立测试。Opaque ancestry 的模块证据不等于所有框架 portal、跨 root relocation 或真实浏览器布局路径都通过 conformance；这些可作为后续有边界的补充场景。可配置 Runtime module selection 的 required Context 诊断仍是 `M-CONTEXT-0001` 的 open question。没有承诺非 Web Adapter 支持。
+
+后续可沿相同方法选择下一块已有稳定 C 和 executable evidence 的 Module/HC 切片；不要按包数量补空实体。

--- a/packages/adapters/base/src/host/exposes.ts
+++ b/packages/adapters/base/src/host/exposes.ts
@@ -31,11 +31,14 @@ export function createScopedExposesReader(
   let lastRaw: Record<string, unknown> | null = null;
   let lastWrapped: Record<string, unknown> = {};
   const externalHandleCache = new WeakMap<object, Record<string, unknown>>();
+  // The top-level record is a replacement snapshot of one instance registry.
+  const rootReceiver = {};
   const callableCache = new WeakMap<object, WeakMap<Function, (...args: unknown[]) => unknown>>();
 
   const wrapCallable = (
     value: (...args: unknown[]) => unknown,
-    receiver: object
+    receiver: object,
+    currentReceiver: () => object = () => receiver
   ): ((...args: unknown[]) => unknown) => {
     let receiverCache = callableCache.get(receiver);
     if (!receiverCache) {
@@ -54,7 +57,7 @@ export function createScopedExposesReader(
 
       let result: unknown;
       invoke(() => {
-        result = Reflect.apply(value, receiver, args);
+        result = Reflect.apply(value, currentReceiver(), args);
       });
       return result;
     };
@@ -120,7 +123,17 @@ export function createScopedExposesReader(
       // consumers but is never part of the App Maker expose record.
       if (key.startsWith('__collection')) continue;
       if (!isAppMakerExposeRecordEntry(value)) continue;
-      defineEntry(target, key, wrapValue(value, source, seen));
+      defineEntry(
+        target,
+        key,
+        source === lastRaw && typeof value === 'function'
+          ? wrapCallable(
+              value as (...args: unknown[]) => unknown,
+              rootReceiver,
+              () => lastRaw ?? source
+            )
+          : wrapValue(value, source, seen)
+      );
     }
   }
 

--- a/packages/adapters/base/test/contract/expose-record.v0.contract.test.ts
+++ b/packages/adapters/base/test/contract/expose-record.v0.contract.test.ts
@@ -148,3 +148,25 @@ describe('adapter-base contract: expose record (v0)', () => {
     expect(snapshot.authorValue).not.toBe(authorValue);
   });
 });
+
+describe('replacement expose snapshot callable identity', () => {
+  it('retains root callables with current receiver while distinguishing nested receivers', () => {
+    const reader = createScopedExposesReader(() => (fn) => fn());
+    function readLabel(this: { label: string }) {
+      return this.label;
+    }
+    const a = { label: 'nested-a', readLabel };
+    const b = { label: 'nested-b', readLabel };
+    const first = reader.read({ label: 'first', readLabel, a, b });
+    const next = reader.read({ label: 'next', readLabel, a, b });
+    expect(next.readLabel).toBe(first.readLabel);
+    expect((first.readLabel as () => string)()).toBe('next');
+    const nestedA = next.a as typeof a,
+      nestedB = next.b as typeof b;
+    expect(nestedA.readLabel).not.toBe(nestedB.readLabel);
+    expect(nestedA.readLabel()).toBe('nested-a');
+    expect(nestedB.readLabel()).toBe('nested-b');
+    reader.invalidate();
+    expect(() => (first.readLabel as () => string)()).toThrow(/terminal disposal/);
+  });
+});

--- a/packages/adapters/base/test/fixtures/context-conformance.ts
+++ b/packages/adapters/base/test/fixtures/context-conformance.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { createContextKey, definePrototype, type Prototype } from '@proto.ui/core';
+
+export type ContextTree = { proto: Prototype; children?: ContextTree[] };
+export type ContextMount = {
+  host: HTMLElement;
+  flush(): Promise<void>;
+  click(target: HTMLElement): Promise<void>;
+  unmount(): Promise<void>;
+};
+
+// C-CONTEXT-0003/0004/0006/0007/0010/0012. Each driver mounts real
+// framework owners; only host composition differs, never Context semantics.
+export function contextAdapterConformance(
+  name: string,
+  mount: (tree: ContextTree[]) => Promise<ContextMount>
+) {
+  describe(`${name}: Context owner and ancestry translation`, () => {
+    it('T-CONTEXT-0003-CASE-ADAPTER: resolves nested scopes and isolates fresh owners after teardown', async () => {
+      const key = createContextKey<{ value: number }>('shared-context');
+      const otherKey = createContextKey<{ value: number }>('shared-context');
+      const transitions: Array<[string, number, number]> = [];
+      let setupCount = 0;
+      const proto = (label: string, initial?: number, optional = false) =>
+        definePrototype({
+          name: `context-${name}-${label}`,
+          setup(def) {
+            setupCount++;
+            if (initial !== undefined) def.context.provide(key, { value: initial });
+            const changed = (
+              run: { update(): void },
+              next: { value: number } | null,
+              prev: { value: number } | null
+            ) => {
+              if (next && prev) transitions.push([label, prev.value, next.value]);
+              run.update();
+            };
+            if (optional) def.context.trySubscribe(key, changed);
+            else def.context.subscribe(key, changed);
+            // Equal debug names never merge ContextKey identity.
+            def.context.trySubscribe(otherKey);
+            if (initial === undefined)
+              def.event.on('press.commit', (run) => {
+                if (optional) run.context.tryUpdate(key, (prev) => ({ value: prev.value + 1 }));
+                else run.context.update(key, (prev) => ({ value: prev.value + 1 }));
+              });
+            return (r) => {
+              const value = optional ? r.read.context.tryRead(key) : r.read.context.read(key);
+              const other = r.read.context.tryRead(otherKey);
+              return [
+                r.el(
+                  'span',
+                  `${label}=${value?.value ?? 'absent'}:${other === null ? 'isolated' : 'leaked'}`
+                ),
+                r.slot(),
+              ];
+            };
+          },
+        });
+      const outer = proto('outer', 1);
+      const inner = proto('inner', 10);
+      const leaf = proto('leaf');
+      const sibling = proto('sibling');
+      const orphan = proto('orphan', undefined, true);
+      const tree = [
+        {
+          proto: outer,
+          children: [{ proto: inner, children: [{ proto: leaf }] }, { proto: sibling }],
+        },
+        { proto: orphan },
+      ];
+      for (let generation = 0; generation < 2; generation++) {
+        const mounted = await mount(tree);
+        const read = (label: string) =>
+          Array.from(mounted.host.querySelectorAll('span')).find((el) =>
+            el.textContent?.startsWith(`${label}=`)
+          );
+        const activate = async (label: string) => {
+          const root = read(label)?.closest<HTMLElement>('[data-pui-root]');
+          if (!root) throw new Error(`Missing ${label} owner`);
+          await mounted.click(root);
+          await mounted.flush();
+        };
+        try {
+          await mounted.flush();
+          expect(setupCount).toBe((generation + 1) * 5);
+          expect(read('outer')?.textContent?.split('=')[1]).toBe('1:isolated');
+          expect(read('inner')?.textContent?.split('=')[1]).toBe('10:isolated');
+          expect(read('leaf')?.textContent?.split('=')[1]).toBe('10:isolated');
+          expect(read('sibling')?.textContent?.split('=')[1]).toBe('1:isolated');
+          expect(read('orphan')?.textContent?.split('=')[1]).toBe('absent:isolated');
+          transitions.length = 0;
+          await activate('leaf');
+          expect(read('leaf')?.textContent?.split('=')[1]).toBe('11:isolated');
+          expect(read('inner')?.textContent?.split('=')[1]).toBe('11:isolated');
+          expect(read('outer')?.textContent?.split('=')[1]).toBe('1:isolated');
+          expect(transitions).toEqual([
+            ['inner', 10, 11],
+            ['leaf', 10, 11],
+          ]);
+          transitions.length = 0;
+          await activate('sibling');
+          expect(read('outer')?.textContent?.split('=')[1]).toBe('2:isolated');
+          expect(read('sibling')?.textContent?.split('=')[1]).toBe('2:isolated');
+          expect(read('inner')?.textContent?.split('=')[1]).toBe('11:isolated');
+          expect(transitions).toEqual([
+            ['outer', 1, 2],
+            ['sibling', 1, 2],
+          ]);
+          transitions.length = 0;
+          await activate('orphan');
+          expect(transitions).toEqual([]);
+          expect(read('orphan')?.textContent?.split('=')[1]).toBe('absent:isolated');
+        } finally {
+          await mounted.unmount();
+        }
+      }
+    });
+  });
+}

--- a/packages/adapters/react/test/context.integration.test.ts
+++ b/packages/adapters/react/test/context.integration.test.ts
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { createReactAdapter } from '../src';
+import {
+  contextAdapterConformance,
+  type ContextTree,
+} from '../../base/test/fixtures/context-conformance';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+contextAdapterConformance('react', async (tree) => {
+  const host = document.createElement('div');
+  document.body.append(host);
+  const root = createRoot(host);
+  const adapt = createReactAdapter(React);
+  const render = (node: ContextTree): React.ReactNode =>
+    React.createElement(
+      adapt(node.proto),
+      { key: node.proto.name },
+      ...(node.children ?? []).map(render)
+    );
+  await act(async () =>
+    root.render(React.createElement(React.Fragment, null, ...tree.map(render)))
+  );
+  return {
+    host,
+    async flush() {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    },
+    async click(target) {
+      await act(async () => {
+        target.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+    },
+    async unmount() {
+      await act(async () => root.unmount());
+      host.remove();
+    },
+  };
+});

--- a/packages/adapters/vue/test/context.integration.test.ts
+++ b/packages/adapters/vue/test/context.integration.test.ts
@@ -1,0 +1,35 @@
+import { createVueAdapter } from '../src/adapt';
+import { VueAny, flushVue } from './utils/vue';
+import {
+  contextAdapterConformance,
+  type ContextTree,
+} from '../../base/test/fixtures/context-conformance';
+
+contextAdapterConformance('vue', async (tree) => {
+  const host = document.createElement('div');
+  document.body.append(host);
+  const adapt = createVueAdapter(VueAny);
+  const render = (node: ContextTree): unknown => {
+    const component = adapt(node.proto);
+    const children = (node.children ?? []).map(render);
+    return VueAny.h(component, { key: node.proto.name }, () => children);
+  };
+  const nodes = tree.map(render);
+  const app = VueAny.createApp({ render: () => VueAny.h('div', nodes) });
+  app.mount(host);
+  return {
+    host,
+    async flush() {
+      await flushVue();
+      await flushVue();
+    },
+    async click(target) {
+      target.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    },
+    async unmount() {
+      app.unmount();
+      await flushVue();
+      host.remove();
+    },
+  };
+});

--- a/packages/adapters/vue2/test/catalog-conformance.test.ts
+++ b/packages/adapters/vue2/test/catalog-conformance.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createContextKey, definePrototype } from '@proto.ui/core';
+import { createVue2Adapter } from '../src/adapt';
+import { Vue2Any, Vue2RuntimeAny, createMountedVue2Adapter, flushVue2 } from './utils/vue2';
+
+describe('Vue 2 catalog follow-through', () => {
+  it('projects default-action requests and stops global delivery at destroy', async () => {
+    const global = vi.fn();
+    const proto = definePrototype({
+      name: 'vue2-catalog-events',
+      setup(def) {
+        def.event.on('press.commit', (_run, event) =>
+          event.control.requestDefaultActionPrevention()
+        );
+        def.event.onGlobal('key.down', global);
+        return (r) => r.el('span', 'events');
+      },
+    });
+    const mounted = createMountedVue2Adapter(proto);
+    try {
+      await flushVue2();
+      const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+      mounted.root!.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(true);
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(global).toHaveBeenCalledOnce();
+    } finally {
+      mounted.unmount();
+    }
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(global).toHaveBeenCalledOnce();
+  });
+
+  it('retains Context, State and Expose identity across keep-alive and clears terminal records', async () => {
+    const key = createContextKey<{ value: number }>('vue2-retained-context');
+    let setups = 0;
+    const proto = definePrototype({
+      name: 'vue2-catalog-retained',
+      setup(def) {
+        setups++;
+        const count = def.state.numberDiscrete('count', 0);
+        def.expose.state('count', count);
+        def.expose.method('increment', () => count.set(count.get() + 1, 'reason: app update'));
+        def.context.provide(key, { value: 0 });
+        def.context.subscribe(key);
+        def.lifecycle.onMounted((run) =>
+          run.context.update(key, (prev) => ({ value: prev.value + 1 }))
+        );
+        return (r) => r.el('span', String(r.read.context.read(key).value));
+      },
+    });
+    const Component = createVue2Adapter(Vue2RuntimeAny)(proto);
+    const active = Vue2Any.observable({ value: true });
+    const host = document.createElement('div');
+    document.body.append(host);
+    const App = Vue2Any.extend({
+      render(h: (type: unknown, props?: unknown, children?: unknown[]) => unknown) {
+        return h(
+          'keep-alive',
+          {},
+          active.value ? [h(Component, { key: 'owner', ref: 'target' })] : []
+        );
+      },
+    });
+    const vm = new App().$mount();
+    host.append(vm.$el);
+    try {
+      await flushVue2();
+      const target = vm.$refs.target;
+      const first = target.getExposes();
+      const count = first.count;
+      const increment = first.increment;
+      const seen = vi.fn();
+      const off = count.subscribe(seen);
+      expect(count.set).toBeUndefined();
+      first.injected = true;
+      expect(target.getExposes()).not.toHaveProperty('injected');
+      increment();
+      expect(count.get()).toBe(1);
+      expect(seen).toHaveBeenCalledOnce();
+      expect(target.$el.textContent).toBe('0'); // Context update alone does not render.
+      target.update();
+      await flushVue2();
+      expect(target.$el.textContent).toBe('1');
+      const beforeDetach = target.getExposes().increment;
+      active.value = false;
+      await flushVue2();
+      expect(target.getExposes().count).toBe(count);
+      expect(target.getExposes().increment).toBe(beforeDetach);
+      active.value = true;
+      await flushVue2();
+      await flushVue2();
+      expect(vm.$refs.target).toBe(target);
+      expect(setups).toBe(1);
+      expect(target.getExposes().count).toBe(count);
+      expect(count.get()).toBe(1);
+      target.update();
+      await flushVue2();
+      expect(target.$el.textContent).toBe('2');
+      off();
+      vm.$destroy();
+      await flushVue2();
+      expect(target.getExposes()).toEqual({});
+      expect(() => increment()).toThrow(/terminal disposal/);
+    } finally {
+      vm.$destroy();
+      host.remove();
+    }
+  });
+
+  it('uses current outward listeners and keeps signal declarations and listeners out of public data', async () => {
+    const old = vi.fn(),
+      current = vi.fn(),
+      vueListener = vi.fn();
+    let raw: unknown;
+    const proto = definePrototype({
+      name: 'vue2-catalog-signal',
+      setup(def) {
+        def.expose.event('save', { payload: 'json' });
+        def.lifecycle.onMounted((run) => {
+          raw = run.props.getRaw();
+        });
+        def.event.on('press.commit', (run) => run.expose.emit('save', { saved: true }));
+        return (r) => r.el('span', 'save');
+      },
+    });
+    const Component = createVue2Adapter(Vue2RuntimeAny)(proto);
+    const state = Vue2Any.observable({ listener: old });
+    const host = document.createElement('div');
+    document.body.append(host);
+    const App = Vue2Any.extend({
+      render(h: (type: unknown, props: unknown) => unknown) {
+        return h(Component, {
+          ref: 'target',
+          attrs: { onSave: state.listener },
+          on: { save: vueListener },
+        });
+      },
+    });
+    const vm = new App().$mount();
+    host.append(vm.$el);
+    try {
+      await flushVue2();
+      expect(raw).not.toHaveProperty('onSave');
+      expect(vm.$refs.target.getExposes()).not.toHaveProperty('save');
+      vm.$refs.target.$el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(old).toHaveBeenCalledOnce();
+      state.listener = current;
+      await flushVue2();
+      expect(current).not.toHaveBeenCalled(); // No replay on listener replacement.
+      vm.$refs.target.$el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(old).toHaveBeenCalledOnce();
+      expect(current).toHaveBeenCalledWith({ saved: true }, undefined);
+      expect(vueListener).toHaveBeenCalledTimes(2);
+    } finally {
+      vm.$destroy();
+      host.remove();
+    }
+  });
+});

--- a/packages/adapters/vue2/test/context.integration.test.ts
+++ b/packages/adapters/vue2/test/context.integration.test.ts
@@ -1,0 +1,43 @@
+import { createVue2Adapter } from '../src/adapt';
+import { Vue2Any, Vue2RuntimeAny, flushVue2 } from './utils/vue2';
+import {
+  contextAdapterConformance,
+  type ContextTree,
+} from '../../base/test/fixtures/context-conformance';
+
+contextAdapterConformance('vue2', async (tree) => {
+  const host = document.createElement('div');
+  document.body.append(host);
+  const adapt = createVue2Adapter(Vue2RuntimeAny);
+  const components = new Map(
+    tree
+      .flatMap(function flatten(node): ContextTree[] {
+        return [node, ...(node.children ?? []).flatMap(flatten)];
+      })
+      .map((node) => [node.proto, adapt(node.proto)])
+  );
+  const App = Vue2Any.extend({
+    render(h: (component: unknown, data: unknown, children?: unknown[]) => unknown) {
+      const render = (node: ContextTree): unknown =>
+        h(components.get(node.proto), { key: node.proto.name }, (node.children ?? []).map(render));
+      return h('div', {}, tree.map(render));
+    },
+  });
+  const vm = new App().$mount();
+  host.append(vm.$el);
+  return {
+    host,
+    async flush() {
+      await flushVue2();
+      await flushVue2();
+    },
+    async click(target) {
+      target.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    },
+    async unmount() {
+      vm.$destroy();
+      await flushVue2();
+      host.remove();
+    },
+  };
+});

--- a/packages/adapters/vue2/test/contract/props-host-source.v0.contract.test.ts
+++ b/packages/adapters/vue2/test/contract/props-host-source.v0.contract.test.ts
@@ -1,0 +1,40 @@
+import { describeAdapterPropsHostSourceConformance } from '../../../base/test-utils/props-host-source';
+import { createVue2Adapter } from '../../src/adapt';
+import { Vue2Any, Vue2RuntimeAny, flushVue2 } from '../utils/vue2';
+
+describeAdapterPropsHostSourceConformance({
+  adapterName: 'adapter-vue2',
+  watchValuesAfterHostUpdate: [2],
+  async mount(proto, props) {
+    const Component = createVue2Adapter(Vue2RuntimeAny)(proto, { autoUpdateOnPropsChange: false });
+    const state = Vue2Any.observable({ props: { ...props } });
+    const host = document.createElement('div');
+    document.body.append(host);
+    const Root = Vue2Any.extend({
+      render(h: (type: unknown, data: unknown) => unknown) {
+        return h(Component, { attrs: state.props, ref: 'target' });
+      },
+    });
+    const vm = new Root().$mount();
+    host.append(vm.$el);
+    await flushVue2();
+    return {
+      async updateHostProps(next) {
+        state.props = { ...next };
+        await flushVue2();
+      },
+      async syncRuntime() {
+        vm.$refs.target.update();
+        await flushVue2();
+      },
+      readRenderedValue() {
+        return host.firstElementChild?.textContent ?? null;
+      },
+      async unmount() {
+        vm.$destroy();
+        await flushVue2();
+        host.remove();
+      },
+    };
+  },
+});

--- a/packages/adapters/vue2/test/contract/props-normalization.v0.contract.test.ts
+++ b/packages/adapters/vue2/test/contract/props-normalization.v0.contract.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { definePrototype } from '@proto.ui/core';
+
+import { createVue2Adapter } from '../../src/adapt';
+import type { Vue2AdapterOptions } from '../../src/adapt';
+import type { Prototype } from '@proto.ui/core';
+import { mountVue2Adapter, Vue2RuntimeAny, flushVue2 } from '../utils/vue2';
+function mount(
+  proto: Prototype,
+  options: Vue2AdapterOptions<Record<string, unknown>>,
+  props: Record<string, unknown>
+) {
+  return mountVue2Adapter(createVue2Adapter(Vue2RuntimeAny)(proto, options), props);
+}
+
+describe('adapter-vue2: Props normalization contract', () => {
+  it('combines component props and attrs before excluding presentation fields and listeners', async () => {
+    let raw: Readonly<Record<string, unknown>> = {};
+
+    const proto = definePrototype({
+      name: 'vue2-props-normalization-default',
+      setup(def) {
+        def.props.define({ label: { type: 'string', default: 'fallback' } });
+        def.lifecycle.onMounted((run) => {
+          raw = { ...run.props.getRaw() };
+        });
+        return (renderer) => [String(renderer.read.props.get().label)];
+      },
+    });
+
+    const mounted = mount(
+      proto,
+      {},
+      {
+        label: 'kept',
+        class: 'consumer-class',
+        hostClass: 'host-class',
+        surfaceClass: 'surface-class',
+        style: { color: 'red' },
+        hostStyle: { margin: '1px' },
+        surfaceStyle: { padding: '2px' },
+        onCheckedChange: () => {},
+      }
+    );
+    await flushVue2();
+
+    expect(raw).toEqual({ label: 'kept' });
+    mounted.unmount();
+  });
+
+  it('passes merged component props and attrs to an explicit replacement getProps option', async () => {
+    let raw: Readonly<Record<string, unknown>> = {};
+
+    const proto = definePrototype({
+      name: 'vue2-props-normalization-custom',
+      setup(def) {
+        def.props.define({
+          label: { type: 'string', default: 'fallback' },
+          classifiedClass: { type: 'string', default: 'missing' },
+          classifiedHostClass: { type: 'string', default: 'missing' },
+          listenerType: { type: 'string', default: 'missing' },
+        });
+        def.lifecycle.onMounted((run) => {
+          raw = { ...run.props.getRaw() };
+        });
+        return (renderer) => [String(renderer.read.props.get().label)];
+      },
+    });
+
+    const mounted = mount(
+      proto,
+      {
+        getProps(props: Record<string, unknown>) {
+          return {
+            label: `custom:${String(props.label)}`,
+            classifiedClass: String(props.class),
+            classifiedHostClass: String(props.hostClass),
+            listenerType: typeof props.onCheckedChange,
+          };
+        },
+      },
+      {
+        label: 'input',
+        class: 'selected-class',
+        hostClass: 'selected-host-class',
+        onCheckedChange: () => {},
+      }
+    );
+    await flushVue2();
+
+    expect(raw).toEqual({
+      label: 'custom:input',
+      classifiedClass: 'selected-class',
+      classifiedHostClass: 'selected-host-class',
+      listenerType: 'function',
+    });
+    mounted.unmount();
+  });
+});

--- a/packages/adapters/web-component/test/context.integration.test.ts
+++ b/packages/adapters/web-component/test/context.integration.test.ts
@@ -1,0 +1,31 @@
+import { AdaptToWebComponent } from '../src';
+import {
+  contextAdapterConformance,
+  type ContextTree,
+} from '../../base/test/fixtures/context-conformance';
+
+contextAdapterConformance('wc', async (tree) => {
+  const host = document.createElement('div');
+  const render = (node: ContextTree): HTMLElement => {
+    if (!customElements.get(node.proto.name)) AdaptToWebComponent(node.proto);
+    const el = document.createElement(node.proto.name);
+    el.append(...(node.children ?? []).map(render));
+    return el;
+  };
+  host.append(...tree.map(render));
+  document.body.append(host);
+  const flush = async () => {
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+  };
+  return {
+    host,
+    flush,
+    async click(target) {
+      target.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    },
+    async unmount() {
+      host.remove();
+      await flush();
+    },
+  };
+});

--- a/packages/modules/context/src/center.ts
+++ b/packages/modules/context/src/center.ts
@@ -116,7 +116,7 @@ export class ContextCenter {
     if (!byKey) return null;
 
     let cur: ContextInstanceToken | null = consumer;
-    while (cur) {
+    while (cur !== null) {
       if (byKey.has(cur)) return cur;
       cur = getParent(cur);
     }
@@ -155,7 +155,7 @@ export class ContextCenter {
     getParent: ContextParentGetter
   ): boolean {
     const provider = this.resolveProvider(consumer, key, getParent);
-    if (!provider) return false;
+    if (provider === null) return false;
 
     this.updateFromProvider(provider, key, next, ctx, getParent);
     return true;
@@ -176,7 +176,8 @@ export class ContextCenter {
       if (!rec || rec.callbacks.length === 0) continue;
 
       const bound = this.resolveProvider(instance, key, getParent);
-      if (bound !== provider) continue;
+      // Match the SameValueZero identity used by the provider Map (including NaN).
+      if (bound !== provider && !Object.is(bound, provider)) continue;
 
       const task: ContextCallbackTask = {
         instance,

--- a/packages/modules/context/src/create.ts
+++ b/packages/modules/context/src/create.ts
@@ -34,7 +34,7 @@ export function createContextModule(ctx: ModuleFactoryArgs): ContextModule {
         },
         port: {
           setCallbackDispatcher: (dispatch) => impl.setCallbackDispatcher(dispatch),
-          resolveScope: (key, consumer) => impl.resolveScope(key, consumer),
+          resolveScope: (...args) => impl.resolveScope(...args),
           dumpProviders: () => impl.portDumpProviders(),
           dumpSubscriptions: () => impl.portDumpSubscriptions(),
           dumpCallbackQueue: () => impl.portDumpCallbackQueue(),

--- a/packages/modules/context/src/impl.ts
+++ b/packages/modules/context/src/impl.ts
@@ -307,7 +307,7 @@ export class ContextModuleImpl extends ModuleBase {
   }
 
   resolveScope(key: ContextKey<any>, consumer?: ContextInstanceToken): ContextInstanceToken | null {
-    const from = arguments.length < 2 ? this.tryGetSelfToken() : consumer;
+    const from = arguments.length < 2 ? this.getSelfToken() : consumer;
     if (from === null) return null;
     return CONTEXT_CENTER.resolveProvider(from, key, this.getParentGetter());
   }

--- a/packages/modules/context/src/impl.ts
+++ b/packages/modules/context/src/impl.ts
@@ -307,7 +307,7 @@ export class ContextModuleImpl extends ModuleBase {
   }
 
   resolveScope(key: ContextKey<any>, consumer?: ContextInstanceToken): ContextInstanceToken | null {
-    const from = consumer ?? this.tryGetSelfToken();
+    const from = arguments.length < 2 ? this.tryGetSelfToken() : consumer;
     if (from === null) return null;
     return CONTEXT_CENTER.resolveProvider(from, key, this.getParentGetter());
   }

--- a/packages/modules/context/src/impl.ts
+++ b/packages/modules/context/src/impl.ts
@@ -115,7 +115,7 @@ export class ContextModuleImpl extends ModuleBase {
     const getParent = this.getParentGetter();
 
     const provider = CONTEXT_CENTER.resolveProvider(self, key, getParent);
-    if (!provider) {
+    if (provider === null) {
       throw contextError(
         ERR.PROVIDER_MISSING,
         `[Context] provider missing for key: ${key?.debugName ?? '(unknown)'}`
@@ -183,7 +183,7 @@ export class ContextModuleImpl extends ModuleBase {
 
     const getParent = this.getParentGetter();
     const provider = CONTEXT_CENTER.resolveProvider(self, key, getParent);
-    if (!provider) {
+    if (provider === null) {
       throw contextError(
         ERR.DISCONNECTED,
         `[Context] provider missing for key: ${key?.debugName ?? '(unknown)'}`
@@ -209,7 +209,7 @@ export class ContextModuleImpl extends ModuleBase {
 
     const getParent = this.getParentGetter();
     const provider = CONTEXT_CENTER.resolveProvider(self, key, getParent);
-    if (!provider) return null;
+    if (provider === null) return null;
 
     return (CONTEXT_CENTER.getProviderValue(provider, key) as T) ?? null;
   }
@@ -225,7 +225,7 @@ export class ContextModuleImpl extends ModuleBase {
 
     const getParent = this.getParentGetter();
     const provider = selfProvidesKey ? self : CONTEXT_CENTER.resolveProvider(self, key, getParent);
-    if (!provider) {
+    if (provider === null) {
       throw contextError(
         ERR.DISCONNECTED,
         `[Context] provider missing for key: ${key?.debugName ?? '(unknown)'}`
@@ -255,7 +255,7 @@ export class ContextModuleImpl extends ModuleBase {
 
     const getParent = this.getParentGetter();
     const provider = CONTEXT_CENTER.resolveProvider(self, key, getParent);
-    if (!provider) return false;
+    if (provider === null) return false;
 
     const prev = CONTEXT_CENTER.getProviderValue(provider, key);
     if (!prev) return false;
@@ -281,7 +281,7 @@ export class ContextModuleImpl extends ModuleBase {
 
   dispose(): void {
     const self = this.tryGetSelfToken();
-    if (self) {
+    if (self !== null) {
       CONTEXT_CENTER.removeInstance(self);
     }
   }
@@ -308,7 +308,7 @@ export class ContextModuleImpl extends ModuleBase {
 
   resolveScope(key: ContextKey<any>, consumer?: ContextInstanceToken): ContextInstanceToken | null {
     const from = consumer ?? this.tryGetSelfToken();
-    if (!from) return null;
+    if (from === null) return null;
     return CONTEXT_CENTER.resolveProvider(from, key, this.getParentGetter());
   }
 
@@ -385,7 +385,11 @@ export class ContextModuleImpl extends ModuleBase {
       );
     }
 
-    return this.caps.get(CONTEXT_INSTANCE_TOKEN_CAP) as ContextInstanceToken;
+    const token = this.caps.get(CONTEXT_INSTANCE_TOKEN_CAP);
+    if (token === null) {
+      throw contextError(ERR.PROVIDER_MISSING, '[Context] host caps invalid: null instance token');
+    }
+    return token as ContextInstanceToken;
   }
 
   private tryGetSelfToken(): ContextInstanceToken | null {

--- a/packages/modules/context/src/types.ts
+++ b/packages/modules/context/src/types.ts
@@ -62,7 +62,7 @@ export type ContextCallbackTask = {
 export type ContextPort = {
   setCallbackDispatcher(dispatch: ContextCallbackDispatcher): void;
   /** Module-internal logical scope identity. Never place this token in a Context value. */
-  /** Omission uses the owner; an explicit consumer (including undefined) is preserved. */
+  /** Omission validates the owner identity; an explicit consumer (including undefined) is preserved. */
   resolveScope(key: ContextKey<any>, consumer?: ContextInstanceToken): ContextInstanceToken | null;
   dumpProviders(): readonly ContextProviderEntry[];
   dumpSubscriptions(): readonly ContextSubscriptionEntry[];

--- a/packages/modules/context/src/types.ts
+++ b/packages/modules/context/src/types.ts
@@ -62,6 +62,7 @@ export type ContextCallbackTask = {
 export type ContextPort = {
   setCallbackDispatcher(dispatch: ContextCallbackDispatcher): void;
   /** Module-internal logical scope identity. Never place this token in a Context value. */
+  /** Omission uses the owner; an explicit consumer (including undefined) is preserved. */
   resolveScope(key: ContextKey<any>, consumer?: ContextInstanceToken): ContextInstanceToken | null;
   dumpProviders(): readonly ContextProviderEntry[];
   dumpSubscriptions(): readonly ContextSubscriptionEntry[];

--- a/packages/modules/context/test/catalog-boundary.test.ts
+++ b/packages/modules/context/test/catalog-boundary.test.ts
@@ -109,6 +109,51 @@ describe('Context capability boundary', () => {
     expect(seen).toEqual([11]);
   });
 
+  it.each([0, false, '', undefined, NaN])(
+    'T-CONTEXT-0003-CASE-OPAQUE-TOKEN: resolves, updates and disposes opaque token %s',
+    (token) => {
+      const key = createContextKey<{ value: number }>('falsy-owner');
+      const childToken = {};
+      const getParent = (instance: unknown) => (instance === childToken ? token : null);
+      const providerSys = createSysCaps(),
+        consumerSys = createSysCaps();
+      const provider = create(makeCaps({ sys: providerSys, instanceToken: token, getParent }));
+      const consumer = create(makeCaps({ sys: consumerSys, instanceToken: childToken, getParent }));
+      const received: number[] = [];
+      provider.provide(key, { value: 1 });
+      try {
+        provider.subscribe(key);
+        consumer.trySubscribe(key, (_run, next) => received.push(next!.value));
+        expect(provider.resolveScope(key)).toBe(token);
+        expect(consumer.resolveScope(key)).toBe(token);
+        providerSys.__setExecPhase('callback');
+        consumerSys.__setExecPhase('callback');
+        expect(provider.read(key)).toEqual({ value: 1 });
+        expect(consumer.tryRead(key)).toEqual({ value: 1 });
+        provider.update(key, { value: 2 });
+        consumer.update(key, { value: 3 });
+        expect(consumer.tryUpdate(key, { value: 4 })).toBe(true);
+        expect(
+          CONTEXT_CENTER.updateFromConsumer(childToken, key, { value: 5 }, null, getParent)
+        ).toBe(true);
+        expect(received).toEqual([2, 3, 4, 5]);
+      } finally {
+        provider.dispose();
+        expect(CONTEXT_CENTER.dumpProviders().filter((row) => row.key === key)).toEqual([]);
+        expect(
+          CONTEXT_CENTER.dumpSubscriptions().some(
+            (row) => row.key === key && Object.is(row.instance, token)
+          )
+        ).toBe(false);
+      }
+      expect(consumer.tryRead(key)).toBeNull();
+      expect(consumer.tryUpdate(key, { value: 6 })).toBe(false);
+      expect(
+        CONTEXT_CENTER.updateFromConsumer(childToken, key, { value: 6 }, null, getParent)
+      ).toBe(false);
+    }
+  );
+
   it('T-CONTEXT-0003-CASE-AVAILABILITY: fails at capability use without inventing an ancestry fallback', () => {
     const key = createContextKey<{ value: number }>('missing-cap');
     const full = makeCaps({ instanceToken: {}, getParent: () => null }) as CapsVaultView;
@@ -116,6 +161,8 @@ describe('Context capability boundary', () => {
       ...full,
       has: (token) => token.id !== id && full.has(token),
     });
+    const nullIdentity = create(makeCaps({ instanceToken: null, getParent: () => null }));
+    expect(() => nullIdentity.provide(key, { value: 0 })).toThrow(/null instance token/);
     const noIdentity = create(missing(CONTEXT_INSTANCE_TOKEN_CAP.id));
     expect(() => noIdentity.provide(key, { value: 0 })).toThrow(/instance token/);
     const noParent = create(missing(CONTEXT_PARENT_CAP.id));

--- a/packages/modules/context/test/catalog-boundary.test.ts
+++ b/packages/modules/context/test/catalog-boundary.test.ts
@@ -109,6 +109,39 @@ describe('Context capability boundary', () => {
     expect(seen).toEqual([11]);
   });
 
+  it('T-CONTEXT-0003-CASE-EXPLICIT-CONSUMER: distinguishes omission, undefined and null through the actual port', () => {
+    const key = createContextKey<{ value: number }>('explicit-consumer');
+    const owner = {},
+      elsewhere = {};
+    const getParent = (token: unknown) => (token === undefined ? elsewhere : null);
+    const ancestor = create(makeCaps({ instanceToken: elsewhere, getParent }));
+    ancestor.provide(key, { value: 2 });
+    const module = createContextModule({
+      init: { prototypeName: 'port-owner', declarations: [] },
+      caps: makeCaps({ instanceToken: owner, getParent }),
+      deps: {
+        requireFacade() {
+          throw new Error('unexpected');
+        },
+        requirePort() {
+          throw new Error('unexpected');
+        },
+        tryFacade: () => undefined,
+        tryPort: () => undefined,
+      },
+    });
+    const port = (module as typeof module & { port: ContextPort }).port;
+    try {
+      module.facade.provide(key, { value: 1 });
+      expect(port.resolveScope(key)).toBe(owner);
+      expect(port.resolveScope(key, undefined)).toBe(elsewhere);
+      expect(port.resolveScope(key, null)).toBeNull();
+      expect(port.resolveScope(key, {})).toBeNull();
+    } finally {
+      module.hooks.dispose?.();
+    }
+  });
+
   it.each([0, false, '', undefined, NaN])(
     'T-CONTEXT-0003-CASE-OPAQUE-TOKEN: resolves, updates and disposes opaque token %s',
     (token) => {

--- a/packages/modules/context/test/catalog-boundary.test.ts
+++ b/packages/modules/context/test/catalog-boundary.test.ts
@@ -187,6 +187,49 @@ describe('Context capability boundary', () => {
     }
   );
 
+  it.each(['missing identity', 'null identity', 'missing ancestry'] as const)(
+    'T-CONTEXT-0003-CASE-AVAILABILITY: actual port diagnoses %s for omitted-owner resolution',
+    (scenario) => {
+      const key = createContextKey<{ value: number }>('port-capability-diagnostic');
+      const full = makeCaps({
+        instanceToken: scenario === 'null identity' ? null : {},
+        getParent: () => null,
+      }) as CapsVaultView;
+      const absentId =
+        scenario === 'missing identity'
+          ? CONTEXT_INSTANCE_TOKEN_CAP.id
+          : scenario === 'missing ancestry'
+            ? CONTEXT_PARENT_CAP.id
+            : null;
+      const module = createContextModule({
+        init: { prototypeName: 'port-capability-diagnostic', declarations: [] },
+        caps: { ...full, has: (token) => token.id !== absentId && full.has(token) },
+        deps: {
+          requireFacade() {
+            throw new Error('unexpected');
+          },
+          requirePort() {
+            throw new Error('unexpected');
+          },
+          tryFacade: () => undefined,
+          tryPort: () => undefined,
+        },
+      });
+      const port = (module as typeof module & { port: ContextPort }).port;
+      try {
+        // Explicit absence needs neither the owner's identity nor traversal.
+        expect(port.resolveScope(key, null)).toBeNull();
+        expect(() => port.resolveScope(key)).toThrow(
+          scenario === 'missing ancestry' ? /parent getter/ : /instance token/
+        );
+        // An explicit valid consumer does not need the miswired owner's identity.
+        if (scenario !== 'missing ancestry') expect(port.resolveScope(key, {})).toBeNull();
+      } finally {
+        module.hooks.dispose?.();
+      }
+    }
+  );
+
   it('T-CONTEXT-0003-CASE-AVAILABILITY: fails at capability use without inventing an ancestry fallback', () => {
     const key = createContextKey<{ value: number }>('missing-cap');
     const full = makeCaps({ instanceToken: {}, getParent: () => null }) as CapsVaultView;

--- a/packages/modules/context/test/catalog-boundary.test.ts
+++ b/packages/modules/context/test/catalog-boundary.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createContextKey, type CapsVaultView } from '@proto.ui/core';
+import { createContextModule } from '../src/create';
+import type { ContextPort } from '../src/types';
+import { ContextModuleImpl } from '../src/impl';
+import { CONTEXT_CENTER } from '../src/center';
+import { CONTEXT_INSTANCE_TOKEN_CAP, CONTEXT_PARENT_CAP } from '../src/caps';
+import { createSysCaps, makeCaps } from './utils/fake-caps';
+
+const owned: ContextModuleImpl[] = [];
+afterEach(() => {
+  for (const module of owned.splice(0)) module.dispose();
+});
+const create = (caps: CapsVaultView) => {
+  const module = new ContextModuleImpl(caps, 'context-boundary');
+  owned.push(module);
+  return module;
+};
+
+describe('Context capability boundary', () => {
+  it('T-CONTEXT-0003-CASE-SURFACE: separates author authority from privileged diagnostics', () => {
+    const sys = createSysCaps();
+    const token = {};
+    const module = createContextModule({
+      init: { prototypeName: 'context-surface', declarations: [] },
+      caps: makeCaps({ sys, instanceToken: token, getParent: () => null }),
+      deps: {
+        requireFacade() {
+          throw new Error('unexpected dependency');
+        },
+        requirePort() {
+          throw new Error('unexpected dependency');
+        },
+        tryFacade: () => undefined,
+        tryPort: () => undefined,
+      },
+    });
+    const port = (module as typeof module & { port: ContextPort }).port;
+    const key = createContextKey<{ value: number }>('surface');
+    try {
+      expect(Object.keys(module.facade).sort()).toEqual([
+        'provide',
+        'read',
+        'subscribe',
+        'tryRead',
+        'trySubscribe',
+        'tryUpdate',
+        'update',
+      ]);
+      expect(Object.keys(port).sort()).toEqual([
+        'dumpCallbackQueue',
+        'dumpProviders',
+        'dumpSubscriptions',
+        'resolveScope',
+        'setCallbackDispatcher',
+      ]);
+      module.facade.provide(key, { value: 1 });
+      expect(port.resolveScope(key)).toBe(token);
+      expect(() => module.facade.update(key, { value: 2 })).toThrow();
+      sys.__setExecPhase('callback');
+      module.facade.update(key, { value: 2 }); // Provider exception is write-only.
+      expect(port.dumpProviders().find((row) => row.instance === token)?.value).toEqual({
+        value: 2,
+      });
+      expect(() => module.facade.read(key)).toThrow();
+      expect(() => module.facade.tryUpdate(key, { value: 3 })).toThrow();
+      expect(() => module.facade.subscribe(key)).toThrow();
+    } finally {
+      module.hooks.dispose?.();
+    }
+  });
+
+  it('T-CONTEXT-0003-CASE-HOST: uses opaque identity and current ancestry for read, update and callback routing', () => {
+    const key = createContextKey<{ value: number }>('scope');
+    const a = {},
+      b = {},
+      c = {};
+    let parent: object | null = a;
+    const getParent = (token: unknown) => (token === c ? parent : null);
+    const sysA = createSysCaps(),
+      sysB = createSysCaps(),
+      sysC = createSysCaps();
+    const pA = create(makeCaps({ sys: sysA, instanceToken: a, getParent }));
+    const pB = create(makeCaps({ sys: sysB, instanceToken: b, getParent }));
+    const child = create(makeCaps({ sys: sysC, instanceToken: c, getParent }));
+    pA.provide(key, { value: 1 });
+    pB.provide(key, { value: 10 });
+    const seen: number[] = [];
+    const off = child.trySubscribe(key, (_run, next) => seen.push(next!.value));
+    for (const sys of [sysA, sysB, sysC]) sys.__setExecPhase('callback');
+    expect(child.tryRead(key)).toEqual({ value: 1 });
+    expect(child.resolveScope(key)).toBe(a);
+    parent = b;
+    expect(child.tryRead(key)).toEqual({ value: 10 });
+    expect(child.resolveScope(key)).toBe(b);
+    expect(seen).toEqual([]); // Ancestry changes are not value notifications.
+    pA.update(key, { value: 2 });
+    expect(seen).toEqual([]);
+    expect(child.tryUpdate(key, { value: 11 })).toBe(true);
+    expect(seen).toEqual([11]);
+    expect(CONTEXT_CENTER.getProviderValue(a, key)).toEqual({ value: 2 });
+    parent = null;
+    expect(child.tryRead(key)).toBeNull();
+    expect(child.tryUpdate(key, { value: 12 })).toBe(false);
+    expect(CONTEXT_CENTER.getProviderValue(b, key)).toEqual({ value: 11 });
+    parent = b;
+    off();
+    pB.update(key, { value: 13 });
+    expect(seen).toEqual([11]);
+  });
+
+  it('T-CONTEXT-0003-CASE-AVAILABILITY: fails at capability use without inventing an ancestry fallback', () => {
+    const key = createContextKey<{ value: number }>('missing-cap');
+    const full = makeCaps({ instanceToken: {}, getParent: () => null }) as CapsVaultView;
+    const missing = (id: string): CapsVaultView => ({
+      ...full,
+      has: (token) => token.id !== id && full.has(token),
+    });
+    const noIdentity = create(missing(CONTEXT_INSTANCE_TOKEN_CAP.id));
+    expect(() => noIdentity.provide(key, { value: 0 })).toThrow(/instance token/);
+    const noParent = create(missing(CONTEXT_PARENT_CAP.id));
+    // Pure declaration does not require traversal; lookup does.
+    noParent.provide(key, { value: 0 });
+    expect(() => noParent.subscribe(key)).toThrow(/parent getter/);
+  });
+});

--- a/packages/modules/scroll/src/impl.ts
+++ b/packages/modules/scroll/src/impl.ts
@@ -259,9 +259,9 @@ export class ScrollModuleImpl extends ModuleBase {
     const binding = this.composedChromeBinding;
     if (!binding) return null;
     const anatomyScope = this.anatomyPort.resolveDomainScope(binding.anatomy);
-    if (!anatomyScope) return null;
+    if (anatomyScope === null) return null;
     const scope = this.contextPort.resolveScope(binding.scope, anatomyScope);
-    if (!scope || scope !== anatomyScope) return null;
+    if (scope === null || (scope !== anatomyScope && !Object.is(scope, anatomyScope))) return null;
     const scrollbars = this.anatomyPort.order.partsOf(binding.anatomy, binding.scrollbarRole, {
       missing: 'empty',
     });

--- a/packages/modules/scroll/test/context-scope.test.ts
+++ b/packages/modules/scroll/test/context-scope.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { createAnatomyFamily, createContextKey, type AnatomyPartView } from '@proto.ui/core';
+import type { AnatomyPort } from '@proto.ui/module-anatomy';
+import { createContextModule, type ContextPort } from '@proto.ui/module-context';
+import { StateModuleImpl } from '../../state/src/impl';
+import { createSysCaps, makeCaps } from '../../context/test/utils/fake-caps';
+import { ScrollModuleImpl } from '../src/impl';
+import {
+  SCROLL_SURFACE_HOST_CAP,
+  type ScrollSurfaceHost,
+  type ScrollSurfaceHostAttachment,
+} from '../src/caps';
+
+// HC-CONTEXT-IDENTITY-0001-B; C-CONTEXT-0004-E. Anatomy supplies opaque
+// domain/target facts; real Context, State and Scroll produce the host binding.
+describe('composed Scroll Context scope identity', () => {
+  it.each([0, false, '', undefined, NaN, {}])(
+    'binds opaque scope %s and rejects absent or mismatched domains',
+    (token) => {
+      const key = createContextKey<{ value: number }>('scroll-scope');
+      const owner = {},
+        foreign = {};
+      const getParent = (instance: unknown) => (instance === foreign ? token : null);
+      const sys = createSysCaps();
+      const deps = {
+        requireFacade() {
+          throw new Error('unexpected');
+        },
+        requirePort() {
+          throw new Error('unexpected');
+        },
+        tryFacade: () => undefined,
+        tryPort: () => undefined,
+      };
+      const makeContext = (instanceToken: unknown) =>
+        createContextModule({
+          init: { prototypeName: 'scroll-scope', declarations: [] },
+          caps: makeCaps({ instanceToken, getParent }),
+          deps,
+        });
+      const provider = makeContext(token),
+        context = makeContext(owner);
+      provider.facade.provide(key, { value: 1 });
+      // A distinct port-owner scope makes undefined-to-owner fallback observable.
+      context.facade.provide(key, { value: 2 });
+      const state = new StateModuleImpl(sys);
+      const trackTarget = {},
+        thumbTarget = {};
+      const scrollbar = {
+        getExpose: () => ({ get: () => 'vertical' }),
+      } as unknown as AnatomyPartView;
+      const thumb = {} as AnatomyPartView;
+      let domain: unknown = token;
+      let refresh = () => {};
+      const anatomy = {
+        resolveDomainScope: () => domain,
+        order: { partsOf: () => [scrollbar] },
+        descendantsOf: () => [thumb],
+        resolvePartTarget: (part: AnatomyPartView) =>
+          part === scrollbar ? trackTarget : thumbTarget,
+        subscribeOrder: (_family: unknown, callback: () => void) => {
+          refresh = callback;
+          return () => {};
+        },
+        subscribeTargets: () => () => {},
+      } as unknown as AnatomyPort;
+      const attachments: ScrollSurfaceHostAttachment[] = [];
+      const host: ScrollSurfaceHost = {
+        support: { system: true, composed: true },
+        attach(connection) {
+          attachments.push(connection);
+          return {
+            update(next) {
+              attachments.push(next);
+            },
+            request() {},
+            dispose() {},
+          };
+        },
+      };
+      const base = makeCaps({ sys, instanceToken: owner, getParent });
+      const caps = {
+        ...base,
+        has: (cap: { id: string }) => cap.id === SCROLL_SURFACE_HOST_CAP.id || base.has(cap),
+        get: (cap: { id: string }) =>
+          cap.id === SCROLL_SURFACE_HOST_CAP.id ? host : base.get(cap),
+      };
+      const scroll = new ScrollModuleImpl(
+        caps,
+        'scroll-scope',
+        state.port,
+        state.facade,
+        anatomy,
+        (context as typeof context & { port: ContextPort }).port
+      );
+      const family = createAnatomyFamily('scroll-scope', {
+        roles: { root: { cardinality: { min: 1, max: 1 } } },
+      });
+      try {
+        scroll.getSurface();
+        scroll.configure({ projection: 'composed' });
+        scroll.bindComposedChrome({
+          scope: key,
+          anatomy: family,
+          scrollbarRole: 'scrollbar',
+          thumbRole: 'thumb',
+          orientationExpose: 'orientation',
+        });
+        sys.__setExecPhase('callback');
+        scroll.onMountPhase('mounted', 1);
+        const chrome = attachments.at(-1)?.composedChrome;
+        expect(chrome).toBeDefined();
+        expect(chrome!.scope).toBe(token);
+        expect(chrome!.controls).toHaveLength(1);
+        expect(chrome!.controls[0].trackTarget).toBe(trackTarget);
+        expect(chrome!.controls[0].thumbTarget).toBe(thumbTarget);
+        expect(chrome!.controls[0].getAxis()).toBe('vertical');
+        domain = null;
+        refresh();
+        expect(attachments.at(-1)?.composedChrome).toBeUndefined();
+        domain = foreign;
+        refresh();
+        expect(attachments.at(-1)?.composedChrome).toBeUndefined();
+        domain = token;
+        refresh();
+        expect(attachments.at(-1)?.composedChrome?.scope).toBe(token);
+      } finally {
+        scroll.onProtoPhase('unmounted');
+        state.dispose();
+        context.hooks.dispose?.();
+        provider.hooks.dispose?.();
+      }
+    }
+  );
+});

--- a/packages/runtime/test/contract/context-lifecycle.v1.contract.test.ts
+++ b/packages/runtime/test/contract/context-lifecycle.v1.contract.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { createContextKey, definePrototype } from '@proto.ui/core';
+import {
+  CONTEXT_INSTANCE_TOKEN_CAP,
+  CONTEXT_PARENT_CAP,
+  type ContextPort,
+} from '@proto.ui/module-context';
+import { createRuntimeSession, type RuntimeHost } from '../../src';
+
+// C-LIFECYCLE-0006 and C-CONTEXT-0012: temporary view detach is not disposal.
+describe('Context instance lifetime', () => {
+  it('T-CONTEXT-0003-CASE-LIFETIME: retains scopes and callbacks through epochs and cleans terminal owners', async () => {
+    const key = createContextKey<{ value: number }>('context-lifetime');
+    const providerToken = {};
+    const consumerToken = {};
+    const transitions: Array<[number, number]> = [];
+    let providerSetups = 0;
+    let consumerSetups = 0;
+    const provider = definePrototype({
+      name: 'context-life-provider',
+      setup(def) {
+        providerSetups++;
+        def.context.provide(key, { value: 0 });
+        def.lifecycle.onMounted((run) =>
+          run.context.update(key, (prev) => ({ value: prev.value + 1 }))
+        );
+        return (r) => r.el('span', 'provider');
+      },
+    });
+    const consumer = definePrototype({
+      name: 'context-life-consumer',
+      setup(def) {
+        consumerSetups++;
+        const seen = def.state.numberDiscrete('seen', 0);
+        def.context.subscribe(key, (_run, next, prev) => {
+          seen.set(next.value, 'reason: context transition');
+          transitions.push([prev.value, next.value]);
+        });
+        return (r) => r.el('span', String(r.read.context.read(key).value));
+      },
+    });
+    const host = (name: string, token: object): RuntimeHost<Record<string, unknown>> => ({
+      prototypeName: name,
+      getRawProps: () => ({}),
+      commit(_children, signal) {
+        signal?.done();
+      },
+      schedule(task) {
+        task();
+      },
+      onRuntimeReady(wiring) {
+        wiring.attach('context', [
+          [CONTEXT_INSTANCE_TOKEN_CAP, token],
+          [
+            CONTEXT_PARENT_CAP,
+            (instance: unknown) => (instance === consumerToken ? providerToken : null),
+          ],
+        ]);
+      },
+    });
+    const p = createRuntimeSession(provider, host(provider.name, providerToken));
+    const c = createRuntimeSession(consumer, host(consumer.name, consumerToken));
+    const port = c.caps.getPort<ContextPort>('context')!;
+    try {
+      await p.mount();
+      await c.mount();
+      expect(transitions).toEqual([[0, 1]]);
+      expect(port.resolveScope(key)).toBe(providerToken);
+      await c.unmount();
+      await p.unmount();
+      expect(c.instancePhase).toBe('alive');
+      expect(port.resolveScope(key)).toBe(providerToken);
+      expect(port.dumpSubscriptions().some((row) => row.instance === consumerToken)).toBe(true);
+      await c.mount();
+      await p.mount();
+      expect(transitions).toEqual([
+        [0, 1],
+        [1, 2],
+      ]);
+      expect([providerSetups, consumerSetups]).toEqual([1, 1]);
+      expect(c.mountEpoch).toBe(2);
+      await c.dispose();
+      expect(port.dumpSubscriptions().some((row) => row.instance === consumerToken)).toBe(false);
+      await p.unmount();
+      await p.mount();
+      expect(transitions).toEqual([
+        [0, 1],
+        [1, 2],
+      ]);
+      await p.dispose();
+      expect(port.dumpProviders().some((row) => row.instance === providerToken)).toBe(false);
+    } finally {
+      await c.dispose();
+      await p.dispose();
+    }
+  });
+});

--- a/spec/adapters/A-REACT-18-19-0001.yaml
+++ b/spec/adapters/A-REACT-18-19-0001.yaml
@@ -77,6 +77,10 @@ criteria:
     text:
       zh-CN: 对声明 `M-IMAGE-VIEW-0001` 的 React Web realization 必须将每个 Image View request 绑定到不可变 generation，清理替换/空 source 的旧视觉目标，并在 view detach/disposal 后移除 owned physical image；该保证由 `T-IMAGE-VIEW-0001` 的 React integration evidence 验证。
       en: The React Web realization of `M-IMAGE-VIEW-0001` must bind each Image View request to an immutable generation, clear stale visual targets on replacement or empty source, and remove the owned physical image after view detach or disposal; `T-IMAGE-VIEW-0001` React integration evidence verifies this guarantee.
+  - id: A-REACT-18-19-0001-CONTEXT
+    text:
+      en: The standard Adapter wires Context with stable opaque instance identity and current logical ancestry; real mounted nested scopes, equal-name Key isolation, callback updates and terminal owner replacement must conform to T-CONTEXT-0003.
+      zh-CN: standard Adapter 接入 Context 并提供稳定 opaque instance identity 与当前 logical ancestry；真实挂载的嵌套 scope、同名 Key 隔离、callback update 与 terminal owner 替换必须符合 T-CONTEXT-0003。
 supports:
   modules:
     - id: M-PROPS-0001
@@ -101,6 +105,10 @@ supports:
       since: 0.3.0-alpha.0
       role: optional-module
       note: React resolves declared Image View requirements to one physical HTMLImageElement root and retains the generation-bound host lease.
+    - id: M-CONTEXT-0001
+      since: 0.3.0-alpha.0
+      role: required-module
+      note: The standard Runtime Context channel uses Adapter-owned identity and ancestry, never framework Context value semantics.
 provides:
   hostCaps:
     - id: HC-PROPS-SOURCE-0001
@@ -122,6 +130,14 @@ provides:
       since: 0.3.0-alpha.0
       role: translated-capability
       note: React maps Image View to the physical image root and carries loading completion through the host lease.
+    - id: HC-CONTEXT-IDENTITY-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Adapter logical instance tokens and parent links translate host ownership into Context facts.
+    - id: HC-CONTEXT-ANCESTRY-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Adapter logical instance tokens and parent links translate host ownership into Context facts.
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -138,6 +154,8 @@ verifies:
     - T-EXPOSE-STATE-0002
     - T-EXPOSE-EVENT-0002
     - id: T-IMAGE-VIEW-0001
+      since: 0.3.0-alpha.0
+    - id: T-CONTEXT-0003
       since: 0.3.0-alpha.0
 sources:
   - path: packages/adapters/react/package.json
@@ -159,6 +177,7 @@ sources:
   - path: packages/adapters/react/test/expose.test.ts
   - path: packages/adapters/react/test/expose-event.test.ts
   - path: packages/adapters/react/test/image-view.integration.test.ts
+  - path: packages/adapters/react/test/context.integration.test.ts
 revisions:
   - version: 0.3.0-alpha.0
     change: revised
@@ -187,4 +206,7 @@ revisions:
   - version: 0.2.0-rc.7
     change: introduced
     summary: Cataloged the official React 18.2-19 profile identity and its required Props translation slice.
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Added the reviewed Context identity/ancestry slice and real-framework nested-scope evidence; other unlisted modules remain uncataloged.
 tags: [adapter, react, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-VUE-2-0001.yaml
+++ b/spec/adapters/A-VUE-2-0001.yaml
@@ -13,10 +13,12 @@ adapterProfile:
       versionRange: '>=2.6.0 <2.7'
 statement:
   zh-CN: >-
-    该 profile 表示 `@proto.ui/adapter-vue2` 在 Web platform 上面向 Vue `>=2.6.0 <2.7` 的 official translation identity。一个 Vue 2 component owner 持有 Proto RuntimeSession，并把 props 与 attrs、DOM input、Vue lifecycle、component public instance 和 Vue event listener 翻译到 required Props、Event、State、Expose core、Expose State 与 Expose Event Module。当前编目只覆盖已有 executable evidence 的 slice；其它 Module 未出现时表示 uncataloged，不得推断为支持或不支持。
+    该 profile 表示 `@proto.ui/adapter-vue2` 在 Web platform 上面向 Vue `>=2.6.0 <2.7` 的 official translation identity。一个 Vue 2 component owner 持有 Proto RuntimeSession，并把 props 与 attrs、DOM input、Vue lifecycle、component public instance 和 Vue event listener 翻译到 required Props、Event、State、Expose core、Expose State、Expose Event 与 Context Module。当前编目只覆盖已有 executable evidence 的 slice；其它 Module 未出现时表示 uncataloged，不得推断为支持或不支持。
+
 
   en: >-
-    This profile is the official translation identity of `@proto.ui/adapter-vue2` for Vue `>=2.6.0 <2.7` on the Web platform. A Vue 2 component owner retains the Proto RuntimeSession and translates props and attrs, DOM input, Vue lifecycle, the component public instance, and Vue event listeners into the required Props, Event, State, Expose core, Expose State, and Expose Event modules. The current catalog is limited to slices with executable evidence; every other Module remains uncataloged rather than implicitly supported or unsupported.
+    This profile is the official translation identity of `@proto.ui/adapter-vue2` for Vue `>=2.6.0 <2.7` on the Web platform. A Vue 2 component owner retains the Proto RuntimeSession and translates props and attrs, DOM input, Vue lifecycle, the component public instance, and Vue event listeners into the required Props, Event, State, Expose core, Expose State, Expose Event, and Context modules. The current catalog is limited to slices with executable evidence; every other Module remains uncataloged rather than implicitly supported or unsupported.
+
 
 criteria:
   - id: A-VUE-2-0001-A
@@ -71,6 +73,10 @@ criteria:
     text:
       zh-CN: Adapter 必须接入 required Expose Event Module，并以 translated capability 提供 `HC-EXPOSE-EVENT-SINK-0001`；合法 emission 映射到 Vue 2 event listener 与当前 typed `onXxx` listener，listener attrs 不得进入 Proto raw props。
       en: The Adapter must wire the required Expose Event module and provide `HC-EXPOSE-EVENT-SINK-0001` as a translated capability; valid emissions map to Vue 2 event listeners and current typed `onXxx` listeners, while listener attrs stay outside Proto raw props.
+  - id: A-VUE-2-0001-CONTEXT
+    text:
+      en: The standard Adapter wires Context with stable opaque instance identity and current logical ancestry; real mounted nested scopes, equal-name Key isolation, callback updates and terminal owner replacement must conform to T-CONTEXT-0003.
+      zh-CN: standard Adapter 接入 Context 并提供稳定 opaque instance identity 与当前 logical ancestry；真实挂载的嵌套 scope、同名 Key 隔离、callback update 与 terminal owner 替换必须符合 T-CONTEXT-0003。
 supports:
   modules:
     - id: M-PROPS-0001
@@ -91,6 +97,10 @@ supports:
     - id: M-EXPOSE-EVENT-0001
       role: required-module
       note: Expose Event owns the outward-signal bridge and receives its sink through expose-event wiring.
+    - id: M-CONTEXT-0001
+      since: 0.3.0-alpha.0
+      role: required-module
+      note: The standard Runtime Context channel uses Adapter-owned identity and ancestry, never framework Context value semantics.
 provides:
   hostCaps:
     - id: HC-PROPS-SOURCE-0001
@@ -108,6 +118,14 @@ provides:
     - id: HC-EXPOSE-EVENT-SINK-0001
       role: translated-capability
       note: Vue 2 maps validated outward signals to event and typed onXxx listeners.
+    - id: HC-CONTEXT-IDENTITY-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Adapter logical instance tokens and parent links translate host ownership into Context facts.
+    - id: HC-CONTEXT-ANCESTRY-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Adapter logical instance tokens and parent links translate host ownership into Context facts.
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -123,6 +141,8 @@ verifies:
     - T-EXPOSE-0002
     - T-EXPOSE-STATE-0002
     - T-EXPOSE-EVENT-0002
+    - id: T-CONTEXT-0003
+      since: 0.3.0-alpha.0
 sources:
   - path: packages/adapters/vue2/package.json
   - path: packages/adapters/vue2/src/adapt.ts
@@ -133,8 +153,12 @@ sources:
   - path: packages/adapters/vue2/test/lifecycle.test.ts
   - path: packages/adapters/vue2/test/expose.test.ts
   - path: packages/adapters/vue2/test/types.test.ts
+  - path: packages/adapters/vue2/test/context.integration.test.ts
 revisions:
   - version: 0.3.0-alpha.0
     change: introduced
     summary: Admitted the official Vue 2.6 Web Adapter profile with reviewed Props, Event, lifecycle, State, Expose, and host-capability translation evidence.
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Added the reviewed Context identity/ancestry slice and real-framework nested-scope evidence; other unlisted modules remain uncataloged.
 tags: [adapter, vue2, vue, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-VUE-3-0001.yaml
+++ b/spec/adapters/A-VUE-3-0001.yaml
@@ -77,6 +77,10 @@ criteria:
     text:
       zh-CN: 对声明 `M-IMAGE-VIEW-0001` 的 Vue Web realization 必须将每个 Image View request 绑定到不可变 generation，清理替换/空 source 的旧视觉目标，并在 view detach/disposal 后移除 owned physical image；该保证由 `T-IMAGE-VIEW-0001` 的 Vue integration evidence 验证。
       en: The Vue Web realization of `M-IMAGE-VIEW-0001` must bind each Image View request to an immutable generation, clear stale visual targets on replacement or empty source, and remove the owned physical image after view detach or disposal; `T-IMAGE-VIEW-0001` Vue integration evidence verifies this guarantee.
+  - id: A-VUE-3-0001-CONTEXT
+    text:
+      en: The standard Adapter wires Context with stable opaque instance identity and current logical ancestry; real mounted nested scopes, equal-name Key isolation, callback updates and terminal owner replacement must conform to T-CONTEXT-0003.
+      zh-CN: standard Adapter 接入 Context 并提供稳定 opaque instance identity 与当前 logical ancestry；真实挂载的嵌套 scope、同名 Key 隔离、callback update 与 terminal owner 替换必须符合 T-CONTEXT-0003。
 supports:
   modules:
     - id: M-PROPS-0001
@@ -101,6 +105,10 @@ supports:
       since: 0.3.0-alpha.0
       role: optional-module
       note: Vue resolves declared Image View requirements to one physical HTMLImageElement root and retains the generation-bound host lease.
+    - id: M-CONTEXT-0001
+      since: 0.3.0-alpha.0
+      role: required-module
+      note: The standard Runtime Context channel uses Adapter-owned identity and ancestry, never framework Context value semantics.
 provides:
   hostCaps:
     - id: HC-PROPS-SOURCE-0001
@@ -122,6 +130,14 @@ provides:
       since: 0.3.0-alpha.0
       role: translated-capability
       note: Vue maps Image View to the physical image root and carries loading completion through the host lease.
+    - id: HC-CONTEXT-IDENTITY-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Adapter logical instance tokens and parent links translate host ownership into Context facts.
+    - id: HC-CONTEXT-ANCESTRY-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Adapter logical instance tokens and parent links translate host ownership into Context facts.
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -138,6 +154,8 @@ verifies:
     - T-EXPOSE-STATE-0002
     - T-EXPOSE-EVENT-0002
     - id: T-IMAGE-VIEW-0001
+      since: 0.3.0-alpha.0
+    - id: T-CONTEXT-0003
       since: 0.3.0-alpha.0
 sources:
   - path: packages/adapters/vue/package.json
@@ -157,6 +175,7 @@ sources:
   - path: packages/adapters/vue/test/expose.test.ts
   - path: packages/adapters/vue/test/expose-event.test.ts
   - path: packages/adapters/vue/test/image-view.integration.test.ts
+  - path: packages/adapters/vue/test/context.integration.test.ts
 revisions:
   - version: 0.3.0-alpha.0
     change: revised
@@ -185,4 +204,7 @@ revisions:
   - version: 0.2.0-rc.7
     change: introduced
     summary: Cataloged the official Vue 3 profile identity and its required Props translation slice.
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Added the reviewed Context identity/ancestry slice and real-framework nested-scope evidence; other unlisted modules remain uncataloged.
 tags: [adapter, vue, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-WEB-COMPONENT-0001.yaml
+++ b/spec/adapters/A-WEB-COMPONENT-0001.yaml
@@ -76,6 +76,10 @@ criteria:
     text:
       zh-CN: 对声明 `M-IMAGE-VIEW-0001` 的 Web Component realization 必须将每个 Image View request 绑定到不可变 generation，清理替换/空 source 的旧视觉目标，并在 view detach/disposal 后移除 owned physical image；该保证由 `T-IMAGE-VIEW-0001` 的 Web Component integration evidence 验证。
       en: The Web Component realization of `M-IMAGE-VIEW-0001` must bind each Image View request to an immutable generation, clear stale visual targets on replacement or empty source, and remove the owned physical image after view detach or disposal; `T-IMAGE-VIEW-0001` Web Component integration evidence verifies this guarantee.
+  - id: A-WEB-COMPONENT-0001-CONTEXT
+    text:
+      en: The standard Adapter wires Context with stable opaque instance identity and current logical ancestry; real mounted nested scopes, equal-name Key isolation, callback updates and terminal owner replacement must conform to T-CONTEXT-0003.
+      zh-CN: standard Adapter 接入 Context 并提供稳定 opaque instance identity 与当前 logical ancestry；真实挂载的嵌套 scope、同名 Key 隔离、callback update 与 terminal owner 替换必须符合 T-CONTEXT-0003。
 supports:
   modules:
     - id: M-PROPS-0001
@@ -100,6 +104,10 @@ supports:
       since: 0.3.0-alpha.0
       role: optional-module
       note: The persistent Custom Element owner keeps its logical boundary while projecting declared Image View requirements to one inner HTMLImageElement target.
+    - id: M-CONTEXT-0001
+      since: 0.3.0-alpha.0
+      role: required-module
+      note: The standard Runtime Context channel uses Adapter-owned identity and ancestry, never framework Context value semantics.
 provides:
   hostCaps:
     - id: HC-PROPS-SOURCE-0001
@@ -121,6 +129,14 @@ provides:
       since: 0.3.0-alpha.0
       role: translated-capability
       note: The Custom Element maps Image View to the inner image target and carries loading completion through the generation-bound host lease.
+    - id: HC-CONTEXT-IDENTITY-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Adapter logical instance tokens and parent links translate host ownership into Context facts.
+    - id: HC-CONTEXT-ANCESTRY-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Adapter logical instance tokens and parent links translate host ownership into Context facts.
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -137,6 +153,8 @@ verifies:
     - T-EXPOSE-STATE-0002
     - T-EXPOSE-EVENT-0002
     - id: T-IMAGE-VIEW-0001
+      since: 0.3.0-alpha.0
+    - id: T-CONTEXT-0003
       since: 0.3.0-alpha.0
 openQuestions:
   - id: A-WEB-COMPONENT-0001-Q-INGRESS-PRECEDENCE
@@ -166,6 +184,7 @@ sources:
   - path: packages/adapters/web-component/test/contract/expose.basic.v0.contract.test.ts
   - path: packages/adapters/web-component/test/expose.test.ts
   - path: packages/adapters/web-component/test/image-view.integration.test.ts
+  - path: packages/adapters/web-component/test/context.integration.test.ts
 revisions:
   - version: 0.3.0-alpha.0
     change: revised
@@ -194,5 +213,8 @@ revisions:
   - version: 0.2.0-rc.7
     change: introduced
     summary: Cataloged the official Web Component profile identity and its source plus direct-push Props translation slice.
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Added the reviewed Context identity/ancestry slice and real-framework nested-scope evidence; other unlisted modules remain uncataloged.
 tags:
   [adapter, web-component, custom-elements, web, props, event, lifecycle, state, expose, official]

--- a/spec/contracts/C-CONTEXT-0004.yaml
+++ b/spec/contracts/C-CONTEXT-0004.yaml
@@ -6,11 +6,11 @@ since: 0.1.0
 summary: Context resolution binds a participant to the nearest provider or equivalent scope owner for the requested ContextKey.
 statement:
   zh-CN: >-
-    Context resolution 必须基于 runtime/adapter 提供的 scope ancestry。常见 UI 宿主中，这个 ancestry 通常表现为 logical tree 或 component tree；若宿主没有树形结构，只要 adapter 能提供等价的 scope resolution 逻辑，Context 仍然可以成立。对于同一个 ContextKey，最近的 scope owner wins。
+    Context resolution 必须基于 runtime/adapter 提供的 scope ancestry。常见 UI 宿主中，这个 ancestry 通常表现为 logical tree 或 component tree；若宿主没有树形结构，只要 adapter 能提供等价的 scope resolution 逻辑，Context 仍然可以成立。对于同一个 ContextKey，从参与者自身开始解析，最近的 scope owner wins；自身提供该 Key 时优先于祖先。
 
 
   en: >-
-    Context resolution must be based on scope ancestry supplied by the runtime/adapter. In common UI hosts this ancestry usually appears as a logical tree or component tree; if a host is not tree-shaped, Context may still work when the adapter provides equivalent scope-resolution logic. For the same ContextKey, the nearest scope owner wins.
+    Context resolution must be based on scope ancestry supplied by the runtime/adapter. In common UI hosts this ancestry usually appears as a logical tree or component tree; if a host is not tree-shaped, Context may still work when the adapter provides equivalent scope-resolution logic. For the same ContextKey, resolution starts at the participant itself and the nearest scope owner wins; a self-provided key takes precedence over ancestors.
 
 
 criteria:
@@ -20,8 +20,8 @@ criteria:
       en: Context resolution must use scope ancestry provided by the runtime/adapter.
   - id: C-CONTEXT-0004-B
     text:
-      zh-CN: 在树形宿主中，resolution 必须选择最近的祖先 provider。
-      en: In tree-shaped hosts, resolution must choose the nearest ancestor provider.
+      zh-CN: 在树形宿主中，resolution 必须从参与者自身开始，再沿 ancestry 向上查找最近 provider；自身提供该 Key 时必须选择自身。
+      en: In tree-shaped hosts, resolution must start at the participant itself, then follow ancestry to the nearest provider; a participant providing the key must resolve to itself.
   - id: C-CONTEXT-0004-C
     text:
       zh-CN: 同一 ContextKey 可以由不同组件实例同时提供；绑定结果按参与者所在 scope 决定。
@@ -51,6 +51,9 @@ dependsOn:
   contracts:
     - C-CONTEXT-0002
 revisions:
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Made nearest-provider resolution explicitly self-inclusive, aligning the contract with the existing provider-self decision, Module criterion and executable evidence.
   - version: 0.2.0-rc.7
     change: revised
     summary: Allowed opaque nearest-provider identity for bounded module-internal coordination without weakening JSON values.

--- a/spec/contracts/C-CONTEXT-0008.yaml
+++ b/spec/contracts/C-CONTEXT-0008.yaml
@@ -5,13 +5,8 @@ status: draft
 since: 0.1.0
 summary: Runtime context updates must explicitly name the ContextKey and next value or updater; `update` requires certainty, while `tryUpdate` models optional context availability.
 statement:
-  zh-CN: >-
-    Context runtime update 必须显式指定 ContextKey 与 next context value，不能依赖隐式当前 context。`run.context.update(key, next)` 用于原型作者确信该 context 应存在的场景；缺少 prior subscription 或当前 provider 不存在时必须失败。`run.context.tryUpdate(key, next)` 用于可选 context；它要求 prior optional subscription，context 不存在时返回 `false`，成功更新时返回 `true`。
-
-
-  en: >-
-    Runtime context updates must explicitly specify the ContextKey and next context value; they must not rely on an implicit current context. `run.context.update(key, next)` is for cases where the author is certain the context should exist; it must fail without prior subscription or when the current provider is absent. `run.context.tryUpdate(key, next)` is for optional contexts; it requires prior optional subscription, returns `false` when the context is absent, and returns `true` after a successful update.
-
+  en: Context runtime updates explicitly name the ContextKey and next value or updater. A provider may call update for its own provided key without subscribing; other participants require prior required or optional subscription. No resolved provider means failure. tryUpdate always requires prior optional subscription, returns false on absence and true on success. Both operations are callback-only; read and tryRead retain their own subscription requirements.
+  zh-CN: Context runtime update 显式指定 ContextKey 与 next value/updater。provider 可不订阅而 update 自己提供的 Key；其他参与者必须先 required 或 optional subscription。没有 resolved provider 时失败。tryUpdate 始终要求 prior optional subscription，缺失返回 false，成功返回 true。两种写操作均为 callback-only；read 与 tryRead 保留各自订阅要求。
 
 criteria:
   - id: C-CONTEXT-0008-A
@@ -24,8 +19,8 @@ criteria:
       en: '`run.context.tryUpdate(key, next)` must explicitly receive a ContextKey and next value/updater.'
   - id: C-CONTEXT-0008-C
     text:
-      zh-CN: '`update` 必须要求 prior subscription，并在 resolved provider 不存在时失败。'
-      en: '`update` must require prior subscription and fail when no provider resolves.'
+      en: update requires prior subscription unless the current instance itself provides the key; it fails when no provider resolves. This exception grants neither read nor tryUpdate authority.
+      zh-CN: update 要求 prior subscription，当前实例自己提供该 Key 时除外；没有 resolved provider 时失败。该例外不授予 read 或 tryUpdate 权限。
   - id: C-CONTEXT-0008-D
     text:
       zh-CN: '`tryUpdate` 必须要求 prior optional subscription，并在 context 不存在时返回 `false`。'
@@ -54,6 +49,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Captured explicit key/value runtime update and the v0 update/tryUpdate split.
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Maintainer accepted provider self-update without subscription while preserving consumer, read and tryUpdate requirements.
 tags:
   - context
   - update

--- a/spec/contracts/C-CONTEXT-0012.yaml
+++ b/spec/contracts/C-CONTEXT-0012.yaml
@@ -5,23 +5,18 @@ status: draft
 since: 0.1.0
 summary: Context providers and subscriptions are bound to the component instance lifecycle, and context failures should be distinguishable for diagnostics.
 statement:
-  zh-CN: >-
-    Context provider 与 subscription 都绑定到组件实例生命周期。实例 unmount/dispose 后，当前实例提供的 context scope 与订阅记录必须被清理，残留 callback 不得继续接收后续 context update。Context 失败应具备可区分诊断信息，尤其是 phase violation、missing provider、missing subscription、duplicate provide、disconnected 与 invalid value。
-
-
-  en: >-
-    Context providers and subscriptions are bound to the component instance lifecycle. After instance unmount/dispose, context scopes and subscription records owned by the instance must be cleaned up, and leftover callbacks must not receive later context updates. Context failures should carry distinguishable diagnostics, especially phase violation, missing provider, missing subscription, duplicate provide, disconnected, and invalid value.
-
+  en: Context providers and subscriptions belong to instance lifetime. Repeatable view unmount preserves them; terminal instance disposal removes the owner records. Unsubscribed or disposed callbacks must not receive later updates. Phase, missing provider/subscription, duplicate provide, disconnection, invalid value and missing required scope capability remain diagnosable.
+  zh-CN: Context provider 与 subscription 属于 instance lifetime。repeatable view unmount 保留这些资源，terminal instance disposal 移除 owner 记录。unsubscribe 或 dispose 后旧 callback 不接收后续 update。phase、missing provider/subscription、duplicate provide、disconnected、invalid value 与缺失必要 scope capability 仍须可诊断。
 
 criteria:
   - id: C-CONTEXT-0012-A
     text:
-      zh-CN: dispose/unmount 必须移除当前实例提供的 context providers。
-      en: Dispose/unmount must remove context providers owned by the current instance.
+      en: Terminal disposal removes this instance’s providers; repeatable view unmount preserves them.
+      zh-CN: terminal disposal 移除当前实例 provider；repeatable view unmount 保留它们。
   - id: C-CONTEXT-0012-B
     text:
-      zh-CN: dispose/unmount 必须移除当前实例的 context subscriptions。
-      en: Dispose/unmount must remove context subscriptions owned by the current instance.
+      en: Terminal disposal removes this instance’s subscriptions; repeatable view unmount preserves intent and callback registrations.
+      zh-CN: terminal disposal 移除当前实例 subscription；repeatable view unmount 保留 intent 与 callback registration。
   - id: C-CONTEXT-0012-C
     text:
       zh-CN: unsubscribe 或 dispose 后，旧 callback 不得继续接收后续 context update。
@@ -49,10 +44,15 @@ dependsOn:
   contracts:
     - C-CONTEXT-0004
     - C-LIFECYCLE-0004
+    - C-LIFECYCLE-0006
+    - C-LIFECYCLE-0007
 revisions:
   - version: 0.1.0
     change: introduced
     summary: Captured lifecycle cleanup and distinguishable context diagnostics.
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Reconciled legacy unmount wording with the existing repeatable-view versus terminal-instance lifecycle.
 tags:
   - context
   - lifecycle

--- a/spec/host-caps/HC-CONTEXT-ANCESTRY-0001.yaml
+++ b/spec/host-caps/HC-CONTEXT-ANCESTRY-0001.yaml
@@ -1,0 +1,46 @@
+id: HC-CONTEXT-ANCESTRY-0001
+type: host-cap
+title: Host supplies current Context scope ancestry
+status: draft
+since: 0.3.0-alpha.0
+summary: The host translates its ownership model into current logical-parent queries over opaque identities; Context owns provider selection.
+statement:
+  en: The host translates its ownership model into current logical-parent queries over opaque identities; Context owns provider selection.
+  zh-CN: 宿主将 ownership 模型翻译为 opaque identity 的当前 logical-parent 查询；Context 自身拥有 provider 选择。
+criteria:
+  - id: HC-CONTEXT-ANCESTRY-0001-A
+    text:
+      en: Queries return the current logical parent identity or null at an ancestry boundary; the relation must form a finite acyclic traversal.
+      zh-CN: 查询返回当前 logical parent identity 或边界处的 null；关系必须形成有限无环遍历。
+  - id: HC-CONTEXT-ANCESTRY-0001-B
+    text:
+      en: The supplied relation reflects logical ownership, rather than requiring DOM containment; physical containment is not a universal Context rule.
+      zh-CN: 关系反映逻辑 ownership，不要求 DOM containment；物理包含不是 Context 通用规则。
+  - id: HC-CONTEXT-ANCESTRY-0001-C
+    text:
+      en: The host provides ancestry facts, not Context values, key matching, subscription policy or callback scheduling; Context resolves the nearest self-inclusive provider.
+      zh-CN: 宿主只提供 ancestry facts，不拥有 Context value、Key matching、subscription policy 或 callback scheduling；Context 从自身开始解析最近 provider。
+  - id: HC-CONTEXT-ANCESTRY-0001-D
+    text:
+      en: Traversal is required when resolution is used; missing traversal fails diagnostically, while a valid null parent is an ordinary root or disconnected boundary.
+      zh-CN: 进行 resolution 时必须提供遍历能力；缺失能力给出诊断并失败，合法 null parent 则是普通 root 或 disconnected 边界。
+relates:
+  contracts:
+    - C-CONTEXT-0004
+    - C-CONTEXT-0011
+    - C-CONTEXT-0012
+verifies:
+  tests:
+    - T-CONTEXT-0003
+sources:
+  - path: packages/modules/context/src/caps.ts
+  - path: packages/modules/context/src/impl.ts
+  - path: packages/adapters/base/src/platform/instance-tree.ts
+revisions:
+  - version: 0.3.0-alpha.0
+    change: introduced
+    summary: Separated the existing Context host identity and ancestry responsibilities without changing cap tokens.
+tags:
+  - context
+  - host-capability
+  - scope

--- a/spec/host-caps/HC-CONTEXT-IDENTITY-0001.yaml
+++ b/spec/host-caps/HC-CONTEXT-IDENTITY-0001.yaml
@@ -14,8 +14,8 @@ criteria:
       zh-CN: 不同 alive instance 具有不同身份；同一实例跨 repeatable view epoch 保留 token。
   - id: HC-CONTEXT-IDENTITY-0001-B
     text:
-      en: The token is an internal identity fact, not a DOM node requirement, framework instance API or serializable Context value.
-      zh-CN: token 是内部身份事实，不要求 DOM node、框架实例 API，也不是可序列化 Context value。
+      en: The token is an internal identity fact, not a DOM node requirement, framework instance API or serializable Context value. Null is reserved for absence; falsy non-null tokens remain valid identities.
+      zh-CN: token 是内部身份事实，不要求 DOM node、框架实例 API，也不是可序列化 Context value。null 保留为缺失标记；非 null 的 falsy token 仍是有效身份。
   - id: HC-CONTEXT-IDENTITY-0001-C
     text:
       en: Identity must be available before a Context declaration that uses it; terminal disposal ends that owner and must not implicitly reuse it for a fresh owner.
@@ -33,6 +33,9 @@ sources:
   - path: packages/modules/context/src/impl.ts
   - path: packages/adapters/base/src/platform/instance-tree.ts
 revisions:
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Reserved null as the absence sentinel without narrowing opaque identity to truthy objects; added falsy-token lifetime evidence.
   - version: 0.3.0-alpha.0
     change: introduced
     summary: Separated the existing Context host identity and ancestry responsibilities without changing cap tokens.

--- a/spec/host-caps/HC-CONTEXT-IDENTITY-0001.yaml
+++ b/spec/host-caps/HC-CONTEXT-IDENTITY-0001.yaml
@@ -1,0 +1,42 @@
+id: HC-CONTEXT-IDENTITY-0001
+type: host-cap
+title: Host provides opaque Context participant identity
+status: draft
+since: 0.3.0-alpha.0
+summary: The host supplies a stable opaque token for one logical component instance, independent of current materialization.
+statement:
+  en: The host supplies a stable opaque token for one logical component instance, independent of current materialization.
+  zh-CN: 宿主为每个逻辑组件实例提供稳定 opaque token，独立于当前物化。
+criteria:
+  - id: HC-CONTEXT-IDENTITY-0001-A
+    text:
+      en: Distinct live instances receive distinct identities; one instance retains its token across repeatable view epochs.
+      zh-CN: 不同 alive instance 具有不同身份；同一实例跨 repeatable view epoch 保留 token。
+  - id: HC-CONTEXT-IDENTITY-0001-B
+    text:
+      en: The token is an internal identity fact, not a DOM node requirement, framework instance API or serializable Context value.
+      zh-CN: token 是内部身份事实，不要求 DOM node、框架实例 API，也不是可序列化 Context value。
+  - id: HC-CONTEXT-IDENTITY-0001-C
+    text:
+      en: Identity must be available before a Context declaration that uses it; terminal disposal ends that owner and must not implicitly reuse it for a fresh owner.
+      zh-CN: 使用身份的 Context declaration 之前必须提供该身份；terminal disposal 终止 owner，不得隐式为新 owner 复用。
+relates:
+  contracts:
+    - C-CONTEXT-0004
+    - C-CONTEXT-0011
+    - C-CONTEXT-0012
+verifies:
+  tests:
+    - T-CONTEXT-0003
+sources:
+  - path: packages/modules/context/src/caps.ts
+  - path: packages/modules/context/src/impl.ts
+  - path: packages/adapters/base/src/platform/instance-tree.ts
+revisions:
+  - version: 0.3.0-alpha.0
+    change: introduced
+    summary: Separated the existing Context host identity and ancestry responsibilities without changing cap tokens.
+tags:
+  - context
+  - host-capability
+  - scope

--- a/spec/modules/M-CONTEXT-0001.yaml
+++ b/spec/modules/M-CONTEXT-0001.yaml
@@ -1,0 +1,106 @@
+id: M-CONTEXT-0001
+type: module
+title: Context owns scoped inter-component values and participation
+status: draft
+since: 0.3.0-alpha.0
+summary: The standard Context module owns JSON scope values, subscription intent, nearest-owner resolution and callback dispatch; adapters supply opaque instance identity and current logical ancestry.
+statement:
+  en: 'Context is the standard Runtime module for the Component-to-Component channel. Its per-instance facade records setup-time providers and required/optional subscriptions, then exposes runtime reads and callback-only updates. The privileged port supplies callback-dispatch integration, opaque scope lookup and diagnostics, never ordinary author access to host identity. A shared coordinator does not make provider or subscription resources global-lifetime resources: they belong to the component instance and survive repeatable view epochs. This first catalog slice remains draft; it neither introduces a new author API nor admits non-Web Adapter conformance.'
+  zh-CN: Context 是 standard Runtime 的组件间信息通路 Module。每实例 facade 记录 setup-time provider 与 required/optional subscription，再提供 runtime read 与 callback-only update；特权 port 提供 callback dispatcher 接入、opaque scope 查询和诊断，不向普通作者开放宿主身份。共享 coordinator 不改变 provider/subscription 的实例资源归属，它们跨 repeatable view epoch 保留。本轮编目保持 draft，不增加作者 API，也不宣称非 Web Adapter conformance。
+criteria:
+  - id: M-CONTEXT-0001-A
+    text:
+      en: The author facade exposes provide/subscribe/trySubscribe only in setup, read/tryRead at runtime including readonly render, and update/tryUpdate only in callback scope.
+      zh-CN: 作者 facade 仅在 setup 提供 provide/subscribe/trySubscribe，在 runtime（包括 readonly render）提供 read/tryRead，并仅在 callback scope 提供 update/tryUpdate。
+  - id: M-CONTEXT-0001-B
+    text:
+      en: Callback dispatcher installation, resolveScope and provider/subscription/queue diagnostics belong to the privileged port; opaque scope tokens never become Context values or author handles.
+      zh-CN: callback dispatcher 安装、resolveScope 与 provider/subscription/queue 诊断属于特权 port；opaque scope token 不得成为 Context value 或作者句柄。
+  - id: M-CONTEXT-0001-C
+    text:
+      en: The standard Runtime installs Context; shared coordination preserves per-instance provider and subscription ownership rather than substituting framework Context or a process-global application store.
+      zh-CN: standard Runtime 必须安装 Context；共享协调保留每实例 provider 与 subscription 所有权，不得以框架 Context 或进程全局应用 store 替代。
+  - id: M-CONTEXT-0001-D
+    text:
+      en: Host-provided identity identifies the participant independently of its current view; ContextKey reference identity independently identifies the channel.
+      zh-CN: 宿主提供的身份标识参与实例且独立于当前 view；ContextKey 引用身份独立标识通路。
+  - id: M-CONTEXT-0001-E
+    text:
+      en: Resolution is self-inclusive and selects the nearest provider using current supplied ancestry. Later reads, updates and notification recipient selection re-resolve; ancestry change alone emits no value callback.
+      zh-CN: resolution 从自身开始，使用当前宿主 ancestry 选择最近 provider。后续 read/update 与通知接收者选择重新解析；ancestry 改变本身不派发 value callback。
+  - id: M-CONTEXT-0001-F
+    text:
+      en: A provider may update its own value without subscribing. Other update callers need prior subscription; tryUpdate always needs optional subscription, while read/tryRead retain their declared subscription modes.
+      zh-CN: provider 可不订阅而 update 自己提供的值；其他 update 调用者必须先订阅。tryUpdate 始终需要 optional subscription，read/tryRead 保留各自订阅模式要求。
+  - id: M-CONTEXT-0001-G
+    text:
+      en: Updates validate top-level JSON objects before committing; callbacks preserve transition next/prev, deterministic order and the recipient Runtime callback scope without imposing one universal scheduling strategy.
+      zh-CN: update 在提交前验证顶层 JSON object；callback 保留 transition 的 next/prev、确定顺序与接收者 Runtime callback scope，不强制统一调度策略。
+  - id: M-CONTEXT-0001-H
+    text:
+      en: Provider values, subscription intent and callback registrations survive repeatable view detach/remount; unsubscribe deactivates delivery and terminal disposal removes the instance records.
+      zh-CN: provider value、subscription intent 与 callback registration 跨 view detach/remount 保留；unsubscribe 停用 delivery，terminal disposal 移除实例记录。
+  - id: M-CONTEXT-0001-I
+    text:
+      en: Operations requiring missing identity or ancestry fail diagnostically rather than guessing a scope. Declaration-only paths need not acquire an unused traversal capability.
+      zh-CN: 需要 identity 或 ancestry 的操作在能力缺失时给出诊断并失败，不猜测 scope；纯声明路径不必索取尚未使用的遍历能力。
+satisfies:
+  contracts:
+    - C-CONTEXT-0001
+    - C-CONTEXT-0002
+    - C-CONTEXT-0003
+    - C-CONTEXT-0004
+    - C-CONTEXT-0005
+    - C-CONTEXT-0006
+    - C-CONTEXT-0007
+    - C-CONTEXT-0008
+    - C-CONTEXT-0009
+    - C-CONTEXT-0010
+    - C-CONTEXT-0011
+    - C-CONTEXT-0012
+requires:
+  hostCaps:
+    - HC-CONTEXT-IDENTITY-0001
+    - HC-CONTEXT-ANCESTRY-0001
+dependsOn:
+  contracts:
+    - C-LIFECYCLE-0006
+    - C-LIFECYCLE-0007
+  knowledge:
+    - K-INFORMATION-CHANNEL-0001
+  decisions:
+    - D-CONTEXT-PROVIDER-SELF-SUBSCRIBE-0001
+    - D-CONTEXT-NOTIFICATION-SCHEDULING-0001
+    - D-CONTEXT-UPDATE-API-0001
+verifies:
+  tests:
+    - T-CONTEXT-0001
+    - T-CONTEXT-0002
+    - T-CONTEXT-0003
+sources:
+  - path: packages/modules/context/src/create.ts
+  - path: packages/modules/context/src/types.ts
+  - path: packages/modules/context/src/impl.ts
+  - path: packages/modules/context/src/center.ts
+  - path: packages/runtime/src/instance/session.ts
+  - path: packages/runtime/src/kernel/handles/def.ts
+  - path: packages/runtime/src/kernel/handles/run.ts
+openQuestions:
+  - id: M-CONTEXT-0001-Q-REQUIRED-SELECTION
+    question:
+      en: How will configurable Runtime module selection reject a missing Context module before author use?
+      zh-CN: 未来可配置 Runtime module selection 如何在作者使用前拒绝缺失 Context？
+    context:
+      en: The standard Runtime installs Context today; no new configurable-module policy is admitted here.
+      zh-CN: 当前 standard Runtime 固定安装 Context；本轮不引入可配置 module policy。
+    blocks:
+      - configurable-runtime-module-selection
+revisions:
+  - version: 0.3.0-alpha.0
+    change: introduced
+    summary: Cataloged the existing Context vertical slice and the maintainer-approved provider self-update exception.
+tags:
+  - context
+  - module
+  - instance
+  - scope

--- a/spec/tests/T-CONTEXT-0002.yaml
+++ b/spec/tests/T-CONTEXT-0002.yaml
@@ -108,6 +108,17 @@ implementations:
     required: true
     consumesCases:
       - T-CONTEXT-0002-CASE-CALLBACK-DELIVERY
+  - id: context-runtime-instance-lifetime
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/context-lifecycle.v1.contract.test.ts
+    required: true
+    consumesCases:
+      - T-CONTEXT-0002-CASE-RUNTIME-UPDATE
+      - T-CONTEXT-0002-CASE-CALLBACK-DELIVERY
+      - T-CONTEXT-0002-CASE-RECONNECT-CLEANUP
+    notes:
+      - Proves provider self-update without subscription and repeatable-view preservation versus terminal cleanup; diagnostics remain covered by module tests.
 verifies:
   contracts:
     - id: C-CONTEXT-0006

--- a/spec/tests/T-CONTEXT-0003.yaml
+++ b/spec/tests/T-CONTEXT-0003.yaml
@@ -10,6 +10,7 @@ cases:
     covers:
       - M-CONTEXT-0001-A
       - M-CONTEXT-0001-B
+      - C-CONTEXT-0004-B
     expectation: context-surface-conforms
   - id: T-CONTEXT-0003-CASE-HOST
     title: Current opaque ancestry controls rebind, updates and recipients
@@ -21,6 +22,17 @@ cases:
       - HC-CONTEXT-ANCESTRY-0001-B
       - HC-CONTEXT-ANCESTRY-0001-C
     expectation: context-host-conforms
+  - id: T-CONTEXT-0003-CASE-OPAQUE-TOKEN
+    title: Falsy non-null identities retain resolution, update and terminal cleanup
+    covers:
+      - C-CONTEXT-0004-B
+      - M-CONTEXT-0001-D
+      - M-CONTEXT-0001-H
+      - HC-CONTEXT-IDENTITY-0001-B
+      - HC-CONTEXT-IDENTITY-0001-C
+      - C-CONTEXT-0012-A
+      - C-CONTEXT-0012-B
+    expectation: falsy-identities-are-not-absence
   - id: T-CONTEXT-0003-CASE-AVAILABILITY
     title: Capability use fails without invented fallback
     covers:
@@ -58,6 +70,7 @@ implementations:
     required: true
     consumesCases:
       - T-CONTEXT-0003-CASE-SURFACE
+      - T-CONTEXT-0003-CASE-OPAQUE-TOKEN
       - T-CONTEXT-0003-CASE-HOST
       - T-CONTEXT-0003-CASE-AVAILABILITY
   - id: context-runtime-lifetime
@@ -142,12 +155,18 @@ verifies:
       anchors:
         - A-WEB-COMPONENT-0001-CONTEXT
   contracts:
+    - id: C-CONTEXT-0004
+      anchors:
+        - C-CONTEXT-0004-B
     - id: C-CONTEXT-0012
       anchors:
         - C-CONTEXT-0012-A
         - C-CONTEXT-0012-B
         - C-CONTEXT-0012-C
 revisions:
+  - version: 0.3.0-alpha.0
+    change: strengthened
+    summary: Bound provider-as-self and falsy opaque token resolution, updates and terminal cleanup to executable Module evidence.
   - version: 0.3.0-alpha.0
     change: introduced
     summary: Mapped bounded Module, Runtime and real four-Adapter executable Context evidence.

--- a/spec/tests/T-CONTEXT-0003.yaml
+++ b/spec/tests/T-CONTEXT-0003.yaml
@@ -1,0 +1,158 @@
+id: T-CONTEXT-0003
+type: test
+title: Context Module and host/Adapter vertical conformance
+status: draft
+since: 0.3.0-alpha.0
+summary: Opaque host facts, facade/port authority, Runtime instance resources and four Web Adapter scope journeys establish the bounded Context catalog slice.
+cases:
+  - id: T-CONTEXT-0003-CASE-SURFACE
+    title: Author facade and privileged port remain distinct
+    covers:
+      - M-CONTEXT-0001-A
+      - M-CONTEXT-0001-B
+    expectation: context-surface-conforms
+  - id: T-CONTEXT-0003-CASE-HOST
+    title: Current opaque ancestry controls rebind, updates and recipients
+    covers:
+      - M-CONTEXT-0001-D
+      - M-CONTEXT-0001-E
+      - HC-CONTEXT-IDENTITY-0001-B
+      - HC-CONTEXT-ANCESTRY-0001-A
+      - HC-CONTEXT-ANCESTRY-0001-B
+      - HC-CONTEXT-ANCESTRY-0001-C
+    expectation: context-host-conforms
+  - id: T-CONTEXT-0003-CASE-AVAILABILITY
+    title: Capability use fails without invented fallback
+    covers:
+      - M-CONTEXT-0001-I
+      - HC-CONTEXT-IDENTITY-0001-C
+      - HC-CONTEXT-ANCESTRY-0001-D
+    expectation: context-availability-conforms
+  - id: T-CONTEXT-0003-CASE-LIFETIME
+    title: Runtime scopes survive epochs and end at terminal disposal
+    covers:
+      - M-CONTEXT-0001-C
+      - M-CONTEXT-0001-F
+      - M-CONTEXT-0001-G
+      - M-CONTEXT-0001-H
+      - HC-CONTEXT-IDENTITY-0001-A
+    expectation: context-lifetime-conforms
+  - id: T-CONTEXT-0003-CASE-ADAPTER
+    title: Real Adapter owners translate nested scopes and fresh-owner identity
+    covers:
+      - M-CONTEXT-0001-D
+      - M-CONTEXT-0001-E
+      - M-CONTEXT-0001-G
+      - M-CONTEXT-0001-H
+      - HC-CONTEXT-IDENTITY-0001-A
+      - A-REACT-18-19-0001-CONTEXT
+      - A-VUE-3-0001-CONTEXT
+      - A-VUE-2-0001-CONTEXT
+      - A-WEB-COMPONENT-0001-CONTEXT
+    expectation: context-adapter-conforms
+implementations:
+  - id: context-module-catalog
+    kind: module-test
+    status: passing
+    path: packages/modules/context/test/catalog-boundary.test.ts
+    required: true
+    consumesCases:
+      - T-CONTEXT-0003-CASE-SURFACE
+      - T-CONTEXT-0003-CASE-HOST
+      - T-CONTEXT-0003-CASE-AVAILABILITY
+  - id: context-runtime-lifetime
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/context-lifecycle.v1.contract.test.ts
+    required: true
+    consumesCases:
+      - T-CONTEXT-0003-CASE-LIFETIME
+  - id: context-react-adapter
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/react/test/context.integration.test.ts
+    required: true
+    consumesCases:
+      - T-CONTEXT-0003-CASE-ADAPTER
+    notes:
+      - Uses the shared real-owner scenario in packages/adapters/base/test/fixtures/context-conformance.ts. This is Web-host DOM evidence, not non-Web conformance or browser geometry.
+  - id: context-vue-adapter
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue/test/context.integration.test.ts
+    required: true
+    consumesCases:
+      - T-CONTEXT-0003-CASE-ADAPTER
+    notes:
+      - Uses the shared real-owner scenario in packages/adapters/base/test/fixtures/context-conformance.ts. This is Web-host DOM evidence, not non-Web conformance or browser geometry.
+  - id: context-vue2-adapter
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue2/test/context.integration.test.ts
+    required: true
+    consumesCases:
+      - T-CONTEXT-0003-CASE-ADAPTER
+    notes:
+      - Uses the shared real-owner scenario in packages/adapters/base/test/fixtures/context-conformance.ts. This is Web-host DOM evidence, not non-Web conformance or browser geometry.
+  - id: context-web-component-adapter
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/context.integration.test.ts
+    required: true
+    consumesCases:
+      - T-CONTEXT-0003-CASE-ADAPTER
+    notes:
+      - Uses the shared real-owner scenario in packages/adapters/base/test/fixtures/context-conformance.ts. This is Web-host DOM evidence, not non-Web conformance or browser geometry.
+verifies:
+  modules:
+    - id: M-CONTEXT-0001
+      anchors:
+        - M-CONTEXT-0001-A
+        - M-CONTEXT-0001-B
+        - M-CONTEXT-0001-C
+        - M-CONTEXT-0001-D
+        - M-CONTEXT-0001-E
+        - M-CONTEXT-0001-F
+        - M-CONTEXT-0001-G
+        - M-CONTEXT-0001-H
+        - M-CONTEXT-0001-I
+  hostCaps:
+    - id: HC-CONTEXT-IDENTITY-0001
+      anchors:
+        - HC-CONTEXT-IDENTITY-0001-A
+        - HC-CONTEXT-IDENTITY-0001-B
+        - HC-CONTEXT-IDENTITY-0001-C
+    - id: HC-CONTEXT-ANCESTRY-0001
+      anchors:
+        - HC-CONTEXT-ANCESTRY-0001-A
+        - HC-CONTEXT-ANCESTRY-0001-B
+        - HC-CONTEXT-ANCESTRY-0001-C
+        - HC-CONTEXT-ANCESTRY-0001-D
+  adapters:
+    - id: A-REACT-18-19-0001
+      anchors:
+        - A-REACT-18-19-0001-CONTEXT
+    - id: A-VUE-3-0001
+      anchors:
+        - A-VUE-3-0001-CONTEXT
+    - id: A-VUE-2-0001
+      anchors:
+        - A-VUE-2-0001-CONTEXT
+    - id: A-WEB-COMPONENT-0001
+      anchors:
+        - A-WEB-COMPONENT-0001-CONTEXT
+  contracts:
+    - id: C-CONTEXT-0012
+      anchors:
+        - C-CONTEXT-0012-A
+        - C-CONTEXT-0012-B
+        - C-CONTEXT-0012-C
+revisions:
+  - version: 0.3.0-alpha.0
+    change: introduced
+    summary: Mapped bounded Module, Runtime and real four-Adapter executable Context evidence.
+tags:
+  - context
+  - adapter
+  - host-capability
+  - lifecycle

--- a/spec/tests/T-CONTEXT-0003.yaml
+++ b/spec/tests/T-CONTEXT-0003.yaml
@@ -33,6 +33,19 @@ cases:
       - C-CONTEXT-0012-A
       - C-CONTEXT-0012-B
     expectation: falsy-identities-are-not-absence
+  - id: T-CONTEXT-0003-CASE-EXPLICIT-CONSUMER
+    title: Actual Context port preserves explicit undefined consumer independently of its owner
+    covers:
+      - M-CONTEXT-0001-B
+      - HC-CONTEXT-IDENTITY-0001-B
+      - C-CONTEXT-0004-E
+    expectation: explicit-consumer-is-not-owner-fallback
+  - id: T-CONTEXT-0003-CASE-SCROLL-SCOPE
+    title: Composed Scroll preserves opaque scope identity through host attachment and refresh
+    covers:
+      - HC-CONTEXT-IDENTITY-0001-B
+      - C-CONTEXT-0004-E
+    expectation: composed-scroll-binds-only-matching-non-null-scopes
   - id: T-CONTEXT-0003-CASE-AVAILABILITY
     title: Capability use fails without invented fallback
     covers:
@@ -70,9 +83,19 @@ implementations:
     required: true
     consumesCases:
       - T-CONTEXT-0003-CASE-SURFACE
+      - T-CONTEXT-0003-CASE-EXPLICIT-CONSUMER
       - T-CONTEXT-0003-CASE-OPAQUE-TOKEN
       - T-CONTEXT-0003-CASE-HOST
       - T-CONTEXT-0003-CASE-AVAILABILITY
+  - id: context-scroll-scope-integration
+    kind: module-test
+    status: passing
+    path: packages/modules/scroll/test/context-scope.test.ts
+    required: true
+    consumesCases:
+      - T-CONTEXT-0003-CASE-SCROLL-SCOPE
+    notes:
+      - Uses real Context, State and Scroll modules with supplied Anatomy domain/target facts; verifies host binding and refresh, not browser geometry or all Anatomy host domains.
   - id: context-runtime-lifetime
     kind: runtime-test
     status: passing
@@ -158,12 +181,16 @@ verifies:
     - id: C-CONTEXT-0004
       anchors:
         - C-CONTEXT-0004-B
+        - C-CONTEXT-0004-E
     - id: C-CONTEXT-0012
       anchors:
         - C-CONTEXT-0012-A
         - C-CONTEXT-0012-B
         - C-CONTEXT-0012-C
 revisions:
+  - version: 0.3.0-alpha.0
+    change: strengthened
+    summary: Added actual-port explicit-consumer and composed Scroll opaque identity integration regressions.
   - version: 0.3.0-alpha.0
     change: strengthened
     summary: Bound provider-as-self and falsy opaque token resolution, updates and terminal cleanup to executable Module evidence.

--- a/spec/tests/T-EVENT-0003.yaml
+++ b/spec/tests/T-EVENT-0003.yaml
@@ -180,6 +180,13 @@ implementations:
       - React, Vue, and Web Component profiles inject the tested Adapter Base projection as their Event default-action capability.
     consumesCases:
       - T-EVENT-0003-CASE-DEFAULT-ACTION-WEB
+  - id: adapter-vue2-follow-through
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue2/test/catalog-conformance.test.ts
+    required: true
+    consumesCases:
+      - T-EVENT-0003-CASE-DEFAULT-ACTION-WEB
 verifies:
   modules:
     - id: M-EVENT-0001

--- a/spec/tests/T-EXPOSE-0002.yaml
+++ b/spec/tests/T-EXPOSE-0002.yaml
@@ -162,6 +162,14 @@ implementations:
     required: true
     consumesCases:
       - T-EXPOSE-0002-CASE-PROFILE
+  - id: adapter-vue2-follow-through
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue2/test/catalog-conformance.test.ts
+    required: true
+    consumesCases:
+      - T-EXPOSE-0002-CASE-LIFECYCLE
+      - T-EXPOSE-0002-CASE-CALLBACK-SCOPE
 verifies:
   modules:
     - id: M-EXPOSE-0001

--- a/spec/tests/T-EXPOSE-EVENT-0002.yaml
+++ b/spec/tests/T-EXPOSE-EVENT-0002.yaml
@@ -173,6 +173,14 @@ implementations:
     required: true
     consumesCases:
       - T-EXPOSE-EVENT-0002-CASE-PROFILES
+  - id: adapter-vue2-follow-through
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue2/test/catalog-conformance.test.ts
+    required: true
+    consumesCases:
+      - T-EXPOSE-EVENT-0002-CASE-DECLARATION
+      - T-EXPOSE-EVENT-0002-CASE-PROFILES
 verifies:
   modules:
     - id: M-EXPOSE-EVENT-0001

--- a/spec/tests/T-EXPOSE-STATE-0002.yaml
+++ b/spec/tests/T-EXPOSE-STATE-0002.yaml
@@ -135,6 +135,14 @@ implementations:
     required: true
     consumesCases:
       - T-EXPOSE-STATE-0002-CASE-WEB-BOUNDARY
+  - id: adapter-vue2-follow-through
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue2/test/catalog-conformance.test.ts
+    required: true
+    consumesCases:
+      - T-EXPOSE-STATE-0002-CASE-LIFECYCLE
+      - T-EXPOSE-STATE-0002-CASE-EXTERNAL-HANDLE
 verifies:
   modules:
     - id: M-EXPOSE-STATE-0001

--- a/spec/tests/T-PROPS-0012.yaml
+++ b/spec/tests/T-PROPS-0012.yaml
@@ -132,17 +132,6 @@ implementations:
     required: true
     consumesCases:
       - T-PROPS-0012-CASE-FRAMEWORK-NORMALIZATION
-  - id: adapter-vue2-props-translation
-    kind: adapter-test
-    status: passing
-    path: packages/adapters/vue2/test/props-update.test.ts
-    required: true
-    notes:
-      - Supporting attrs classification and typed-listener exclusion evidence is in packages/adapters/vue2/test/expose.test.ts and packages/adapters/vue2/test/event.test.ts.
-    consumesCases:
-      - T-PROPS-0012-CASE-ADAPTER-WIRING
-      - T-PROPS-0012-CASE-INVALIDATION
-      - T-PROPS-0012-CASE-FRAMEWORK-NORMALIZATION
   - id: adapter-web-component-props-normalization
     kind: adapter-test
     status: passing
@@ -166,6 +155,22 @@ implementations:
     required: true
     consumesCases:
       - T-PROPS-0012-CASE-DIRECT-APPLY
+  - id: adapter-vue2-props-host-source
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue2/test/contract/props-host-source.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0012-CASE-ADAPTER-WIRING
+      - T-PROPS-0012-CASE-SOURCE-SNAPSHOT
+      - T-PROPS-0012-CASE-INVALIDATION
+  - id: adapter-vue2-props-normalization
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue2/test/contract/props-normalization.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0012-CASE-FRAMEWORK-NORMALIZATION
 verifies:
   modules:
     - id: M-PROPS-0001

--- a/spec/tests/T-STATE-0005.yaml
+++ b/spec/tests/T-STATE-0005.yaml
@@ -142,6 +142,14 @@ implementations:
     required: true
     consumesCases:
       - T-STATE-0005-CASE-REQUIRED-SUPPORT
+  - id: adapter-vue2-follow-through
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue2/test/catalog-conformance.test.ts
+    required: true
+    consumesCases:
+      - T-STATE-0005-CASE-INSTANCE-LIFETIME
+      - T-STATE-0005-CASE-EXPLICIT-RENDER
 verifies:
   modules:
     - id: M-STATE-0001


### PR DESCRIPTION
## Summary

Catalog Context as a coherent Module/Host Capability/Adapter slice and close concrete Vue 2 follow-through gaps. Add draft `M-CONTEXT-0001`, identity/ancestry HC entities, four official Adapter support relations, and `T-CONTEXT-0003` with real-framework tests.

The Vue 2 keep-alive audit exposed a shared Adapter reader regression: replacement expose snapshots recreated top-level method wrappers across view detachment. Preserve wrapper identity while retaining the current root receiver, distinct nested receivers, callback scope, and terminal invalidation.

## Related context

- Issue: maintainer-directed Context cataloging and Vue 2 follow-through audit; no automatic issue closure.
- Applicable entities: draft `C-CONTEXT-0001..0012`, `M-CONTEXT-0001`, `HC-CONTEXT-IDENTITY-0001`, `HC-CONTEXT-ANCESTRY-0001`; existing official React, Vue 3, Vue 2 and Web Component A profiles.
- Criteria / evidence: `C-CONTEXT-0008-C`, `C-CONTEXT-0012-A/B/C`, `C-EXPOSE-0008-B`; `T-CONTEXT-0002/0003`, `T-PROPS-0012`, `T-EVENT-0003`, `T-STATE-0005`, and Expose-family T entities.
- Engineering record: `internal/records/2026-09-07-context-module-host-cap-adapter-audit.zh-CN.md`.

## Scope boundary

- The maintainer explicitly accepted provider self-update without subscription; consumers still require subscription. The exception does not change read, tryRead or tryUpdate authority.
- Clarify old Context unmount wording using the existing repeatable-view versus terminal-instance lifecycle authority. Reconcile legacy readable projections.
- Add Vue 2 evidence for Props normalization/invalidation, default action/global event cleanup, keep-alive State/Expose retention and current outward listeners.
- No lifecycle promotion, new public author API, non-Web conformance, or complete portal/cross-root relocation matrix.

## Source-of-truth alignment

- [x] Checked applicable spec entities before relying on contracts, records, implementation or docs.
- [x] Updated criteria, revisions, executable evidence, relations and affected legacy projections together.
- [x] No empty catalog identities or implicit stable promotion.

## Contribution provenance

- [x] This contribution includes material AI-assisted generation or transformation.
- [x] No third-party source disclosure is required.

### Third-party or upstream sources

No external code or assets were imported. Tests reuse and adapt existing Proto UI fixtures and Adapter test patterns from baseline `f8f98d22` under this repository's MIT license.

### AI assistance

OpenAI Codex assisted with repository tracing, catalog authoring, tests, the shared reader repair and documentation. The current user decided the provider-update boundary and authorized submission after receiving the change and validation summary. No independent human code review is claimed. Source material used was this repository and current user instructions; no external private code was supplied for this change.

## DCO

- [x] The commit includes a matching Signed-off-by trailer.

## Prototype website preview

- [x] A new or updated website page is not applicable: no public Prototype identity, anatomy or visual demo behavior is introduced. This is Context cataloging, Adapter evidence and a shared Expose lifecycle repair.
- Browser/visual preview: not performed; tests mount real framework owners in happy-dom.

## Validation

Node 22.23.2; pnpm 10.32.1 via Corepack.

- `corepack pnpm@10.32.1 exec vitest run packages/modules/context/test packages/runtime/test/contract/context-lifecycle.v1.contract.test.ts packages/adapters/base/test packages/adapters/react/test packages/adapters/vue/test packages/adapters/vue2/test packages/adapters/web-component/test packages/spec/test` — 188 files, 560 tests passed. Spec suites were separately run with the correct `packages/spec` directory below.
- `corepack pnpm@10.32.1 exec vitest run packages/spec` — 22 files, 61 tests passed. Candidate evidence initially used a temporary Git index; repeated after commit with the real index.
- `corepack pnpm@10.32.1 check:types` — passed (Astro: 188 files, zero diagnostic errors/warnings/hints).
- `corepack pnpm@10.32.1 spec:docs:agent` and `corepack pnpm@10.32.1 workspace:generate` — 572 entities; generated local projections remain ignored.
- `corepack pnpm@10.32.1 check:prototype-catalog`, `check:agent-doc`, `check:agent-operations` — passed; agent operations includes 58 passing tests.
- `git diff --check` and commit-time Prettier — passed.
- Full release-gated `pnpm test`, docs production build and real-browser geometry checks were not run; affected Adapter/module/runtime/spec suites and type checks define this validation scope.

## Context identity and capability boundaries

The final implementation reconciles these boundaries across contract, Context port and its Scroll consumer:

- C-CONTEXT-0004 explicitly resolves from the participant itself, with a clarification revision and executable provider-as-self evidence.
- Null alone denotes identity absence. Falsy tokens (0, false, empty string, undefined and NaN) preserve resolution, updates, callback delivery and terminal cleanup. Identity equality matches the provider Map's SameValueZero semantics.
- The actual Context port preserves argument count. Omission validates the owner with getSelfToken; absent or null owner caps fail diagnostically. Explicit undefined remains a consumer identity, and explicit null deliberately returns no scope without requiring owner identity or ancestry.
- Composed Scroll uses null-only absence and matching identity semantics. Real Context/State/Scroll module tests with supplied Anatomy domain/target facts verify host scrollbar bindings, missing or mismatched scopes, and restoration.

Latest diagnostic correction: f2d1a068. Actual-port tests reproduce both owner-identity failures before the fix and verify missing ancestry, explicit null, and explicit valid consumers independently. The existing T-CONTEXT-0003-CASE-AVAILABILITY mapping covers this evidence; no further semantic change was needed.

Latest validation: `corepack pnpm@10.32.1 exec vitest run packages/modules/context/test packages/modules/scroll/test packages/runtime/test packages/adapters/react/test/context.integration.test.ts packages/adapters/vue/test/context.integration.test.ts packages/adapters/vue2/test/context.integration.test.ts packages/adapters/web-component/test/context.integration.test.ts --maxWorkers=2 --minWorkers=1 --testTimeout=20000` — 264 passed, 34 existing todo (49 passing files, 3 skipped). `check:types:workspace` and `git diff --check` passed.

The preceding integration validation also passed 336 tests including Anatomy and spec, plus full check:types and catalog/projection checks; its initial high-concurrency run hit default 5-second spec timeouts and passed after limiting concurrency without changing assertions. Browser geometry and the full release suite were not rerun locally for these follow-ups. Independent re-review remains pending.
