### PR TITLE
style(www): refine documentation navigation and reading layout

### DIFF
--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -65,8 +65,7 @@ const protoUiSourcePlugin = {
 
 const inProgressBadge = {
   text: { en: 'WIP', 'zh-CN': '施工中' },
-  class:
-    'text-xs px-1.5 h-4.5 rounded-full bg-amber-100 text-amber-900 dark:bg-amber-900 dark:text-amber-100',
+  class: 'docs-wip-badge',
 };
 const whitepaperRedirects = {
   '/en/whitepaper/component-as-protocol': '/en/whitepaper/1-components-before-code/',

--- a/apps/www/src/components/override/PageFrame.astro
+++ b/apps/www/src/components/override/PageFrame.astro
@@ -18,7 +18,12 @@ const localizedPath = (path: string) =>
   <script>
     import '../../scripts/proto-concept';
   </script>
-  <div class="bg-background container-wrapper flex flex-1 flex-col px-2">
+  <div
+    class:list={[
+      'bg-background container-wrapper flex flex-1 flex-col px-2',
+      { 'docs-shell': hasSidebar },
+    ]}
+  >
     <header class="bg-background sticky top-0 z-50 w-full"><slot name="header" /></header>
     <noscript>
       <style is:inline>
@@ -147,6 +152,12 @@ const localizedPath = (path: string) =>
 </script>
 
 <style>
+  /* Keep the header and all three documentation columns on one centered canvas. */
+  .docs-shell {
+    max-width: 85rem;
+    margin-inline: auto;
+  }
+
   .docs-sidebar {
     width: 0;
     flex: none;

--- a/apps/www/src/components/override/TwoColumnContent.astro
+++ b/apps/www/src/components/override/TwoColumnContent.astro
@@ -43,7 +43,6 @@ const mainPaneClass = isSplash
       .right-sidebar {
         position: fixed;
         top: 0;
-        border-inline-start: 1px solid var(--sl-color-hairline);
         padding-top: var(--sl-nav-height);
         width: 100%;
         height: 100vh;

--- a/apps/www/src/styles/markdown.css
+++ b/apps/www/src/styles/markdown.css
@@ -57,7 +57,7 @@
    */
   .docs-content-flow {
     --docs-content-flow-space: calc(var(--spacing) * 4);
-    margin-block-start: var(--docs-content-flow-space);
+    margin-block-start: 2rem;
   }
 
   .docs-content-flow > :where(* + *) {
@@ -90,6 +90,17 @@
 
   main[data-pagefind-body] p {
     @apply leading-[1.625] [&:not(:first-child)]:mt-4;
+  }
+
+  /* Prose has a roomier rhythm; embedded MDX roots retain the 1rem flow gap. */
+  main[data-pagefind-body] .docs-content-flow > p,
+  main[data-pagefind-body] .docs-content-flow > blockquote p,
+  main[data-pagefind-body] .docs-content-flow > :is(ul, ol) li {
+    line-height: 1.8;
+  }
+
+  main[data-pagefind-body] .docs-content-flow > :is(p, ul, ol) + :is(p, ul, ol) {
+    margin-block-start: 1.5rem;
   }
 
   main[data-pagefind-body] a {
@@ -195,6 +206,42 @@
 
   main[data-pagefind-body] ul {
     @apply my-6 ml-6 list-disc [&>li]:mt-2;
+  }
+
+  main[data-pagefind-body] .docs-content-flow > :is(ul, ol) {
+    margin-inline-start: 0;
+    margin-block: 1.5rem 0;
+    padding-inline-start: 1.5rem;
+  }
+
+  main[data-pagefind-body] .docs-content-flow > ul {
+    list-style-type: disc;
+  }
+
+  main[data-pagefind-body] .docs-content-flow > ol {
+    list-style-type: decimal;
+  }
+
+  main[data-pagefind-body] .docs-content-flow > :is(ul, ol) li:first-child {
+    margin-block-start: 0;
+  }
+
+  main[data-pagefind-body] .docs-content-flow > :is(ul, ol) li + li {
+    margin-block-start: 0.5rem;
+  }
+
+  main[data-pagefind-body] .docs-content-flow > :is(ul, ol) :is(ul, ol) {
+    margin-inline-start: 0;
+    margin-block: 0.5rem 0;
+    padding-inline-start: 1.5rem;
+  }
+
+  main[data-pagefind-body] .docs-content-flow > :is(ul, ol) ul {
+    list-style-type: circle;
+  }
+
+  main[data-pagefind-body] .docs-content-flow > :is(ul, ol) ol {
+    list-style-type: decimal;
   }
 
   /* 仅对行内 code 应用样式，排除 pre>code 代码块（如 Shiki 高亮），避免暗色模式下黑色矩形 */

--- a/apps/www/src/styles/sidebar.css
+++ b/apps/www/src/styles/sidebar.css
@@ -7,47 +7,116 @@
     @apply w-full;
   }
 
-  .sidebar-pane .sidebar-content {
-    @apply w-full;
-  }
-
   .sidebar-pane .top-level {
     @apply w-full;
+    padding-inline: 0.5rem;
   }
 
-  .sidebar-pane summary {
-    @apply flex px-2;
-    @apply ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md text-xs outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0 group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 text-muted-foreground font-medium;
+  /* Align section headings and their immediate children on one reading axis. */
+  .sidebar-pane .top-level li {
+    margin-inline-start: 0;
+    padding-inline-start: 0;
+    border-inline-start: 0;
   }
 
-  .sidebar-pane summary span {
-    @apply ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md text-xs outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0 group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 text-muted-foreground font-medium;
+  .sidebar-pane .top-level > li + li {
+    margin-block-start: 1.5rem;
   }
 
-  .sidebar-pane details {
-    @apply p-2;
+  .sidebar-pane .top-level details {
+    padding: 0;
   }
-  .sidebar-pane details ul {
+
+  .sidebar-pane .top-level ul {
     @apply flex flex-col gap-0.5;
   }
 
-  .sidebar-pane a {
-    @apply h-7.5 flex items-center font-medium flex justify-between;
-  }
-  .sidebar-pane a span {
-    @apply px-2 h-full rounded-sm flex items-center border-transparent text-[13px] leading-5;
-  }
-  .sidebar-pane a:hover span {
-    @apply bg-muted border-muted;
+  /* Only nested sections introduce an indent and a quiet guide for level three. */
+  .sidebar-pane .top-level ul details > ul {
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.75rem;
+    border-inline-start: 1px solid var(--color-border);
   }
 
-  .sidebar-pane a[aria-current='page'] span {
-    @apply bg-accent text-accent-foreground border-accent;
+  .sidebar-pane .top-level summary {
+    @apply flex items-center justify-between gap-2 rounded-md text-muted-foreground;
+    min-height: 2rem;
+    padding: 0.375rem 0.5rem;
+    font-size: 0.75rem;
+    line-height: 1.25rem;
+    font-weight: 500;
   }
 
-  :where(a)[aria-current='page'],
-  :where(a)[aria-current='page']:hover,
-  :where(a)[aria-current='page']:focus {
-    background: transparent;
+  .sidebar-pane .top-level summary .group-label {
+    min-width: 0;
+  }
+
+  .sidebar-pane .top-level summary .large {
+    font: inherit;
+    color: inherit;
+  }
+
+  .sidebar-pane .top-level ul summary {
+    @apply text-sidebar-foreground;
+    font-size: 0.8125rem;
+  }
+
+  .sidebar-pane .top-level summary .caret {
+    width: 0.875rem;
+    height: 0.875rem;
+    color: var(--color-muted-foreground);
+  }
+
+  .sidebar-pane .top-level a {
+    @apply flex items-center justify-between gap-2 rounded-md text-sidebar-foreground;
+    min-height: 2rem;
+    padding: 0.375rem 0.5rem;
+    font-size: 0.8125rem;
+    line-height: 1.25rem;
+    font-weight: 400;
+  }
+
+  .sidebar-pane .top-level a > span:first-child {
+    min-width: 0;
+  }
+
+  .sidebar-pane .top-level .sl-badge {
+    flex-shrink: 0;
+  }
+
+  .sidebar-pane .top-level .docs-wip-badge {
+    border: 1px solid var(--color-border);
+    background: var(--color-muted);
+    color: var(--color-muted-foreground);
+    border-radius: 999px;
+    padding: 0.125rem 0.375rem;
+    font-family: inherit;
+    font-size: 0.6875rem;
+    font-weight: 500;
+    line-height: 1rem;
+    white-space: nowrap;
+  }
+
+  .sidebar-pane .top-level a:hover,
+  .sidebar-pane .top-level summary:hover {
+    @apply bg-muted text-sidebar-foreground;
+  }
+
+  .sidebar-pane .top-level a[aria-current='page'] {
+    @apply bg-accent text-accent-foreground;
+    font-weight: 500;
+  }
+
+  .sidebar-pane .top-level a:focus-visible,
+  .sidebar-pane .top-level summary:focus-visible {
+    outline: 2px solid var(--color-sidebar-ring);
+    outline-offset: 2px;
+  }
+
+  @media (max-width: 63.999rem) {
+    .sidebar-pane .top-level a,
+    .sidebar-pane .top-level summary {
+      min-height: 2.75rem;
+    }
   }
 }


### PR DESCRIPTION
## Summary

The documentation sidebar accumulated indentation across three levels, prose spacing was inconsistent, and wide screens pushed navigation far away from the article. This change aligns the first two sidebar levels, improves reading rhythm, and centers the header and three-column documentation layout within a 1360px maximum width.

- Retain a single indent and subtle guide for third-level navigation; support wrapping labels, full-row selection, keyboard focus, and 44px mobile rows.
- Replace the mixed blue/amber WIP badge with a neutral palette in both themes.
- Use 24px between paragraphs and lists, 1.8 prose line-height, and 32px between the description and body; preserve compact embedded-example spacing.
- Keep article/sidebars at their existing widths on wide screens, leave additional space outside the centered shell, and remove the long right-TOC separator.

## Related context

- Issue: maintainer-directed website styling session; no linked issue.
- Applicable spec entities and lifecycle: no entity prescribes these website presentation choices; no protocol semantics or lifecycle changed.
- Criteria / test anchors: existing documentation flow boundaries in `apps/www/src/content/docs/zh-cn/docs-content-flow.browser.test.ts` informed preservation of embedded-example and section gaps.
- Related upstream: visual inspection of https://ui.shadcn.com/docs and https://tailwindcss.com/docs/installation/using-vite.

## Scope boundary

The maintainer requested and reviewed the sidebar, badge, typography, centered-header layout, and separator changes. Only five website configuration/component/style files change. Whitepaper prose, public APIs, routing, native disclosure behavior, and the landing-page layout remain unchanged.

## Source-of-truth alignment

- [x] I checked applicable `spec/**` entities before relying on contracts, records, implementation, or docs.
- Normative behavior changes: not applicable; presentation only.
- [x] This change does not create an empty catalog identity or silently widen a draft/active public guarantee.

## Contribution provenance

- [x] This contribution includes material AI-assisted generation or transformation.
- [x] No third-party source disclosure is required for copied material: no external implementation, tokens, or assets were copied.

### Third-party or upstream sources

Public shadcn/ui and Tailwind documentation were observed in a browser for visual reference on 2026-09-07. Existing installed Starlight component markup and CSS were inspected to understand overrides. No third-party code or assets were imported by this change.

### AI assistance

Codex generated the local CSS/Astro adjustments and performed build and browser validation under direct maintainer guidance. The maintainer reviewed iterative local previews and selected the layout direction. Repository code and public documentation pages were inspected; no external private code was supplied.

## DCO

- [x] I have checked the DCO status of this PR: the single commit carries the configured contributor's `Signed-off-by` trailer.

## Prototype website preview

- [x] A new or updated website page is not applicable because no public Prototype behavior changes; this PR updates the existing documentation shell.
- Public docs routes: `/zh-cn/start-here/what-you-saw/`, `/zh-cn/whitepaper/3-component-boundary/`, `/en/start-here/quick-start/`, `/zh-cn/ui-libraries/shadcn/tooltip/`.
- Applicable runtimes manually reviewed: native Astro documentation shell; runtime conformance is outside this styling change.
- External demo orchestration: none added.

## Validation

Node.js 22.23.2 and pnpm 10.32.1:

- `corepack pnpm@10.32.1 --filter apps-www build` — passed; 238 pages and search index generated.
- `corepack pnpm@10.32.1 check:public-docs` — passed.
- `corepack pnpm@10.32.1 test:public-docs` — passed.
- `corepack pnpm@10.32.1 check:agent-operations` — passed.
- `corepack pnpm@10.32.1 check:agent-doc` — passed.
- Prettier checks / commit hook and `git diff --check` — passed.
- Browser: Chinese and English routes, light/dark themes, WIP selected state, wrapping long labels, keyboard disclosure/focus, 390px mobile menu, and 1024/1280/1440/1920/2560px layouts. At 1920px, the shell is 1360px with 280px outer margins and 64px article-to-sidebar gaps. Sticky header and sidebars remain positioned after scrolling.
- Measured prose gaps: paragraph/paragraph and paragraph/list 24px; description/opening quote 32px. Embedded code-example gaps remain 16px and section gaps 64px. Right-TOC border is 0px while Markdown quote borders remain 2px.
- Full runtime/type and browser-harness suites were not run for this bounded presentation change; browser verification used the live local website.
