### PR TITLE
feat(base): complete Image consumer surface

### DIFF
--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -377,6 +377,11 @@ export default defineConfig({
                   slug: 'ui-libraries/base/textarea',
                 },
                 {
+                  label: 'Image',
+                  translations: { en: 'Image', 'zh-CN': 'Image' },
+                  slug: 'ui-libraries/base/image',
+                },
+                {
                   label: 'Separator',
                   translations: { en: 'Separator', 'zh-CN': 'Separator' },
                   slug: 'ui-libraries/base/separator',

--- a/apps/www/public/images/base-image/landscape.svg
+++ b/apps/www/public/images/base-image/landscape.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="320" viewBox="0 0 640 320" preserveAspectRatio="none">
+  <rect width="640" height="320" fill="#d9edf4"/>
+  <circle cx="490" cy="86" r="42" fill="#f6ba63"/>
+  <path d="M0 264 174 72 352 264Z" fill="#436f87"/>
+  <path d="m112 140 62-68 64 69-65-24Z" fill="#f5f9fa"/>
+  <path d="m252 280 155-164 173 164Z" fill="#668d84"/>
+  <path d="M0 251q164-42 320 12t320-7v64H0Z" fill="#243f53"/>
+</svg>

--- a/apps/www/public/images/base-image/portrait.svg
+++ b/apps/www/public/images/base-image/portrait.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="480" viewBox="0 0 320 480" preserveAspectRatio="none">
+  <rect width="320" height="480" fill="#f6e5d2"/>
+  <circle cx="160" cy="139" r="70" fill="#d87559"/>
+  <path d="M55 480V300a105 105 0 0 1 210 0v180Z" fill="#55766b"/>
+  <path d="M101 480V306a59 59 0 0 1 118 0v174Z" fill="#273f42"/>
+</svg>

--- a/apps/www/src/components/PrototypeLibraryOverview.astro
+++ b/apps/www/src/components/PrototypeLibraryOverview.astro
@@ -175,6 +175,15 @@ const entriesByLibrary: Record<LibraryId, PrototypeEntry[]> = {
         : 'Host-mediated native multiline text editing.',
       href: './textarea/',
     },
+    {
+      id: 'image',
+      name: 'Image',
+      demoId: 'demo-base-image',
+      description: isZh
+        ? '宿主图片呈现、替代文本与加载状态。'
+        : 'Host-owned images, alternative text, and loading status.',
+      href: './image/',
+    },
   ],
   shadcn: [
     {

--- a/apps/www/src/components/PrototypePreviewer/DemoMatrix.astro
+++ b/apps/www/src/components/PrototypePreviewer/DemoMatrix.astro
@@ -39,6 +39,14 @@ function getGroupId(id: string) {
 
 const demos = getAvailableDemos().sort((a, b) => a.localeCompare(b));
 const runtimes = InternalAdapterIds;
+// D-IMAGE-VIEW-PROJECTION-0001-E currently admits WC, React, and Vue 3 only.
+function isUnavailable(demoId: string, runtime: RuntimeId) {
+  return demoId === 'demo-base-image' && runtime === 'vue2';
+}
+const previewCount = demos.reduce(
+  (count, demoId) => count + runtimes.filter((runtime) => !isUnavailable(demoId, runtime)).length,
+  0
+);
 const groups = demos.reduce<DemoGroup[]>((result, demoId) => {
   const groupId = getGroupId(demoId);
   let group = result.find((item) => item.id === groupId);
@@ -75,7 +83,7 @@ function getPreviewerClass(demoId: string) {
       <span class="demo-matrix__label">Adapters</span>
     </div>
     <div>
-      <span class="demo-matrix__metric">{demos.length * runtimes.length}</span>
+      <span class="demo-matrix__metric">{previewCount}</span>
       <span class="demo-matrix__label">Preview mounts</span>
     </div>
   </div>
@@ -101,17 +109,24 @@ function getPreviewerClass(demoId: string) {
                   <section
                     class="demo-matrix__adapter"
                     aria-label={`${demoId} ${runtimeLabels[runtime]}`}
+                    data-unavailable={
+                      isUnavailable(demoId, runtime) ? `${demoId}:${runtime}` : undefined
+                    }
                   >
                     <div class="demo-matrix__adapter-label">{runtimeLabels[runtime]}</div>
-                    <PrototypePreviewer
-                      demoId={demoId}
-                      initialRuntime={runtime}
-                      runtimes={[runtime]}
-                      allowExperimentalRuntimes
-                      toolbar={false}
-                      codePanel={false}
-                      class={getPreviewerClass(demoId)}
-                    />
+                    {isUnavailable(demoId, runtime) ? (
+                      <p>Image View is not implemented for Vue 2.</p>
+                    ) : (
+                      <PrototypePreviewer
+                        demoId={demoId}
+                        initialRuntime={runtime}
+                        runtimes={[runtime]}
+                        allowExperimentalRuntimes
+                        toolbar={false}
+                        codePanel={false}
+                        class={getPreviewerClass(demoId)}
+                      />
+                    )}
                   </section>
                 ))}
               </div>

--- a/apps/www/src/components/PrototypePreviewer/prototype-modules.ts
+++ b/apps/www/src/components/PrototypePreviewer/prototype-modules.ts
@@ -119,6 +119,10 @@ const manualPrototypeModules: Record<string, PrototypeModuleLoader> = {
     const mod = await import('@proto.ui/prototypes-base/textarea');
     registerPrototype('base-textarea-root', mod.textareaRoot);
   },
+  'base-image-root': async () => {
+    const mod = await import('@proto.ui/prototypes-base/image');
+    registerPrototype('base-image-root', mod.imageRoot);
+  },
   'brutalist-textarea-root': async () => {
     const mod = await import('@proto.ui/prototypes-brutalist/textarea');
     registerPrototype('brutalist-textarea-root', mod.brutalistTextareaRoot);

--- a/apps/www/src/content/docs/en/ui-libraries/base/image.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/image.mdx
@@ -1,0 +1,99 @@
+---
+title: 'Image'
+desp: 'Image base prototype'
+description: 'Host-owned image presentation with explicit accessibility and loading status'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+`base-image-root` is a draft Base prototype available in the `0.3.0-alpha.0` package line. It declares one host-owned image target and exposes its source, fit, and loading status. Web Components, React, and Vue 3 currently project it to one physical `<img>` per instance. Vue 2 Image View wiring is not implemented; these previews prove a bounded Web profile, not non-Web host support.
+
+<div>
+  <PrototypePreviewer
+    demoId="demo-base-image"
+    initialRuntime="wc"
+    runtimes={['wc', 'react', 'vue']}
+  />
+</div>
+
+The three upper frames use the same image and size to compare `contain`, `cover`, and `fill`. The small illustration is decorative. The lower image starts without a source: load, replace, break, or clear its source to inspect real `loadingStatusChange` events. A cached or local image may finish loading too quickly to see the intermediate state; the transition log retains it. The controls, frame sizes, and log belong to this demo, not to Base Image.
+
+## Use Image
+
+Import the real prototype and adapt it in the host application:
+
+```tsx
+import * as React from 'react';
+import { createReactAdapter } from '@proto.ui/adapter-react';
+import { imageRoot } from '@proto.ui/prototypes-base/image';
+
+const Image = createReactAdapter(React)(imageRoot);
+
+export function Cover() {
+  return (
+    <Image
+      source="/images/cover.jpg"
+      a11yMode="informative"
+      alternativeText="A mountain ridge reflected in a lake"
+      fit="cover"
+      surfaceStyle={{ width: '100%', height: '240px' }}
+    />
+  );
+}
+```
+
+Vue uses `createVueAdapter(Vue)(imageRoot)`. Web Components use `AdaptToWebComponent(imageRoot, { registerAs: 'app-image' })`; set the declared props with `setElementProps()` before mounting. Use matching exact package versions throughout the application.
+
+The workspace CLI registers `base-image` for `react`, `vue`, and `wc`, generating `BaseImageRoot` or `BaseImageRootElement`. A build containing the entry supports `proto-ui add react base-image` and the corresponding `vue` / `wc` commands.
+
+Historical release boundary: the `0.3.0-alpha.0` prerelease contains the direct Image exports shown above, but its CLI predates the `base-image` registry entry. Image is outside the stable `0.2.0` surface.
+
+## Props and Exposes
+
+| Prop | Meaning |
+| --- | --- |
+| `source` | Opaque URI string. Omitted or empty means `idle`. Synchronizing the same URI does not restart a settled request. |
+| `a11yMode` | Choose `informative` or `decorative` explicitly. The default is `informative`, which still requires non-empty alternative text. |
+| `alternativeText` | Required non-empty text for an informative image. Decorative input must omit it or use an empty string. |
+| `fit` | `contain` (default), `cover`, or `fill`, centered in the consumer-sized frame. |
+
+An informative image receives its alternative text on the physical target. A decorative image has empty `alt` and contributes no image name to the accessibility tree. Contradictory or incomplete accessibility input is rejected; Base Image does not invent a label from the URI.
+
+The exposed states are `source`, `fit`, and `loadingStatus`. The only outward transition event is `loadingStatusChange`:
+
+```text
+{ status, previousStatus, source }
+```
+
+Status is `idle | loading | loaded | error`. A changed non-empty source enters `loading` before host work; its current request can settle as `loaded` or `error`. Replacing a source clears the previous visual and retires its pending completion. Clearing the source returns to `idle`. Native events and host error objects are not part of the payload.
+
+The current Web profile uses a displayable synchronous cache hit or that source request's `HTMLImageElement.decode()` settlement. This is a Web readiness mapping, not a promise that every host uses the same decoder API. A failed source has no built-in retry button or fallback content; the application chooses what to display around it.
+
+## Compose and Style
+
+Root has no authored children. The application supplies dimensions, framing, and any adjacent caption or status display; `fit` describes how the image fills that physical frame. Web Components retain a custom-element boundary with one inner image; `surfaceClassName` and `surfaceStyle` target the image. React and Vue use the physical image as their root.
+
+A prototype reusing the authored hook must also reuse its frozen static requirements so the Adapter can select the image target before setup:
+
+```ts
+import { definePrototype } from '@proto.ui/core';
+import { asImageRoot } from '@proto.ui/prototypes-base/image';
+
+const framedImage = definePrototype({
+  name: 'framed-image',
+  modules: asImageRoot.modules,
+  setup() {
+    asImageRoot();
+  },
+});
+```
+
+Base Image does not own Avatar fallback, upload, cropping, zoom, gallery navigation, responsive `srcset`, caching policy, or live announcements. An image used inside a Button or Link does not become an independent control; the surrounding control owns activation and its functional name.
+
+## References
+
+- Prototype: [P-BASE-IMAGE](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-IMAGE.yaml)
+- Contract: [C-IMAGE-VIEW-0001](https://github.com/Proto-UI/Proto-UI/blob/main/spec/contracts/C-IMAGE-VIEW-0001.yaml)
+- Web projection: [D-IMAGE-VIEW-PROJECTION-0001](https://github.com/Proto-UI/Proto-UI/blob/main/spec/decisions/D-IMAGE-VIEW-PROJECTION-0001.yaml)
+- Source: [packages/prototypes/base/src/image](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/image)
+- Evidence: [T-IMAGE-VIEW-0001](https://github.com/Proto-UI/Proto-UI/blob/main/spec/tests/T-IMAGE-VIEW-0001.yaml)

--- a/apps/www/src/content/docs/zh-cn/demo-base-image.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-image.browser.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment node
+
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import type { Browser, Locator, Page } from 'playwright-core';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  applyColorScheme,
+  launchBrowser,
+  openRoute,
+  selectRuntime,
+  startServer,
+  stopServer,
+} from './browser-harness';
+
+const ROUTE = '/en/ui-libraries/base/image/';
+const RUNTIMES = ['wc', 'react', 'vue'] as const;
+let browser: Browser;
+let baseUrl = '';
+
+function physicalImage(previewer: Locator, ref: string): Locator {
+  return previewer.locator(`img[data-demo-ref="${ref}"], [data-demo-ref="${ref}"] img`);
+}
+
+async function state(previewer: Locator, expected: string): Promise<void> {
+  await expect
+    .poll(() => previewer.locator('[data-demo-ref="status"]').textContent())
+    .toBe(expected);
+}
+
+async function settle(page: Page): Promise<void> {
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      })
+  );
+}
+
+beforeAll(async () => {
+  baseUrl = await startServer(ROUTE);
+  browser = await launchBrowser();
+}, 150_000);
+
+afterAll(async () => {
+  await browser?.close();
+  await stopServer();
+}, 60_000);
+
+// T-IMAGE-VIEW-0001-CASE-PUBLIC-BROWSER
+describe.sequential('Base Image public consumer browser evidence', () => {
+  for (const runtime of RUNTIMES) {
+    for (const scheme of ['light', 'dark'] as const) {
+      for (const width of [1280, 390]) {
+        it(`${runtime} projects fit, a11y, and resource transitions in ${scheme} at ${width}px`, async () => {
+          const { context, page, previewer } = await openRoute(browser, baseUrl, ROUTE, {
+            width,
+            height: 900,
+          });
+          let release: (() => void) | undefined;
+          try {
+            await applyColorScheme(page, scheme);
+            await selectRuntime(page, previewer, runtime, 'img', 5);
+            await state(previewer, 'idle');
+            expect(await previewer.locator('.host img').count()).toBe(5);
+
+            // P-BASE-IMAGE-DECLARATION/ALT-TEXT/FIT and D-IMAGE-VIEW-PROJECTION-0001-E.
+            // Frame dimensions are authored by this demo, not Base Image defaults.
+            const widths: number[] = [];
+            for (const fit of ['contain', 'cover', 'fill']) {
+              const image = physicalImage(previewer, `fit-${fit}`);
+              expect(await image.count()).toBe(1);
+              await expect
+                .poll(() => image.evaluate((el) => (el as HTMLImageElement).naturalWidth))
+                .toBe(640);
+              const facts = await image.evaluate((el) => {
+                const image = el as HTMLImageElement;
+                const rect = image.getBoundingClientRect();
+                return {
+                  fit: getComputedStyle(image).objectFit,
+                  position: getComputedStyle(image).objectPosition,
+                  height: rect.height,
+                  width: rect.width,
+                  alt: image.alt,
+                  tabIndex: image.tabIndex,
+                };
+              });
+              expect(facts).toMatchObject({
+                fit,
+                position: '50% 50%',
+                height: 112,
+                alt: `Mountains and a sun (${fit})`,
+                tabIndex: -1,
+              });
+              expect(facts.width).toBeGreaterThan(0);
+              widths.push(facts.width);
+            }
+            expect(Math.max(...widths) - Math.min(...widths)).toBeLessThan(1);
+            expect(await physicalImage(previewer, 'decorative').getAttribute('alt')).toBe('');
+            expect(await previewer.locator('.host').getByRole('img').count()).toBe(4);
+
+            const image = physicalImage(previewer, 'resource');
+            const log = previewer.locator('[data-demo-ref="transitions"]');
+            const load = previewer.getByRole('button', { name: 'Load landscape', exact: true });
+            await load.press('Enter');
+            await state(previewer, 'loaded');
+            expect(await image.getAttribute('src')).toBe(
+              '/images/base-image/landscape.svg?resource'
+            );
+            expect(await image.getAttribute('alt')).toBe('Selected illustration');
+            expect(await log.textContent()).toBe('loading → loaded');
+            expect(
+              await previewer
+                .getByRole('img', { name: 'Selected illustration', exact: true })
+                .count()
+            ).toBe(1);
+
+            // Equal source synchronization cannot restart a settled request (C-IMAGE-VIEW-0001-E).
+            await load.click();
+            await settle(page);
+            expect(await log.textContent()).toBe('loading → loaded');
+
+            // Hold a real response, never substitute Image state or native decode.
+            const pending = new Promise<void>((resolve) => {
+              release = resolve;
+            });
+            await page.route('**/images/base-image/portrait.svg?resource', async (route) => {
+              await pending;
+              await route.continue();
+            });
+            await previewer.getByRole('button', { name: 'Replace source', exact: true }).click();
+            await state(previewer, 'loading');
+            expect(await image.getAttribute('src')).toBe(
+              '/images/base-image/portrait.svg?resource'
+            );
+            expect(await log.textContent()).toBe('loading → loaded → loading');
+            // Replacement clears the old visual (C-IMAGE-VIEW-0001-G).
+            expect(await image.evaluate((el) => (el as HTMLImageElement).naturalWidth)).toBe(0);
+            release!();
+            await state(previewer, 'loaded');
+            expect(
+              await image.evaluate((el) => [
+                (el as HTMLImageElement).naturalWidth,
+                (el as HTMLImageElement).naturalHeight,
+              ])
+            ).toEqual([320, 480]);
+            expect(await log.textContent()).toBe('loading → loaded → loading → loaded');
+
+            const screenshotDir = process.env.PROTO_UI_IMAGE_SCREENSHOT_DIR;
+            if (screenshotDir) {
+              await mkdir(screenshotDir, { recursive: true });
+              await previewer.screenshot({
+                path: path.join(screenshotDir, `${runtime}-${scheme}-${width}.png`),
+                style: 'astro-dev-toolbar { visibility: hidden; }',
+              });
+            }
+            // P-BASE-IMAGE-STATUS / C-IMAGE-VIEW-0001-F: failure and clear use the canonical surface.
+            await previewer.getByRole('button', { name: 'Broken source', exact: true }).click();
+            await state(previewer, 'error');
+            expect(await image.evaluate((el) => (el as HTMLImageElement).naturalWidth)).toBe(0);
+            expect(await image.getAttribute('alt')).toBe('Selected illustration');
+            expect(await log.textContent()).toBe(
+              'loading → loaded → loading → loaded → loading → error'
+            );
+            await previewer
+              .getByRole('button', { name: 'Clear source', exact: true })
+              .press('Space');
+            await state(previewer, 'idle');
+            expect(await image.getAttribute('src')).toBeNull();
+            expect(await log.textContent()).toBe(
+              'loading → loaded → loading → loaded → loading → error → idle'
+            );
+            expect(await previewer.locator('.host img').count()).toBe(5);
+            expect(
+              await page.evaluate(
+                () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+              )
+            ).toBeLessThanOrEqual(0);
+          } finally {
+            release?.();
+            await context.close();
+          }
+        }, 60_000);
+      }
+    }
+  }
+
+  it('keeps the Chinese page on the same three-adapter public demo', async () => {
+    const { context, page, previewer } = await openRoute(
+      browser,
+      baseUrl,
+      '/zh-cn/ui-libraries/base/image/',
+      { width: 390, height: 900 }
+    );
+    try {
+      await selectRuntime(page, previewer, 'wc', 'img', 5);
+      expect(
+        await page.getByRole('heading', { name: 'Props 与 Exposes', exact: true }).count()
+      ).toBe(1);
+      expect(await previewer.getAttribute('data-demo-id')).toBe('demo-base-image');
+      expect(await physicalImage(previewer, 'fit-cover').getAttribute('alt')).toBe(
+        'Mountains and a sun (cover)'
+      );
+    } finally {
+      await context.close();
+    }
+  }, 60_000);
+});

--- a/apps/www/src/content/docs/zh-cn/demo-base-image.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-image.demo.ts
@@ -1,0 +1,149 @@
+import type { ImageViewStatusChange } from '@proto.ui/core';
+import type {
+  DemoNode,
+  DemoSetupContext,
+  DemoSpec,
+} from '../../../components/PrototypePreviewer/demo-types';
+
+const landscape = '/images/base-image/landscape.svg';
+const portrait = '/images/base-image/portrait.svg';
+const unavailable = 'data:image/png;base64,invalid';
+const resourceProps = {
+  source: '',
+  a11yMode: 'informative',
+  alternativeText: 'Selected illustration',
+  fit: 'contain',
+} as const;
+
+function image(ref: string, props: Record<string, unknown>, height: string): DemoNode {
+  return {
+    kind: 'proto',
+    prototypeId: 'base-image-root',
+    ref,
+    props,
+    surfaceStyle: {
+      display: 'block',
+      width: '100%',
+      height,
+      backgroundColor: 'var(--color-muted)',
+      borderRadius: '8px',
+    },
+  };
+}
+
+function action(ref: string, label: string): DemoNode {
+  return {
+    kind: 'proto',
+    prototypeId: 'base-button',
+    ref,
+    props: {},
+    className:
+      'cursor-pointer rounded-md border border-border bg-background px-3 py-2 text-xs text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring',
+    children: [label],
+  };
+}
+
+export default {
+  type: 'demo',
+  setup({ refs, api }: DemoSetupContext) {
+    const history: string[] = [];
+    let frame = 0;
+    const renderStatus = () => {
+      refs.status.textContent = String(api.call('resource', 'loadingStatus.get') ?? 'idle');
+    };
+    const record = (event: ImageViewStatusChange) => {
+      history.push(event.status);
+      refs.transitions.textContent = history.slice(-8).join(' → ');
+      renderStatus();
+    };
+    const setSource = (source: string) =>
+      api.setProps('resource', { ...resourceProps, source, onLoadingStatusChange: record });
+    setSource('');
+    const onStatus = (event: Event) => {
+      if (event instanceof CustomEvent) record(event.detail);
+    };
+    refs.resource.addEventListener('loadingStatusChange', onStatus);
+
+    const actions = {
+      loadImage: () => setSource(`${landscape}?resource`),
+      replaceImage: () => setSource(`${portrait}?resource`),
+      failImage: () => setSource(unavailable),
+      clearImage: () => setSource(''),
+    };
+    const disposers = Object.entries(actions).map(([ref, activate]) => {
+      api.setProps(ref, { onClick: activate });
+      const onClick = (event: Event) => {
+        if (event instanceof CustomEvent) activate();
+      };
+      refs[ref].addEventListener('click', onClick);
+      return () => refs[ref].removeEventListener('click', onClick);
+    });
+    frame = requestAnimationFrame(renderStatus);
+    return () => {
+      cancelAnimationFrame(frame);
+      refs.resource.removeEventListener('loadingStatusChange', onStatus);
+      disposers.forEach((dispose) => dispose());
+    };
+  },
+  root: {
+    kind: 'box',
+    className: 'flex w-full max-w-xl flex-col gap-4',
+    children: [
+      {
+        kind: 'box',
+        className: 'grid grid-cols-3 gap-3',
+        children: (['contain', 'cover', 'fill'] as const).map((fit) => ({
+          kind: 'box',
+          className: 'flex min-w-0 flex-col gap-2',
+          children: [
+            image(
+              `fit-${fit}`,
+              {
+                source: landscape,
+                a11yMode: 'informative',
+                alternativeText: `Mountains and a sun (${fit})`,
+                fit,
+              },
+              '112px'
+            ),
+            { kind: 'box', className: 'text-center font-mono text-xs', children: [fit] },
+          ],
+        })),
+      },
+      {
+        kind: 'box',
+        className: 'flex items-center gap-3 text-sm text-muted-foreground',
+        children: [
+          {
+            kind: 'box',
+            className: 'w-12 shrink-0',
+            children: [image('decorative', { source: portrait, a11yMode: 'decorative' }, '48px')],
+          },
+          'Decorative image · the text carries the meaning.',
+        ],
+      },
+      image('resource', resourceProps, '160px'),
+      {
+        kind: 'box',
+        className: 'flex flex-wrap gap-2',
+        children: [
+          action('loadImage', 'Load landscape'),
+          action('replaceImage', 'Replace source'),
+          action('failImage', 'Broken source'),
+          action('clearImage', 'Clear source'),
+        ],
+      },
+      {
+        kind: 'box',
+        className: 'flex flex-wrap gap-2 font-mono text-xs text-muted-foreground',
+        children: ['loadingStatus:', { kind: 'box', ref: 'status', children: ['idle'] }],
+      },
+      {
+        kind: 'box',
+        ref: 'transitions',
+        className: 'min-h-5 break-words font-mono text-xs text-muted-foreground',
+        children: ['Choose a source to inspect its status transitions.'],
+      },
+    ],
+  },
+} satisfies DemoSpec;

--- a/apps/www/src/content/docs/zh-cn/demo-matrix.browser.test.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-matrix.browser.test.ts
@@ -15,6 +15,7 @@ type MatrixFacts = {
   adapterColumns: string;
   adapterColumnCount: number;
   runtimeRows: Record<string, number>;
+  unavailable: string[];
 };
 
 type InteractiveFact = {
@@ -39,7 +40,12 @@ async function waitForMatrix(page: Page): Promise<void> {
       const demos = document.querySelectorAll('.demo-matrix__item').length;
       const previewers = document.querySelectorAll('[data-previewer-id]').length;
       const initialized = document.querySelectorAll('[data-previewer-id][data-inited="1"]').length;
-      return demos > 0 && previewers === demos * runtimeCount && initialized === previewers;
+      const unavailable = document.querySelectorAll(
+        '.demo-matrix__adapter[data-unavailable]'
+      ).length;
+      return (
+        demos > 0 && previewers === demos * runtimeCount - unavailable && initialized === previewers
+      );
     },
     RUNTIMES.length,
     { timeout: 60_000 }
@@ -95,6 +101,10 @@ async function readMatrixFacts(page: Page): Promise<MatrixFacts> {
       adapterColumns: firstGrid ? getComputedStyle(firstGrid).gridTemplateColumns : '',
       adapterColumnCount: firstColumns.size,
       runtimeRows,
+      unavailable: adapters.flatMap((adapter) => {
+        const reason = adapter.getAttribute('data-unavailable');
+        return reason ? [reason] : [];
+      }),
     };
   }, RUNTIMES);
 }
@@ -140,7 +150,7 @@ async function readInteractiveFacts(page: Page): Promise<Record<string, Interact
     document.querySelectorAll<HTMLElement>('.demo-matrix__item').forEach((item) => {
       result[item.id] = Array.from(
         item.querySelectorAll<HTMLElement>(
-          ':scope > .demo-matrix__adapters > .demo-matrix__adapter'
+          ':scope > .demo-matrix__adapters > .demo-matrix__adapter:not([data-unavailable])'
         )
       ).map((adapter) =>
         Array.from(adapter.querySelectorAll<HTMLElement>('[role],button,input,select,textarea'))
@@ -193,7 +203,7 @@ afterAll(async () => {
 }, 60_000);
 
 describe.sequential('Website Demo Matrix browser smoke', () => {
-  it('mounts every demo in every official adapter without errors or overflow', async () => {
+  it('mounts every supported demo and names the unimplemented Image adapter', async () => {
     const { context, page } = await openRoute(browser, baseUrl, MATRIX_ROUTE, {
       width: 1440,
       height: 900,
@@ -203,7 +213,12 @@ describe.sequential('Website Demo Matrix browser smoke', () => {
       await waitForMatrix(page);
       const facts = await readMatrixFacts(page);
       expect(facts.demos).toBeGreaterThan(0);
-      expect(facts.previewers).toBe(facts.demos * RUNTIMES.length);
+      // D-IMAGE-VIEW-PROJECTION-0001-E admits only WC/React/Vue 3 for Image.
+      expect(facts.unavailable).toEqual(['demo-base-image:vue2']);
+      expect(facts.previewers).toBe(facts.demos * RUNTIMES.length - 1);
+      expect(await page.locator('[data-unavailable]').innerText()).toContain(
+        'Image View is not implemented for Vue 2.'
+      );
       expect(facts.initialized).toBe(facts.previewers);
       expect(facts.errors).toBe(0);
       expect(facts.overflow).toBeLessThanOrEqual(0);
@@ -260,7 +275,8 @@ describe.sequential('Website Demo Matrix browser smoke', () => {
         expect(facts.errors).toBe(0);
         expect(facts.overflow).toBeLessThanOrEqual(0);
         expect(facts.adapterColumnCount).toBe(1);
-        expect(facts.previewers).toBe(facts.demos * RUNTIMES.length);
+        expect(facts.unavailable).toEqual(['demo-base-image:vue2']);
+        expect(facts.previewers).toBe(facts.demos * RUNTIMES.length - 1);
       } finally {
         await context.close();
       }

--- a/apps/www/src/content/docs/zh-cn/internal/demo-matrix.mdx
+++ b/apps/www/src/content/docs/zh-cn/internal/demo-matrix.mdx
@@ -8,6 +8,6 @@ tableOfContents: false
 
 import DemoMatrix from '@/components/PrototypePreviewer/DemoMatrix.astro';
 
-这个页面是 Proto UI 官网的可执行 parity loop：当前所有 demo 会在 Web Components、React、Vue 与 Vue 2 四个官方适配器下同时挂载，便于在同一个页面发现跨适配器差异。浏览器 smoke 会验证完整挂载数、错误回退、全局适配器切换，以及 320px 窄屏的零溢出布局。它不会出现在左侧导航里。
+这个页面是 Proto UI 官网的可执行 parity loop：各个 demo 在已支持的 Web Components、React、Vue 与 Vue 2 适配器下同时挂载，便于在同一个页面发现跨适配器差异。尚未接入的能力会明确标记，不计为成功挂载；目前 Image View 尚不支持 Vue 2。浏览器 smoke 会验证支持范围内的完整挂载数、错误回退、全局适配器切换，以及 320px 窄屏的零溢出布局。它不会出现在左侧导航里。
 
 <DemoMatrix />

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/image.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/image.mdx
@@ -1,0 +1,99 @@
+---
+title: 'Image'
+desp: 'Image 基础原型'
+description: '由宿主呈现图片，显式表达可访问性与加载状态'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+`base-image-root` 是 `0.3.0-alpha.0` 包系列中的 draft Base 原型。它声明一个由宿主管理的图片目标，并公开 source、fit 和加载状态。目前 Web Components、React、Vue 3 将每个实例投射为一个物理 `<img>`。Vue 2 尚未接入 Image View；这些预览验证的是有界 Web profile，不代表非 Web 宿主支持。
+
+<div>
+  <PrototypePreviewer
+    demoId="demo-base-image"
+    initialRuntime="wc"
+    runtimes={['wc', 'react', 'vue']}
+  />
+</div>
+
+上方三个等大的框用同一张图片比较 `contain`、`cover` 和 `fill`。小图是装饰性图片。下方图片初始没有 source：加载、替换、传入无效 source 或清空，观察真实的 `loadingStatusChange` 事件。缓存或本地图片可能很快完成加载，来不及看到中间状态；事件记录会保留这次转换。按钮、图片框尺寸和记录区域由 demo 提供，不属于 Base Image。
+
+## 使用 Image
+
+导入真实原型，在宿主应用中完成适配：
+
+```tsx
+import * as React from 'react';
+import { createReactAdapter } from '@proto.ui/adapter-react';
+import { imageRoot } from '@proto.ui/prototypes-base/image';
+
+const Image = createReactAdapter(React)(imageRoot);
+
+export function Cover() {
+  return (
+    <Image
+      source="/images/cover.jpg"
+      a11yMode="informative"
+      alternativeText="倒映在湖中的山脊"
+      fit="cover"
+      surfaceStyle={{ width: '100%', height: '240px' }}
+    />
+  );
+}
+```
+
+Vue 使用 `createVueAdapter(Vue)(imageRoot)`。Web Components 使用 `AdaptToWebComponent(imageRoot, { registerAs: 'app-image' })`，挂载前通过 `setElementProps()` 设置声明的 props。应用内各个包应使用一致的精确版本。
+
+工作区 CLI 已为 `react`、`vue`、`wc` 注册 `base-image`，生成 `BaseImageRoot` 或 `BaseImageRootElement`。包含新注册项的构建支持 `proto-ui add react base-image` 及对应的 `vue` / `wc` 命令。
+
+历史发行边界：`0.3.0-alpha.0` 预发行包包含上面示例中的 Image 直接导出，但它的 CLI 早于 `base-image` 注册项。Image 不属于稳定版 `0.2.0` 的功能范围。
+
+## Props 与 Exposes
+
+| Prop | 含义 |
+| --- | --- |
+| `source` | opaque URI 字符串。省略或空字符串表示 `idle`。同步同一个 URI 不会重启已经结束的请求。 |
+| `a11yMode` | 显式选择 `informative` 或 `decorative`。默认值为 `informative`，仍然要求非空替代文本。 |
+| `alternativeText` | informative 图片要求非空文本；decorative 图片应省略或使用空字符串。 |
+| `fit` | `contain`（默认）、`cover` 或 `fill`，在调用方设定的图片框中居中。 |
+
+informative 图片把替代文本投射到物理目标。decorative 图片使用空 `alt`，不向可访问性树提供图片名称。互相矛盾或缺失的可访问性输入会被拒绝；Base Image 不会从 URI 猜测名称。
+
+公开状态为 `source`、`fit` 和 `loadingStatus`。唯一的对外状态转换事件是 `loadingStatusChange`：
+
+```text
+{ status, previousStatus, source }
+```
+
+状态为 `idle | loading | loaded | error`。新的非空 source 在宿主工作开始前进入 `loading`，当前请求随后可进入 `loaded` 或 `error`。替换 source 会清除之前的视觉内容，并使其未完成请求失效；清空 source 返回 `idle`。事件 payload 不包含原生事件或宿主错误对象。
+
+当前 Web profile 以可展示的同步缓存命中，或该 source 请求对应的 `HTMLImageElement.decode()` 结果，作为加载完成依据。这是 Web 的 readiness 映射，不要求所有宿主使用同一种解码 API。失败的 source 不会自动生成重试按钮或 fallback 内容，由应用决定周围如何呈现。
+
+## 组合与样式
+
+Root 不接收 authored children。应用负责尺寸、外框、相邻说明和状态显示；`fit` 负责图片如何填充这个物理框。Web Components 保留自定义元素边界和一个内部图片，`surfaceClassName`、`surfaceStyle` 指向物理图片；React 与 Vue 直接使用物理图片作为 root。
+
+复用 authored hook 的原型还必须携带它已经冻结的静态需求，让 Adapter 在 setup 之前选定图片目标：
+
+```ts
+import { definePrototype } from '@proto.ui/core';
+import { asImageRoot } from '@proto.ui/prototypes-base/image';
+
+const framedImage = definePrototype({
+  name: 'framed-image',
+  modules: asImageRoot.modules,
+  setup() {
+    asImageRoot();
+  },
+});
+```
+
+Base Image 不拥有 Avatar fallback、上传、裁剪、缩放、图库导航、响应式 `srcset`、缓存策略或实时播报。放在 Button 或 Link 中的图片不会成为独立控件；外层控件拥有激活行为和功能名称。
+
+## 参考
+
+- 原型：[P-BASE-IMAGE](https://github.com/Proto-UI/Proto-UI/blob/main/spec/prototypes/P-BASE-IMAGE.yaml)
+- 合同：[C-IMAGE-VIEW-0001](https://github.com/Proto-UI/Proto-UI/blob/main/spec/contracts/C-IMAGE-VIEW-0001.yaml)
+- Web 投射：[D-IMAGE-VIEW-PROJECTION-0001](https://github.com/Proto-UI/Proto-UI/blob/main/spec/decisions/D-IMAGE-VIEW-PROJECTION-0001.yaml)
+- 源码：[packages/prototypes/base/src/image](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/image)
+- 证据：[T-IMAGE-VIEW-0001](https://github.com/Proto-UI/Proto-UI/blob/main/spec/tests/T-IMAGE-VIEW-0001.yaml)

--- a/packages/cli/src/registry/components.ts
+++ b/packages/cli/src/registry/components.ts
@@ -678,6 +678,7 @@ export const COMPONENT_REGISTRY: Record<string, ComponentEntry> = {
   'base-toggle': base('base-toggle', 'base Toggle', 'toggle', 'BaseToggle'),
   'base-transition': base('base-transition', 'base Transition', 'transition', 'BaseTransition'),
   'base-textarea': base('base-textarea', 'Base Textarea', 'textareaRoot', 'BaseTextareaRoot'),
+  'base-image': base('base-image', 'Base Image', 'imageRoot', 'BaseImageRoot'),
 
   'base-switch': baseCompound('base-switch', 'base Switch', [
     {

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -215,6 +215,42 @@ describe('@proto.ui/cli', () => {
     }
   });
 
+  it('materializes the Base Image facade for each supported Web adapter', () => {
+    expect(COMPONENT_REGISTRY['base-image']).toMatchObject({
+      packageName: '@proto.ui/prototypes-base',
+      importPath: '@proto.ui/prototypes-base/image',
+      stylePreset: null,
+      items: [
+        {
+          prototypeImport: 'imageRoot',
+          reactExport: 'BaseImageRoot',
+          vueExport: 'BaseImageRoot',
+          wcExport: 'BaseImageRootElement',
+          elementName: 'proto-ui-base-image',
+        },
+      ],
+    });
+
+    for (const host of ['react', 'vue', 'wc'] as const) {
+      const source = renderHostIndex(host, ['base-image']);
+      expect(source).toContain("import { imageRoot } from '@proto.ui/prototypes-base/image';");
+      expect(source).toContain(
+        host === 'wc'
+          ? "export const BaseImageRootElement = AdaptToWebComponent(imageRoot, { registerAs: 'proto-ui-base-image' });"
+          : 'export const BaseImageRoot = adapt(imageRoot);'
+      );
+    }
+
+    const root = renderRootIndex({
+      react: ['base-image'],
+      vue: ['base-image'],
+      wc: ['base-image'],
+    });
+    expect(root).toContain("export { BaseImageRoot as ReactBaseImageRoot } from './react';");
+    expect(root).toContain("export { BaseImageRoot as VueBaseImageRoot } from './vue';");
+    expect(root).toContain("export { BaseImageRootElement } from './wc';");
+  });
+
   it('registers the exact shadcn Tooltip family facade', () => {
     expect(COMPONENT_REGISTRY['shadcn-tooltip']).toMatchObject({
       packageName: '@proto.ui/prototypes-shadcn',

--- a/packages/cli/test/smoke-render/react.mjs
+++ b/packages/cli/test/smoke-render/react.mjs
@@ -28,7 +28,8 @@ GlobalRegistrator.register();
 
 const React = await import('react');
 const ReactDOMClient = await import('react-dom/client');
-const { ShadcnButton, BaseButton } = await import('./proto-ui/components/react/index.ts');
+const { ShadcnButton, BaseButton, BaseImageRoot } =
+  await import('./proto-ui/components/react/index.ts');
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 50));
 
@@ -82,6 +83,37 @@ if (!shadcnClass.includes('user-added')) {
 
 const base = await renderHost('base BaseButton', BaseButton);
 
+const imageContainer = document.createElement('div');
+document.body.appendChild(imageContainer);
+const imageRoot = ReactDOMClient.createRoot(imageContainer);
+const source =
+  'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/%3E';
+imageRoot.render(
+  React.createElement(BaseImageRoot, {
+    source,
+    a11yMode: 'informative',
+    alternativeText: 'Packed Base Image',
+    fit: 'cover',
+  })
+);
+await flush();
+const image = imageContainer.querySelector('img');
+if (
+  imageContainer.querySelectorAll('img').length !== 1 ||
+  image?.getAttribute('src') !== source ||
+  image.alt !== 'Packed Base Image' ||
+  image.style.objectFit !== 'cover'
+) {
+  throw new Error(
+    'react smoke: Base Image did not project its physical image: ' + imageContainer.innerHTML
+  );
+}
+imageRoot.unmount();
+
 console.log(
-  'react smoke ok | shadcn=' + shadcn.outerHTML.length + 'B base=' + base.outerHTML.length + 'B'
+  'react smoke ok | shadcn=' +
+    shadcn.outerHTML.length +
+    'B base=' +
+    base.outerHTML.length +
+    'B + Base Image'
 );

--- a/packages/cli/test/smoke-render/vue.mjs
+++ b/packages/cli/test/smoke-render/vue.mjs
@@ -26,7 +26,7 @@ import { GlobalRegistrator } from '@happy-dom/global-registrator';
 GlobalRegistrator.register();
 
 const Vue = await import('vue');
-const { ShadcnButton, ShadcnDialogContent, ShadcnDialogRoot, ShadcnSwitch } =
+const { ShadcnButton, ShadcnDialogContent, ShadcnDialogRoot, ShadcnSwitch, BaseImageRoot } =
   await import('./proto-ui/components/vue/index.ts');
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 50));
@@ -100,4 +100,32 @@ if (!closeIcon) {
   throw new Error('vue smoke: Dialog Content preset did not mount its default CloseIcon');
 }
 
-console.log('vue smoke ok | Button + Switch preset + Dialog CloseIcon preset');
+const imageContainer = document.createElement('div');
+document.body.appendChild(imageContainer);
+const source =
+  'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/%3E';
+const imageApp = Vue.createApp({
+  render: () =>
+    Vue.h(BaseImageRoot, {
+      source,
+      a11yMode: 'informative',
+      alternativeText: 'Packed Base Image',
+      fit: 'cover',
+    }),
+});
+imageApp.mount(imageContainer);
+await flush();
+const image = imageContainer.querySelector('img');
+if (
+  imageContainer.querySelectorAll('img').length !== 1 ||
+  image?.getAttribute('src') !== source ||
+  image.alt !== 'Packed Base Image' ||
+  image.style.objectFit !== 'cover'
+) {
+  throw new Error(
+    'vue smoke: Base Image did not project its physical image: ' + imageContainer.innerHTML
+  );
+}
+imageApp.unmount();
+
+console.log('vue smoke ok | Button + Switch preset + Dialog CloseIcon preset + Base Image');

--- a/packages/cli/test/smoke-render/wc.mjs
+++ b/packages/cli/test/smoke-render/wc.mjs
@@ -9,6 +9,7 @@ import { GlobalRegistrator } from '@happy-dom/global-registrator';
 GlobalRegistrator.register();
 
 await import('./proto-ui/components/wc/index.ts');
+const { setElementProps } = await import('@proto.ui/adapter-web-component');
 
 const tag = 'proto-ui-shadcn-button';
 const ctor = customElements.get(tag);
@@ -54,6 +55,31 @@ if (!closeIcon || closeIcon.getAttribute('aria-label') !== 'Close') {
   throw new Error('wc smoke: Dialog Content preset did not mount its default CloseIcon');
 }
 
+const imageElement = document.createElement('proto-ui-base-image');
+const source =
+  'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/%3E';
+setElementProps(imageElement, {
+  source,
+  a11yMode: 'informative',
+  alternativeText: 'Packed Base Image',
+  fit: 'cover',
+});
+document.body.appendChild(imageElement);
+await flush();
+const image = imageElement.querySelector('img');
+if (
+  imageElement.querySelectorAll('img').length !== 1 ||
+  image?.getAttribute('src') !== source ||
+  image.alt !== 'Packed Base Image' ||
+  image.style.objectFit !== 'cover'
+) {
+  throw new Error(
+    'wc smoke: Base Image did not project its physical image: ' + imageElement.outerHTML
+  );
+}
+imageElement.remove();
+
 console.log(
-  'wc smoke ok | Button + Switch preset + Dialog CloseIcon preset, instance tagName=' + el.tagName
+  'wc smoke ok | Button + Switch preset + Dialog CloseIcon preset + Base Image, instance tagName=' +
+    el.tagName
 );

--- a/packages/prototypes/base/test/image.test.ts
+++ b/packages/prototypes/base/test/image.test.ts
@@ -103,6 +103,11 @@ describe('prototypes/base: image', () => {
     expect(namedImageRoot).toBe(imageRoot);
     expect(imageRoot.modules).toEqual(asImageRoot.modules);
     expect(imageRoot.modules).toHaveLength(1);
+    expect(Object.isFrozen(imageRoot.modules)).toBe(true);
+    expect(Object.isFrozen(asImageRoot.modules)).toBe(true);
+    expect(imageRoot.modules?.[0]).toBe(asImageRoot.modules[0]);
+    expect(Object.isFrozen(asImageRoot.modules[0])).toBe(true);
+    expect(Object.isFrozen(asImageRoot.modules[0].config)).toBe(true);
     expect(imageRoot.modules?.[0]?.config).toMatchObject({
       source: '',
       alternativeText: '',

--- a/scripts/release/consumer-smoke-cli.mjs
+++ b/scripts/release/consumer-smoke-cli.mjs
@@ -101,12 +101,15 @@ try {
   for (const [host, component] of [
     ['react', 'shadcn-button'],
     ['react', 'base-button'],
+    ['react', 'base-image'],
     ['react', 'shadcn-switch'],
     ['react', 'shadcn-dialog'],
     ['vue', 'shadcn-button'],
+    ['vue', 'base-image'],
     ['vue', 'shadcn-switch'],
     ['vue', 'shadcn-dialog'],
     ['wc', 'shadcn-button'],
+    ['wc', 'base-image'],
     ['wc', 'shadcn-switch'],
     ['wc', 'shadcn-dialog'],
   ]) {
@@ -221,6 +224,7 @@ function verifyGeneratedConsumer(root) {
     '@proto.ui/adapter-web-component',
     'shadcn-button',
     'base-button',
+    'base-image',
     'shadcn-switch',
     'shadcn-dialog',
   ]) {

--- a/scripts/release/consumer-smoke/adapter-types.tsx
+++ b/scripts/release/consumer-smoke/adapter-types.tsx
@@ -1,8 +1,14 @@
 import type { ComponentProps, ComponentRef } from 'react';
 
-import { ShadcnButton as ReactShadcnButton } from './proto-ui/components/react';
-import { ShadcnButton as VueShadcnButton } from './proto-ui/components/vue';
-import { ShadcnButtonElement } from './proto-ui/components/wc';
+import {
+  ShadcnButton as ReactShadcnButton,
+  BaseImageRoot as ReactBaseImageRoot,
+} from './proto-ui/components/react';
+import {
+  ShadcnButton as VueShadcnButton,
+  BaseImageRoot as VueBaseImageRoot,
+} from './proto-ui/components/vue';
+import { ShadcnButtonElement, BaseImageRootElement } from './proto-ui/components/wc';
 
 type ReactButtonProps = ComponentProps<typeof ReactShadcnButton>;
 type ReactButtonHandle = ComponentRef<typeof ReactShadcnButton>;
@@ -41,6 +47,35 @@ const webComponentInvalidProp: WebComponentButtonProps = { unknownProtoProp: tru
 declare const webComponentElement: WebComponentButton;
 const webComponentDisabled: boolean = webComponentElement.getExposes().disabled.get();
 
+type ReactImageProps = ComponentProps<typeof ReactBaseImageRoot>;
+type VueImageProps = InstanceType<typeof VueBaseImageRoot>['$props'];
+type WebComponentImageProps = NonNullable<
+  InstanceType<typeof BaseImageRootElement>['__protoUiProps']
+>;
+
+const imageValid: ReactImageProps & VueImageProps & WebComponentImageProps = {
+  source: 'image:consumer',
+  a11yMode: 'informative',
+  alternativeText: 'Packed image',
+  fit: 'cover',
+};
+// @ts-expect-error Packed React Image facade must preserve the fit union.
+const reactInvalidFit: ReactImageProps = { fit: 'stretch' };
+// @ts-expect-error Packed Vue Image facade must preserve the fit union.
+const vueInvalidFit: VueImageProps = { fit: 'stretch' };
+// @ts-expect-error Packed Web Component Image facade must preserve the fit union.
+const webComponentInvalidFit: WebComponentImageProps = { fit: 'stretch' };
+
+declare const reactImage: ComponentRef<typeof ReactBaseImageRoot>;
+declare const vueImage: InstanceType<typeof VueBaseImageRoot>;
+declare const webComponentImage: InstanceType<typeof BaseImageRootElement>;
+type ImageStatus = 'idle' | 'loading' | 'loaded' | 'error';
+const imageStatuses: ImageStatus[] = [
+  reactImage.getExposes().loadingStatus.get(),
+  vueImage.getExposes().loadingStatus.get(),
+  webComponentImage.getExposes().loadingStatus.get(),
+];
+
 void reactValid;
 void reactInvalidVariant;
 void reactInvalidProp;
@@ -53,3 +88,8 @@ void webComponentValid;
 void webComponentInvalidVariant;
 void webComponentInvalidProp;
 void webComponentDisabled;
+void imageValid;
+void reactInvalidFit;
+void vueInvalidFit;
+void webComponentInvalidFit;
+void imageStatuses;

--- a/scripts/release/test/demo-matrix-policy.test.mjs
+++ b/scripts/release/test/demo-matrix-policy.test.mjs
@@ -23,10 +23,12 @@ test('Demo Matrix remains development-only documentation', async () => {
   }
 });
 
-test('Demo Matrix renders every adapter side by side for each demo', async () => {
+test('Demo Matrix renders every adapter column and identifies unavailable Image support', async () => {
   const source = await readFile(matrixComponent, 'utf8');
 
-  assert.match(source, /demos\.length \* runtimes\.length/);
+  assert.match(source, /\{previewCount\}/);
+  assert.match(source, /demoId === 'demo-base-image' && runtime === 'vue2'/);
+  assert.match(source, /data-unavailable=/);
   assert.match(source, /runtimes\.map\(\(runtime\) =>/);
   assert.match(source, /initialRuntime=\{runtime\}/);
   assert.match(source, /runtimes=\{\[runtime\]\}/);

--- a/scripts/test/run-runtime-tests.mjs
+++ b/scripts/test/run-runtime-tests.mjs
@@ -17,6 +17,7 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 // can exceed its own hook timeout and fall back to spawning its own server.
 // Warm every route the suites wait on.
 const READY_ROUTES = [
+  '/en/ui-libraries/base/image/',
   '/en/start-here/quick-start/',
   '/en/ui-libraries/shadcn/select/',
   '/en/ui-libraries/base/scroll-area/',

--- a/scripts/test/runtime-test-plan.mjs
+++ b/scripts/test/runtime-test-plan.mjs
@@ -1,4 +1,5 @@
 export const BROWSER_SUITES = Object.freeze([
+  'apps/www/src/content/docs/zh-cn/demo-base-image.browser.test.ts',
   'apps/www/src/content/docs/zh-cn/demo-base-controls.browser.test.ts',
   'apps/www/src/content/docs/zh-cn/demo-brutalist-controls.browser.test.ts',
   'apps/www/src/content/docs/zh-cn/demo-brutalist-checkbox.browser.test.ts',

--- a/spec/prototypes/P-BASE-IMAGE.yaml
+++ b/spec/prototypes/P-BASE-IMAGE.yaml
@@ -44,6 +44,10 @@ sources:
   - path: packages/prototypes/base/src/image/root.proto.ts
   - path: packages/prototypes/base/src/image/types.ts
   - path: packages/prototypes/base/test/image.test.ts
+  - path: apps/www/src/content/docs/en/ui-libraries/base/image.mdx
+  - path: apps/www/src/content/docs/zh-cn/ui-libraries/base/image.mdx
+  - path: apps/www/src/content/docs/zh-cn/demo-base-image.demo.ts
+  - path: packages/cli/src/registry/components.ts
 dependsOn:
   contracts: [C-IMAGE-VIEW-0001, C-AS-HOOK-0001]
   modules: [M-IMAGE-VIEW-0001]

--- a/spec/tests/T-IMAGE-VIEW-0001.yaml
+++ b/spec/tests/T-IMAGE-VIEW-0001.yaml
@@ -5,6 +5,26 @@ status: draft
 since: 0.3.0-alpha.0
 summary: Covers host-neutral image presentation requirements, portable property projection, a11y binary input, generation-bound lease lifecycle, loading status transitions, stale completion rejection, replacement visual clearing, lease cleanup, and the bounded Web Component, React, and Vue profile.
 cases:
+  - id: T-IMAGE-VIEW-0001-CASE-BASE-ENTRIES
+    title: Direct and authored Base Image entries share frozen static requirements
+    covers: [P-BASE-IMAGE-DECLARATION]
+    expectation: direct-and-authored-image-entries-retain-the-same-frozen-requirement
+  - id: T-IMAGE-VIEW-0001-CASE-BASE-PROPERTIES
+    title: Base Image props and exposes retain Image View ownership
+    covers: [P-BASE-IMAGE-SOURCE, P-BASE-IMAGE-FIT, P-BASE-IMAGE-STATUS]
+    expectation: base-image-props-and-source-replacement-project-canonical-status-and-fit
+  - id: T-IMAGE-VIEW-0001-CASE-PUBLIC-CONSUMER
+    title: Installed public Image exports generate typed components in the three supported adapters
+    covers: [P-BASE-IMAGE-DECLARATION, P-BASE-IMAGE-FIT]
+    expectation: packed-image-exports-generate-typed-wc-react-vue-components-with-one-physical-image
+  - id: T-IMAGE-VIEW-0001-CASE-PUBLIC-BROWSER
+    title: Public Image demo renders fit, accessibility, and actual resource transitions
+    covers:
+      - P-BASE-IMAGE-SOURCE
+      - P-BASE-IMAGE-ALT-TEXT
+      - P-BASE-IMAGE-FIT
+      - P-BASE-IMAGE-STATUS
+    expectation: real-wc-react-vue-images-show-fit-and-alt-with-idle-loading-loaded-error-replacement-and-clear-transitions
   - id: T-IMAGE-VIEW-0001-CASE-DECLARATION
     title: Host-neutral static requirement declares one image presentation target
     covers:
@@ -98,6 +118,8 @@ implementations:
     path: packages/prototypes/base/test/image.test.ts
     required: true
     consumesCases:
+      - T-IMAGE-VIEW-0001-CASE-BASE-ENTRIES
+      - T-IMAGE-VIEW-0001-CASE-BASE-PROPERTIES
       - T-IMAGE-VIEW-0001-CASE-DECLARATION
       - T-IMAGE-VIEW-0001-CASE-PROPERTIES
       - T-IMAGE-VIEW-0001-CASE-STATUS-TRANSITION
@@ -137,7 +159,29 @@ implementations:
       - M-IMAGE-VIEW-0001
       - HC-IMAGE-VIEW-0001
       - P-BASE-IMAGE
+  - id: base-image-packed-consumer
+    kind: workspace-check
+    status: passing
+    path: scripts/release/consumer-smoke-cli.mjs
+    required: true
+    consumesCases: [T-IMAGE-VIEW-0001-CASE-PUBLIC-CONSUMER]
+    exercises: [P-BASE-IMAGE]
+  - id: base-image-public-browser
+    kind: runtime-test
+    status: passing
+    path: apps/www/src/content/docs/zh-cn/demo-base-image.browser.test.ts
+    required: true
+    consumesCases: [T-IMAGE-VIEW-0001-CASE-PUBLIC-BROWSER]
+    exercises: [P-BASE-IMAGE]
 verifies:
+  prototypes:
+    - id: P-BASE-IMAGE
+      anchors:
+        - P-BASE-IMAGE-DECLARATION
+        - P-BASE-IMAGE-SOURCE
+        - P-BASE-IMAGE-ALT-TEXT
+        - P-BASE-IMAGE-FIT
+        - P-BASE-IMAGE-STATUS
   contracts:
     - id: C-IMAGE-VIEW-0001
       anchors:
@@ -160,6 +204,8 @@ exercises:
     - A-REACT-18-19-0001
     - A-VUE-3-0001
 sources:
+  - path: scripts/release/consumer-smoke-cli.mjs
+  - path: apps/www/src/content/docs/zh-cn/demo-base-image.browser.test.ts
   - path: packages/modules/image-view/test/impl-spec.test.ts
   - path: packages/modules/image-view/test/web.test.ts
   - path: packages/prototypes/base/test/image.test.ts
@@ -167,6 +213,9 @@ sources:
   - path: packages/adapters/react/test/image-view.integration.test.ts
   - path: packages/adapters/vue/test/image-view.integration.test.ts
 revisions:
+  - version: 0.3.0-alpha.0
+    change: extended
+    summary: Mapped Base Image criteria to frozen authoring entries, installed consumer facades, and public Web resource/fit/accessibility evidence.
   - version: 0.3.0-alpha.0
     change: introduced
     summary: >-


### PR DESCRIPTION
## Summary

Base Image has a public prototype and Web implementation, but no CLI entry or public demo. This completes Checkpoint D with `base-image` facades, EN/ZH Image pages, and real-resource browser evidence.

Closes #374. Checkpoint C was integrated by #581.

## Related context

- Existing draft authority: `P-BASE-IMAGE`, `C-IMAGE-VIEW-0001`, `D-IMAGE-VIEW-PROJECTION-0001`, `M-IMAGE-VIEW-0001`, `HC-IMAGE-VIEW-0001`.
- `T-IMAGE-VIEW-0001` now maps Base criteria to frozen authoring entries, packed consumer facades, and the public browser scenario.

## Scope boundary

The accepted Image props, status events, host lease, and loading semantics are unchanged. This adds the missing consumer projections and verifies the existing implementation.

The Image matrix is Web Components / React / Vue 3. Demo Matrix keeps the Vue 2 column with an explicit unavailable cell, and its tests require that exact exclusion. No Vue 2 Image support, Avatar, new Prototype identity, lifecycle promotion, or publication is included.

## Source-of-truth alignment

- [x] Applicable spec entities, lifecycle, and integrated prerequisite were checked.
- [x] P/T mappings and reader projections match the existing Image behavior.
- [x] No empty identity or broader stable guarantee is introduced.

## Contribution provenance

- [x] This contribution was created by me and I have the right to submit it.
- [x] This contribution includes material AI-assisted generation or transformation.
- [x] No third-party source disclosure is required.

Codex assisted with code, tests, documentation, and browser inspection. The two SVG fixtures are original geometric illustrations; no third-party assets or private source were supplied. A separate local agent inspected the change; human maintainer review remains pending.

## DCO

- [x] The commit has a matching `Signed-off-by` trailer and an SSH signature.

## Prototype website preview

- [x] The existing public Image prototype now has reachable EN/ZH pages and a real-export demo.
- Routes: `/en/ui-libraries/base/image/`, `/zh-cn/ui-libraries/base/image/`.
- [x] The demo uses the public Image export and Base Button activation.
- [x] Demo Matrix supplements the public page; it does not replace it.
- Consumer-owned orchestration: image URIs, frame sizing, source-selection buttons, and status-log text. Loading/error observations come from Image events and real browser resources.
- Manually inspected WC/React/Vue 3 screenshots in Light/Dark, desktop/narrow layouts. Browser regression covers 1280px and 390px; Matrix covers 1440px, 390px and 320px.

## Validation

- `corepack pnpm@10.32.1 test` — passed: 2013 non-browser tests and 54 browser tests; the existing 34 TODOs / 3 skipped files are unchanged.
- `corepack pnpm@10.32.1 check:types` — passed, 191 Astro files with zero diagnostics.
- `node scripts/release/consumer-smoke-cli.mjs` — passed: all 43 public packages built/packed; 40-package consumer closure installed; generated Image facades type-checked and mounted through WC/React/Vue.
- Focused CLI/Base Image tests — 30 passed; catalog evidence integrity — 3 passed; Demo Matrix policy — 3 passed.
- Image browser matrix — 13 passed; Demo Matrix browser suite — 4 passed. Inspected retained Light/Dark screenshots across all three Image runtimes and desktop/narrow layouts.
- `check:prototype-catalog`, `spec:docs:agent`, `check:agent-doc`, `check:public-docs`, `check:package-manifests`, `check:package-budgets` — passed.
- `corepack pnpm@10.32.1 docs:build` — passed, 240 pages.
- Changed-file Prettier check and `git diff --check` — passed.

The published alpha boundary was also checked against the actual npm CLI/Base/Adapter tarballs and their SHA-512 integrity. That artifact inspection is distinct from the candidate installed-consumer smoke above.

Remote validation for `b13ed38ff59416f856c206963eb79ce2a9ac5a5f`: [all nine CI jobs passed](https://github.com/Proto-UI/Proto-UI/actions/runs/34359859175), DCO passes, and GitHub verifies the SSH signature. [Codex reviewed the same commit and reported no major issues](https://github.com/Proto-UI/Proto-UI/pull/633#issuecomment-5603188459); that comment does not replace the required independent approval.
