### PR TITLE
feat: finish Overlay, Text Control, Image View and Scroll catalog

### DIFF
--- a/internal/contracts/overlay/as-overlay.v0.md
+++ b/internal/contracts/overlay/as-overlay.v0.md
@@ -16,7 +16,7 @@ It is responsible for:
 - overlay content registration
 - optional trigger/anchor registration as structural roles
 - dismiss policy
-- focus entry and restore coordination
+- consumer-owned focus integration (generic entry/restore remains deferred)
 - overlay stack and nesting participation
 - host-mediated placement negotiation
 
@@ -34,7 +34,7 @@ The returned handle exposes setup-only options such as `modal`, `closeOnOutsideP
 Normative direction:
 
 - `modal` should be treated as a **policy declaration**
-- outside/focus-outside semantics should ultimately derive from a dedicated interaction-boundary capability
+- outside press consumes Boundary classification; focus-outside awaits a reliable neutral sample
 - overlay should remain a consumer of those semantics rather than the foundational owner of them
 
 This means:
@@ -48,7 +48,7 @@ This means:
 
 Overlay behavior crosses multiple subsystems:
 
-- event: escape, outside press, focus outside
+- Event: neutral Escape input; Boundary: outside press classification
 - focus: entry, restore, local boundary behavior
 - state: open/closed facts
 - host/layout: anchor-relative placement and visibility
@@ -252,19 +252,9 @@ Escape is not a Boundary classification. When enabled, Overlay consumes the neut
 
 ## 8. Focus Policy
 
-`asOverlay()` should coordinate with the focus system rather than replacing it.
+`entry` and `restore` are retained configuration fields; the current generic Overlay does not execute these policies. Dialog, Dropdown and other consumers retain their own Focus and Root request protocols. `closeOnAnchorPress` and `closeOnTriggerPress` are likewise not automatic generic dismissal implementations.
 
-v0 should support:
-
-- `entry`
-  - examples: `first | selected | content | manual`
-
-- `restore`
-  - examples: `trigger | previous | none`
-
-- optional local focus-scope integration
-
-Routine policies such as "restore to trigger on close" should not require manual author scripting.
+Focus-outside remains deferred until a reliable neutral sample contract is admitted. These boundaries are cataloged in `M-OVERLAY-0001-D`; configuration shape alone is not evidence of behavior.
 
 ---
 
@@ -341,9 +331,9 @@ Example shape:
 type OverlayHandle = {
   open: ObservedStateHandle<boolean, any>;
 
-  show(reason?: string): void;
-  hide(reason?: string): void;
-  toggle(reason?: string): void;
+  openOverlay(reason?: OverlayReason): void;
+  close(reason?: OverlayReason): void;
+  toggle(reason?: OverlayReason): void;
 
   configure(patch: OverlayConfigPatch): void;
   updatePosition(patch: OverlayPositionPatch): void;
@@ -359,7 +349,7 @@ type OverlayHandle = {
 
 Notes:
 
-- naming may later be normalized to `open/close/toggle`
+- `open` is observed state; `openOverlay` is the command
 - `configure(...)` must be setup-only
 - `updatePosition(...)` updates only runtime geometry policy and does not redefine dismiss, focus, modal, or Portal policy
 - registration targets are adapter-facing and need not be public author primitives
@@ -371,7 +361,13 @@ Notes:
 
 The core boundary is:
 
-- `asOverlay()` governs overlay existence, dismissal, placement, and focus coordination
+- `asOverlay()` governs overlay existence, explicit dismissal, and delegated placement
 - trigger hooks govern which interaction requests state change
 
 This separation keeps overlay as a reusable structural capability while allowing dropdown, tooltip, dialog, and context menu to define their own trigger semantics.
+
+## 14. Cataloged host resources and Escape
+
+`M-OVERLAY-0001` coordinates optional `HC-OVERLAY-PORTAL-0001`, `HC-OVERLAY-MODAL-0001` and `HC-OVERLAY-LAYER-0001`. Missing providers acquire no corresponding resource. Replacement releases through the old provider before the active mounted view reconciles through the new one. The Web modal realization shares body scroll-lock ownership and restores the original inline overflow only after the final release; it does not supply inertness or a focus trap. The numeric layer scheduler preserves/restores inline z-index and its priority; role offsets do not establish an absolute hierarchy.
+
+`C-AS-OVERLAY-0001-P` defines one eligible owner per Escape sample within a shared input scope. Overlay owns selection, Event carries opaque privileged scope/sample identity, and ordinary Event broadcasts remain unchanged. Synchronous controlled reopen cannot pass the same sample to another Overlay. Repeated open does not reorder an already eligible candidate.

--- a/internal/records/2026-09-09-ordinary-catalog-completion.zh-CN.md
+++ b/internal/records/2026-09-09-ordinary-catalog-completion.zh-CN.md
@@ -1,0 +1,34 @@
+# 普通编目收尾进展
+
+日期：2026-09-09。接续 `2026-09-09-overlay-and-remaining-catalog.zh-CN.md`，不改写此前计划和决策。
+
+## 已完成语义切片
+
+- Overlay：`M-OVERLAY-0001`、三个资源 HC、Event privileged input identity 与四 Adapter 映射；单 sample Escape、受控嵌套消费者、共享 modal 锁、provider 替换清理、layer disposer 修复。
+- Text Control：补全既有 `M-TEXT-CONTROL-0001`、`HC-TEXT-CONTROL-0001` 的 addressable criteria 和四 Adapter 关联。旧 lease 回调与延后恢复只作用于当前 session；注册返回取消函数遵循 setup-only。现有单行、多行、IME、patch 与 Base Input/Textarea 证据保留。
+- Image View：补全既有 `M-IMAGE-VIEW-0001`、`HC-IMAGE-VIEW-0001` 与四 Adapter generation 证据。Vue 2 此前没有物理 img 选择与 host bridge，本轮复用共享 Web host 补齐，增加 workspace dependency 与 lockfile；未另造 source/readiness/API。listener cancellation 对齐 `C-CORE-SYNTAX-0007`，旧测试中的 runtime unsubscribe 不作为隐式契约保留。
+- Scroll：补齐 `M-SCROLL-0001` 的 State/Context/Anatomy 依赖及四 Adapter 关联。既有 `M-SCROLL-0001-D` 要求迟到 facts 无效，但实现没有 session guard；回归测试复现后修复。四 Adapter 新测试覆盖真实 wiring 的 request → 物理 offset → observed fact 与 cleanup；已有四 Adapter composed Thumb journey 继续覆盖 Move Gesture 通路。
+
+所有实体维持原有 draft 状态。正向 Adapter 关系是这些有界切片的证据，不代表全领域、全部宿主或任意未来 capability 的认证。
+
+## 下一批必须独立评估
+
+本批次到此结束，提交一个 PR 后停顿，不继续扩张队列。
+
+1. A11y 的 def → asHook API 重设计及迁移策略。
+2. Rule Meta 的稳定 abstraction，以及 Rule deferred features 的真实使用需求。
+3. Presence legacy compatibility 与 deprecated State module 的清理/兼容性决策。
+4. Overlay 通用 focus entry/restore、anchor/trigger dismissal、focus-outside，以及更强 layer hierarchy 和完整 modal policy。
+5. Text Control portable selection/edit-menu，Image View asset resolution/非 Web readiness，Scroll 非 Web/辅助技术/virtualization。它们需要场景推动，不因普通编目已收尾就自动启动。
+
+后续工作应先从这些独立问题中选择有明确需求和验收边界的一项，而不是继续按 package 数补空实体。
+
+## 本地验证与限制
+
+Node 22.23.2、pnpm 10.32.1。最终使用独立 worktree 依赖安装；临时依赖 symlink 已移除，未提交生成的 Agent/workspace 投影。
+
+- Spec fixture/graph：22 文件、61 项通过；catalog、完整 workspace/docs types、Agent projection check 和 package manifests 通过。
+- 全量测试中的发布、治理、public-docs、type contract 检查通过；非浏览器部分 447 文件、2048 项通过，保留仓库既有 3 skipped files／34 todo。
+- Vue 2 package build 及其 35 个构建依赖通过；新增 Image View dependency 的 BOM 通过生成器同步。
+- 全量浏览器首轮：12 文件中 10 通过，41 项断言中 40 通过；Shadcn controls 在 Adapter 切换就绪等待处超时，Select 首屏套件断言通过但 afterAll 清理超时。因此不称整条 `pnpm test` 一次全绿。
+- Select 首屏以 60 秒 hook timeout 定向复跑通过。Shadcn controls 第二轮在不同用例的同一 readiness wait 超时；基线 `839a6143` 的对照运行、当前分支诊断运行和移除诊断代码后的最终原样运行均为 5/5 通过。未修改生产代码或测试断言来掩盖超时，也未将不稳定性归因为已经证实的基线缺陷；CI 仍需复核。

--- a/internal/records/2026-09-09-overlay-and-remaining-catalog.zh-CN.md
+++ b/internal/records/2026-09-09-overlay-and-remaining-catalog.zh-CN.md
@@ -1,0 +1,25 @@
+# Overlay 与普通编目收尾批次
+
+日期：2026-09-09。基线：PR #632 合入后的 `839a6143`。用户要求更新为：Overlay 边界清理与已接受的 Escape 仲裁完成后，继续 Text Control、Image View、Scroll；各语义切片独立 commit，共用一个 PR，随后停顿。此安排更新此前 Escape 独立 PR 的交付顺序，不重新打开已经接受的策略。
+
+## Overlay
+
+新增 draft `M-OVERLAY-0001` 与 Portal、modal、layer 三个 HC，四 Adapter profile 和 `T-OVERLAY-CATALOG-0001`。Event 只补 privileged opaque input identity，Overlay 拥有候选和单 sample 仲裁。author payload 不携带这些 identity 或 host reference。
+
+四 Adapter 模拟 DOM 集成覆盖嵌套 Escape、受控同步 reopen、两个 modal 按两种关闭顺序释放；Runtime 覆盖 scope 隔离、detach/reenter、重复 open 和 callback 内 metadata 窗口。嵌套 Dialog／Dropdown consumer 测试证明请求只到达选中 Root。Chrome 四 Adapter Brutalist Dialog 几何测试通过；首次执行套件清理超时，使用 60 秒 hook timeout 重跑整套通过。这项浏览器证据证明 Portal／几何回归，不能代替嵌套受控请求证据或完整 modal 认证。
+
+局部漂移已有失败到通过证据：多 modal 覆盖 body overflow 快照；Overlay 替换 host provider 后旧资源未释放；layer disposer 重复执行且丢失 inline priority。修复保持既有 API 与责任分配。
+
+## 保留边界与独立事项
+
+- 通用 entry/restore、anchor/trigger press dismissal 只是配置；focus-outside deferred。消费者 Focus/Root request 不迁入 Overlay。
+- modal 当前只提供 Web scroll lock，不承诺 inert、focus trap、backdrop 或 A11y。
+- layer 使用 sequence + role offset 算式，长序列不保证绝对 role hierarchy；多 owner 同一 layer target 不在当前保证中。
+- Presence legacy compatibility 仍是独立清单，不因为 Transition 使用 ViewIntent 就新建 Presence M/HC。
+- `registerContent(null)` 会回退当前 host capability；无 host 时的旧 Portal/layer 生命周期仍按 view detach 清理，不将该调用推断为新的通用 target-detach API。
+- Event sample identity 基于同一宿主输入对象；人工重复派发同一个 native Event 对象不构成经过认证的新输入 generation。
+- A11y asHook/API 重设计、Rule Meta 稳定化、deprecated State module 清理及其它架构演进不进入本批次。
+
+## 后续队列
+
+依次对 Text Control、Image View、Scroll 做既有实体补全和实际 Adapter evidence 审查；不按 package 数创建占位实体。完成后更新本记录的后续进展记录，并提交一个批次 PR。

--- a/internal/records/2026-09-10-overlay-catalog-package-budget.zh-CN.md
+++ b/internal/records/2026-09-10-overlay-catalog-package-budget.zh-CN.md
@@ -1,0 +1,11 @@
+# Overlay 编目批次的包体积预算调整
+
+日期：2026-09-10。范围：PR #634 的 `public_package_build`。
+
+CI run `34431080908` 在 head `f26e5c9a1bc5ac19625c130a76c03642a75d0c8f` 完成公开包构建和 manifest 校验后，Web Component 入口测得 75,115 gzip bytes，超过 75,000 上限 115 bytes。其余八个入口的预算通过；完整 test、type-check、release-stage 和公开消费者检查通过。
+
+本批引入 scoped Escape arbitration、共享 modal 锁及 provider/session 清理等已编目逻辑。体积增长没有伴随新增第三方运行时依赖。曾试验去重 Escape 清理和压缩 sample 状态表示，本地仅减少约 20 bytes，未保留这些为预算微调实现的改动。
+
+本次只将 Web Component 入口上限从 75,000 调整为 76,000 gzip bytes（增加 1,000 bytes，约 1.33%）；相对这次 CI 实测留出 885 bytes。保留原有 bundle、minify、tree-shaking、外部依赖和 gzip 计算口径，其他入口上限不变。此调整认可本批已审查范围内的体积增量，不代表关闭预算约束或允许后续自动增加。
+
+本地 Node 22.23.2 的压缩结果与 CI 略有差异，应分别记录，不以本地数字冒充 CI 实测。后续新 CI 负责复核相同入口的新结果。

--- a/internal/releases/0.3.0-alpha.0/package-bom.json
+++ b/internal/releases/0.3.0-alpha.0/package-bom.json
@@ -534,6 +534,7 @@
         "@proto.ui/module-feedback",
         "@proto.ui/module-focus",
         "@proto.ui/module-hit-participation",
+        "@proto.ui/module-image-view",
         "@proto.ui/module-overlay",
         "@proto.ui/module-positioning",
         "@proto.ui/module-props",

--- a/packages/adapters/base/test/fixtures/overlay-catalog-conformance.ts
+++ b/packages/adapters/base/test/fixtures/overlay-catalog-conformance.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { definePrototype, type Prototype, type OverlayHandle } from '@proto.ui/core';
+import { asOverlay } from '@proto.ui/hooks';
+export type OverlayTree = { proto: Prototype; children?: OverlayTree[] };
+export type OverlayMount = {
+  host: HTMLElement;
+  flush(): Promise<void>;
+  unmount(): Promise<void>;
+  dispatch(target: EventTarget, event: Event): Promise<void>;
+};
+export function overlayCatalogConformance(
+  name: string,
+  mount: (tree: OverlayTree[]) => Promise<OverlayMount>
+) {
+  describe(`${name}: Overlay catalog`, () => {
+    it.each([false, true])(
+      'T-OVERLAY-CATALOG-0001-CASE-ESCAPE: nested Escape has one owner (controlled=%s)',
+      async (controlled) => {
+        const handles: OverlayHandle[] = [];
+        const requests = [0, 0, 0];
+        const protos = [0, 1, 2].map((index) =>
+          definePrototype({
+            name: `overlay-${name}-${controlled ? 'controlled' : 'ordinary'}-${index}`,
+            setup() {
+              const overlay = (handles[index] = asOverlay());
+              overlay.configure({ defaultOpen: true, closeOnEscape: index !== 2 });
+              overlay.open.watch((_run, event) => {
+                if (event.type !== 'next' || event.next || event.reason !== 'escape') return;
+                requests[index]++;
+                if (controlled && index === 1) overlay.openOverlay('controlled.sync');
+              });
+              return (r) => r.slot();
+            },
+          })
+        );
+        const mounted = await mount([
+          { proto: protos[0], children: [{ proto: protos[1] }] },
+          { proto: protos[2] },
+        ]);
+        try {
+          await mounted.flush();
+          await mounted.dispatch(
+            document,
+            new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+          );
+          expect(requests).toEqual([0, 0, 0]);
+          await mounted.dispatch(
+            document,
+            new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+          );
+          await mounted.flush();
+          expect(requests).toEqual([0, 1, 0]);
+          expect(handles[0].isOpen()).toBe(true);
+          await mounted.dispatch(
+            document,
+            new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+          );
+          await mounted.flush();
+          expect(requests).toEqual(controlled ? [0, 2, 0] : [1, 1, 0]);
+        } finally {
+          await mounted.unmount();
+        }
+        const previous = [...requests];
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+        expect(requests).toEqual(previous);
+      }
+    );
+    it.each([0, 1])(
+      'T-OVERLAY-CATALOG-0001-CASE-MODAL: shared scroll lock restores only after the last owner (first=%s)',
+      async (first) => {
+        const before = document.body.style.cssText;
+        document.body.style.setProperty('overflow', 'scroll', 'important');
+        const protos = [0, 1].map((index) =>
+          definePrototype({
+            name: `overlay-modal-${name}-${first}-${index}`,
+            setup(def) {
+              const overlay = asOverlay();
+              overlay.configure({ defaultOpen: true, modal: true });
+              def.event.on('host:close-modal', () => overlay.close('programmatic'));
+              return (r) => r.el('span', 'modal');
+            },
+          })
+        );
+        const mounted = await mount(protos.map((proto) => ({ proto })));
+        try {
+          await mounted.flush();
+          const roots = [...mounted.host.querySelectorAll<HTMLElement>('[data-pui-root]')];
+          expect(roots).toHaveLength(2);
+          expect(document.body.style.overflow).toBe('hidden');
+          await mounted.dispatch(roots[first], new Event('close-modal'));
+          await mounted.flush();
+          expect(document.body.style.overflow).toBe('hidden');
+          await mounted.dispatch(roots[1 - first], new Event('close-modal'));
+          await mounted.flush();
+          expect(document.body.style.overflow).toBe('scroll');
+          expect(document.body.style.getPropertyPriority('overflow')).toBe('important');
+        } finally {
+          await mounted.unmount();
+          document.body.style.cssText = before;
+        }
+      }
+    );
+  });
+}

--- a/packages/adapters/base/test/fixtures/scroll-catalog-conformance.ts
+++ b/packages/adapters/base/test/fixtures/scroll-catalog-conformance.ts
@@ -1,0 +1,64 @@
+import { expect, it } from 'vitest';
+import { definePrototype, type Prototype, type ScrollSurfaceHandle } from '@proto.ui/core';
+import { asScrollSurface } from '@proto.ui/hooks';
+export type ScrollTree = { proto: Prototype; children?: ScrollTree[] };
+export type ScrollMount = {
+  host: HTMLElement;
+  flush(): Promise<void>;
+  unmount(): Promise<void>;
+  dispatch(target: EventTarget, event: Event): Promise<void>;
+};
+export function scrollCatalogConformance(
+  name: string,
+  mount: (tree: ScrollTree[]) => Promise<ScrollMount>
+) {
+  it(`T-SCROLL-0001-CASE-ADAPTER: ${name} projects requests and current facts and cleans up the view`, async () => {
+    let surface!: ScrollSurfaceHandle;
+    let changes = 0;
+    const proto = definePrototype({
+      name: `scroll-catalog-${name}`,
+      setup(def) {
+        surface = asScrollSurface();
+        surface.configure({ axes: 'vertical', projection: 'system' });
+        surface.vertical.position.watch(() => {
+          changes++;
+        });
+        def.event.on('host:scroll-request', () =>
+          surface.request({ kind: 'to', axis: 'vertical', position: 0.5 })
+        );
+        return (r) => r.el('div', 'content');
+      },
+    });
+    const m = await mount([{ proto }]);
+    let unmounted = false;
+    try {
+      await m.flush();
+      const el = m.host.querySelector<HTMLElement>('[data-pui-root]')!;
+      Object.defineProperties(el, {
+        clientHeight: { configurable: true, value: 200 },
+        scrollHeight: { configurable: true, value: 1000 },
+        clientWidth: { configurable: true, value: 100 },
+        scrollWidth: { configurable: true, value: 100 },
+        scrollTop: { configurable: true, value: 0, writable: true },
+        scrollLeft: { configurable: true, value: 0, writable: true },
+      });
+      await m.dispatch(el, new Event('scroll'));
+      await m.flush();
+      expect(el.dataset.puiScrollProjection).toBe('system');
+      expect(surface.vertical.visibleRatio.get()).toBe(0.2);
+      await m.dispatch(el, new Event('scroll-request'));
+      await m.flush();
+      expect(el.scrollTop).toBe(400);
+      expect(surface.vertical.position.get()).toBe(0.5);
+      await m.unmount();
+      unmounted = true;
+      expect(el.hasAttribute('data-pui-scroll-projection')).toBe(false);
+      const beforeLateEvent = changes;
+      el.scrollTop = 800;
+      el.dispatchEvent(new Event('scroll'));
+      expect(changes).toBe(beforeLateEvent);
+    } finally {
+      if (!unmounted) await m.unmount();
+    }
+  });
+}

--- a/packages/adapters/base/test/overlay-layer-scheduler.test.ts
+++ b/packages/adapters/base/test/overlay-layer-scheduler.test.ts
@@ -61,3 +61,18 @@ describe('module-overlay: z-index layer scheduler', () => {
     expect(el.style.zIndex).toBe('42');
   });
 });
+
+it('T-OVERLAY-CATALOG-0001-CASE-LAYER: restores inline priority once and cannot undo a later lease', () => {
+  const el = document.createElement('div');
+  el.style.setProperty('z-index', '42', 'important');
+  const scheduler = createZIndexOverlayLayerScheduler();
+  const off = scheduler.attach(el, req('overlay'));
+  off();
+  expect(el.style.getPropertyValue('z-index')).toBe('42');
+  expect(el.style.getPropertyPriority('z-index')).toBe('important');
+  const next = scheduler.attach(el, req('overlay'));
+  const value = el.style.zIndex;
+  off();
+  expect(el.style.zIndex).toBe(value);
+  next();
+});

--- a/packages/adapters/react/src/runtime/modules.ts
+++ b/packages/adapters/react/src/runtime/modules.ts
@@ -34,6 +34,7 @@ import { EFFECTS_CAP } from '@proto.ui/module-feedback';
 import {
   EVENT_CANCEL_DEFAULT_ACTION_CAP,
   EVENT_GLOBAL_TARGET_CAP,
+  EVENT_GLOBAL_INPUT_SCOPE_CAP,
   EVENT_ROOT_TARGET_CAP,
 } from '@proto.ui/module-event';
 import { EXPOSE_EVENT_SINK_CAP } from '@proto.ui/module-expose-event';
@@ -67,6 +68,7 @@ import {
   OVERLAY_GLOBAL_MOUNT_CAP,
   OVERLAY_LAYER_SCHEDULER_CAP,
   OVERLAY_MODAL_CAP,
+  createWebOverlayModal,
   type OverlayGlobalMount,
   type OverlayLayerScheduler,
 } from '@proto.ui/module-overlay';
@@ -261,6 +263,7 @@ export function createReactModules<Props extends PropsBaseType>(args: {
     .use('event', [
       [EVENT_ROOT_TARGET_CAP, () => router.rootTarget],
       [EVENT_GLOBAL_TARGET_CAP, () => router.globalTarget],
+      [EVENT_GLOBAL_INPUT_SCOPE_CAP, () => el.ownerDocument],
       [EVENT_CANCEL_DEFAULT_ACTION_CAP, cancelWebEventDefaultAction],
     ])
     .use('expose-event', [[EXPOSE_EVENT_SINK_CAP, emit]])
@@ -379,21 +382,7 @@ export function createReactModules<Props extends PropsBaseType>(args: {
     .use('overlay', () => [
       [HOST_ELEMENT_CAP, el],
       [OVERLAY_GLOBAL_MOUNT_CAP, createReactOverlayGlobalMount(instanceToken)],
-      [
-        OVERLAY_MODAL_CAP,
-        {
-          lock() {
-            const original = document.body.style.overflow;
-            (document.body as any).__proto_ui_original_overflow = original;
-            document.body.style.overflow = 'hidden';
-          },
-          unlock() {
-            const original = (document.body as any).__proto_ui_original_overflow ?? '';
-            document.body.style.overflow = original;
-            delete (document.body as any).__proto_ui_original_overflow;
-          },
-        },
-      ],
+      [OVERLAY_MODAL_CAP, createWebOverlayModal(el.ownerDocument)],
       ...(args.overlayLayerScheduler
         ? [[OVERLAY_LAYER_SCHEDULER_CAP, args.overlayLayerScheduler] as const]
         : []),

--- a/packages/adapters/react/test/overlay-catalog.integration.test.ts
+++ b/packages/adapters/react/test/overlay-catalog.integration.test.ts
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { createReactAdapter } from '../src';
+import {
+  overlayCatalogConformance,
+  type OverlayTree,
+} from '../../base/test/fixtures/overlay-catalog-conformance';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+overlayCatalogConformance('react', async (tree) => {
+  const host = document.createElement('div');
+  document.body.append(host);
+  const root = createRoot(host);
+  const adapt = createReactAdapter(React);
+  const render = (node: OverlayTree): React.ReactNode =>
+    React.createElement(
+      adapt(node.proto),
+      { key: node.proto.name, className: 'user-overlay-class' },
+      ...(node.children ?? []).map(render)
+    );
+  await act(async () =>
+    root.render(React.createElement(React.Fragment, null, ...tree.map(render)))
+  );
+  return {
+    host,
+    async dispatch(target, event) {
+      await act(async () => {
+        target.dispatchEvent(event);
+      });
+    },
+    async flush() {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    },
+    async unmount() {
+      await act(async () => root.unmount());
+      host.remove();
+    },
+  };
+});

--- a/packages/adapters/react/test/scroll-catalog.integration.test.ts
+++ b/packages/adapters/react/test/scroll-catalog.integration.test.ts
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { createReactAdapter } from '../src';
+import {
+  scrollCatalogConformance,
+  type ScrollTree,
+} from '../../base/test/fixtures/scroll-catalog-conformance';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+scrollCatalogConformance('react', async (tree) => {
+  const host = document.createElement('div');
+  document.body.append(host);
+  const root = createRoot(host);
+  const adapt = createReactAdapter(React);
+  const render = (node: ScrollTree): React.ReactNode =>
+    React.createElement(
+      adapt(node.proto),
+      { key: node.proto.name, className: 'user-scroll-class' },
+      ...(node.children ?? []).map(render)
+    );
+  await act(async () =>
+    root.render(React.createElement(React.Fragment, null, ...tree.map(render)))
+  );
+  return {
+    host,
+    async dispatch(target, event) {
+      await act(async () => {
+        target.dispatchEvent(event);
+      });
+    },
+    async flush() {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    },
+    async unmount() {
+      await act(async () => root.unmount());
+      host.remove();
+    },
+  };
+});

--- a/packages/adapters/vue/src/runtime/modules.ts
+++ b/packages/adapters/vue/src/runtime/modules.ts
@@ -34,6 +34,7 @@ import { EFFECTS_CAP } from '@proto.ui/module-feedback';
 import {
   EVENT_CANCEL_DEFAULT_ACTION_CAP,
   EVENT_GLOBAL_TARGET_CAP,
+  EVENT_GLOBAL_INPUT_SCOPE_CAP,
   EVENT_ROOT_TARGET_CAP,
 } from '@proto.ui/module-event';
 import { EXPOSE_EVENT_SINK_CAP } from '@proto.ui/module-expose-event';
@@ -59,6 +60,7 @@ import {
   OVERLAY_GLOBAL_MOUNT_CAP,
   OVERLAY_LAYER_SCHEDULER_CAP,
   OVERLAY_MODAL_CAP,
+  createWebOverlayModal,
   type OverlayGlobalMount,
   type OverlayLayerScheduler,
 } from '@proto.ui/module-overlay';
@@ -261,6 +263,7 @@ export function createVueModules<Props extends PropsBaseType>(args: {
     .use('event', [
       [EVENT_ROOT_TARGET_CAP, () => router.rootTarget],
       [EVENT_GLOBAL_TARGET_CAP, () => router.globalTarget],
+      [EVENT_GLOBAL_INPUT_SCOPE_CAP, () => el.ownerDocument],
       [EVENT_CANCEL_DEFAULT_ACTION_CAP, cancelWebEventDefaultAction],
     ])
     .use('expose-event', [[EXPOSE_EVENT_SINK_CAP, emit]])
@@ -379,21 +382,7 @@ export function createVueModules<Props extends PropsBaseType>(args: {
     .use('overlay', () => [
       [HOST_ELEMENT_CAP, el],
       [OVERLAY_GLOBAL_MOUNT_CAP, createVueOverlayGlobalMount(instanceToken)],
-      [
-        OVERLAY_MODAL_CAP,
-        {
-          lock() {
-            const original = document.body.style.overflow;
-            (document.body as any).__proto_ui_original_overflow = original;
-            document.body.style.overflow = 'hidden';
-          },
-          unlock() {
-            const original = (document.body as any).__proto_ui_original_overflow ?? '';
-            document.body.style.overflow = original;
-            delete (document.body as any).__proto_ui_original_overflow;
-          },
-        },
-      ],
+      [OVERLAY_MODAL_CAP, createWebOverlayModal(el.ownerDocument)],
       ...(args.overlayLayerScheduler
         ? [[OVERLAY_LAYER_SCHEDULER_CAP, args.overlayLayerScheduler] as const]
         : []),

--- a/packages/adapters/vue/test/overlay-catalog.integration.test.ts
+++ b/packages/adapters/vue/test/overlay-catalog.integration.test.ts
@@ -1,0 +1,39 @@
+import { createVueAdapter } from '../src/adapt';
+import { VueAny, flushVue } from './utils/vue';
+import {
+  overlayCatalogConformance,
+  type OverlayTree,
+} from '../../base/test/fixtures/overlay-catalog-conformance';
+
+overlayCatalogConformance('vue', async (tree) => {
+  const host = document.createElement('div');
+  document.body.append(host);
+  const adapt = createVueAdapter(VueAny);
+  const render = (node: OverlayTree): unknown => {
+    const component = adapt(node.proto);
+    const children = (node.children ?? []).map(render);
+    return VueAny.h(
+      component,
+      { key: node.proto.name, class: 'user-overlay-class' },
+      () => children
+    );
+  };
+  const nodes = tree.map(render);
+  const app = VueAny.createApp({ render: () => VueAny.h('div', nodes) });
+  app.mount(host);
+  return {
+    host,
+    async dispatch(target, event) {
+      target.dispatchEvent(event);
+    },
+    async flush() {
+      await flushVue();
+      await flushVue();
+    },
+    async unmount() {
+      app.unmount();
+      await flushVue();
+      host.remove();
+    },
+  };
+});

--- a/packages/adapters/vue/test/scroll-catalog.integration.test.ts
+++ b/packages/adapters/vue/test/scroll-catalog.integration.test.ts
@@ -1,0 +1,39 @@
+import { createVueAdapter } from '../src/adapt';
+import { VueAny, flushVue } from './utils/vue';
+import {
+  scrollCatalogConformance,
+  type ScrollTree,
+} from '../../base/test/fixtures/scroll-catalog-conformance';
+
+scrollCatalogConformance('vue', async (tree) => {
+  const host = document.createElement('div');
+  document.body.append(host);
+  const adapt = createVueAdapter(VueAny);
+  const render = (node: ScrollTree): unknown => {
+    const component = adapt(node.proto);
+    const children = (node.children ?? []).map(render);
+    return VueAny.h(
+      component,
+      { key: node.proto.name, class: 'user-scroll-class' },
+      () => children
+    );
+  };
+  const nodes = tree.map(render);
+  const app = VueAny.createApp({ render: () => VueAny.h('div', nodes) });
+  app.mount(host);
+  return {
+    host,
+    async dispatch(target, event) {
+      target.dispatchEvent(event);
+    },
+    async flush() {
+      await flushVue();
+      await flushVue();
+    },
+    async unmount() {
+      app.unmount();
+      await flushVue();
+      host.remove();
+    },
+  };
+});

--- a/packages/adapters/vue2/package.json
+++ b/packages/adapters/vue2/package.json
@@ -26,7 +26,8 @@
     "@proto.ui/module-text-control": "workspace:*",
     "@proto.ui/module-props": "workspace:*",
     "@proto.ui/module-rule-expose-state-web": "workspace:*",
-    "@proto.ui/module-rule-meta": "workspace:*"
+    "@proto.ui/module-rule-meta": "workspace:*",
+    "@proto.ui/module-image-view": "workspace:*"
   },
   "devDependencies": {
     "@proto.ui/prototypes-base": "workspace:*",

--- a/packages/adapters/vue2/src/adapt.ts
+++ b/packages/adapters/vue2/src/adapt.ts
@@ -1,3 +1,4 @@
+import { IMAGE_VIEW_DECLARATION, resolveWebImageLocalName } from '@proto.ui/module-image-view';
 import {
   getModuleDeclaration,
   type Prototype,
@@ -178,12 +179,20 @@ export function createVue2Adapter(runtime: Vue2Runtime) {
     const textControlRootTag = textControl
       ? resolveWebTextControlLocalName(textControl)
       : undefined;
-    if (textControlRootTag && opt.rootTag && opt.rootTag !== textControlRootTag) {
+    const imageView = getModuleDeclaration(proto, IMAGE_VIEW_DECLARATION)?.config;
+    const imageViewRootTag = imageView ? resolveWebImageLocalName() : undefined;
+    if (textControlRootTag && imageViewRootTag) {
       throw new Error(
-        `[Vue2 Adapter] text-control declaration conflicts with rootTag: ${opt.rootTag}`
+        '[Vue2 Adapter] text-control and image-view declarations cannot share a root.'
       );
     }
-    const rootTag = textControlRootTag ?? opt.rootTag ?? 'div';
+    const declaredRootTag = textControlRootTag ?? imageViewRootTag;
+    if (declaredRootTag && opt.rootTag && opt.rootTag !== declaredRootTag) {
+      throw new Error(
+        `[Vue2 Adapter] rootTag conflicts with the static ${textControlRootTag ? 'text-control' : 'image-view'} declaration.`
+      );
+    }
+    const rootTag = declaredRootTag ?? opt.rootTag ?? 'div';
 
     const hasCustomOverlayLayerConfig =
       !!opt.overlayLayer &&

--- a/packages/adapters/vue2/src/runtime/modules.ts
+++ b/packages/adapters/vue2/src/runtime/modules.ts
@@ -34,6 +34,7 @@ import {
   EVENT_CANCEL_DEFAULT_ACTION_CAP,
   type EventDefaultActionCancelRequest,
   EVENT_GLOBAL_TARGET_CAP,
+  EVENT_GLOBAL_INPUT_SCOPE_CAP,
   EVENT_ROOT_TARGET_CAP,
 } from '@proto.ui/module-event';
 import { EXPOSE_EVENT_SINK_CAP } from '@proto.ui/module-expose-event';
@@ -59,6 +60,7 @@ import {
   OVERLAY_GLOBAL_MOUNT_CAP,
   OVERLAY_LAYER_SCHEDULER_CAP,
   OVERLAY_MODAL_CAP,
+  createWebOverlayModal,
   type OverlayGlobalMount,
   type OverlayLayerScheduler,
 } from '@proto.ui/module-overlay';
@@ -274,6 +276,7 @@ export function createVue2Modules<Props extends PropsBaseType>(args: {
     .use('event', [
       [EVENT_ROOT_TARGET_CAP, () => router.rootTarget],
       [EVENT_GLOBAL_TARGET_CAP, () => router.globalTarget],
+      [EVENT_GLOBAL_INPUT_SCOPE_CAP, () => el.ownerDocument],
       [
         EVENT_CANCEL_DEFAULT_ACTION_CAP,
         ({ event }: EventDefaultActionCancelRequest) => {
@@ -399,21 +402,7 @@ export function createVue2Modules<Props extends PropsBaseType>(args: {
     .use('overlay', () => [
       [HOST_ELEMENT_CAP, el],
       [OVERLAY_GLOBAL_MOUNT_CAP, createVue2OverlayGlobalMount(instanceToken)],
-      [
-        OVERLAY_MODAL_CAP,
-        {
-          lock() {
-            const original = document.body.style.overflow;
-            (document.body as any).__proto_ui_original_overflow = original;
-            document.body.style.overflow = 'hidden';
-          },
-          unlock() {
-            const original = (document.body as any).__proto_ui_original_overflow ?? '';
-            document.body.style.overflow = original;
-            delete (document.body as any).__proto_ui_original_overflow;
-          },
-        },
-      ],
+      [OVERLAY_MODAL_CAP, createWebOverlayModal(el.ownerDocument)],
       ...(args.overlayLayerScheduler
         ? [[OVERLAY_LAYER_SCHEDULER_CAP, args.overlayLayerScheduler] as const]
         : []),

--- a/packages/adapters/vue2/src/runtime/modules.ts
+++ b/packages/adapters/vue2/src/runtime/modules.ts
@@ -1,3 +1,8 @@
+import {
+  IMAGE_VIEW_HOST_CAP,
+  IMAGE_VIEW_RUN_IN_CALLBACK_CAP,
+  createWebImageViewHost,
+} from '@proto.ui/module-image-view';
 import type { FocusEntryConfig } from '@proto.ui/core';
 import { resolveWebFocusEntryTarget } from '@proto.ui/adapter-base';
 import {
@@ -262,6 +267,13 @@ export function createVue2Modules<Props extends PropsBaseType>(args: {
     .use('text-control', [
       [TEXT_CONTROL_HOST_CAP, createWebTextControlHost(physicalControl)],
       [TEXT_CONTROL_RUN_IN_CALLBACK_CAP, args.runInCallbackScope],
+    ])
+    .use('image-view', [
+      [
+        IMAGE_VIEW_HOST_CAP,
+        createWebImageViewHost(() => args.getCurrentElement() as HTMLImageElement | null),
+      ],
+      [IMAGE_VIEW_RUN_IN_CALLBACK_CAP, args.runInCallbackScope],
     ])
     .use('props', [[RAW_PROPS_SOURCE_CAP, rawPropsSource]])
     .use('feedback', [[EFFECTS_CAP, effectsPort]])

--- a/packages/adapters/vue2/test/image-view.integration.test.ts
+++ b/packages/adapters/vue2/test/image-view.integration.test.ts
@@ -1,0 +1,84 @@
+import { expect, it, vi } from 'vitest';
+import imageRoot from '../../../prototypes/base/src/image';
+import { createMountedVue2Adapter, flushVue2 } from './utils/vue2';
+
+it('T-IMAGE-VIEW-0001-CASE-VUE2: one physical image projects attributes and retires pending completion on unmount', async () => {
+  let resolve!: () => void;
+  const decode = vi.spyOn(HTMLImageElement.prototype, 'decode').mockImplementation(
+    () =>
+      new Promise<void>((r) => {
+        resolve = r;
+      })
+  );
+  const onLoadingStatusChange = vi.fn();
+  const m = createMountedVue2Adapter(imageRoot, {
+    source: 'image:a',
+    a11yMode: 'informative',
+    alternativeText: 'A',
+    fit: 'cover',
+    onLoadingStatusChange,
+  });
+  let unmounted = false;
+  try {
+    await flushVue2();
+    const image = m.root as HTMLImageElement;
+    expect(image.tagName).toBe('IMG');
+    expect(image.getAttribute('src')).toBe('image:a');
+    expect(image.alt).toBe('A');
+    expect(image.style.objectFit).toBe('cover');
+    expect(m.vm.getExposes().loadingStatus.get()).toBe('loading');
+    expect(decode).toHaveBeenCalledTimes(1);
+    const count = onLoadingStatusChange.mock.calls.length;
+    m.unmount();
+    unmounted = true;
+    resolve();
+    await flushVue2();
+    expect(onLoadingStatusChange).toHaveBeenCalledTimes(count);
+    expect(image.isConnected).toBe(false);
+  } finally {
+    if (!unmounted) m.unmount();
+    decode.mockRestore();
+  }
+});
+
+it('T-IMAGE-VIEW-0001-CASE-VUE2: source replacement retires old decode and accepts only the current request', async () => {
+  const { Vue2Any, Vue2RuntimeAny } = await import('./utils/vue2');
+  const { createVue2Adapter } = await import('../src/adapt');
+  const requests: Array<() => void> = [];
+  const decode = vi
+    .spyOn(HTMLImageElement.prototype, 'decode')
+    .mockImplementation(() => new Promise<void>((r) => requests.push(r)));
+  const Component = createVue2Adapter(Vue2RuntimeAny)(imageRoot);
+  const Root = Vue2Any.extend({
+    data: () => ({ source: 'image:a' }),
+    render(this: any, h: any) {
+      return h(Component, {
+        attrs: { source: this.source, a11yMode: 'informative', alternativeText: 'Image' },
+      });
+    },
+  });
+  const vm = new Root().$mount();
+  document.body.append(vm.$el);
+  try {
+    await flushVue2();
+    const child = vm.$children[0];
+    vm.source = 'image:b';
+    await flushVue2();
+    expect(vm.$el.getAttribute('src')).toBe('image:b');
+    expect(requests).toHaveLength(2);
+    requests[0]();
+    await flushVue2();
+    expect(child.getExposes().loadingStatus.get()).toBe('loading');
+    requests[1]();
+    await flushVue2();
+    expect(child.getExposes().loadingStatus.get()).toBe('loaded');
+    vm.source = '';
+    await flushVue2();
+    expect(vm.$el.hasAttribute('src')).toBe(false);
+    expect(child.getExposes().loadingStatus.get()).toBe('idle');
+  } finally {
+    vm.$destroy();
+    vm.$el.remove();
+    decode.mockRestore();
+  }
+});

--- a/packages/adapters/vue2/test/overlay-catalog.integration.test.ts
+++ b/packages/adapters/vue2/test/overlay-catalog.integration.test.ts
@@ -1,0 +1,47 @@
+import { createVue2Adapter } from '../src/adapt';
+import { Vue2Any, Vue2RuntimeAny, flushVue2 } from './utils/vue2';
+import {
+  overlayCatalogConformance,
+  type OverlayTree,
+} from '../../base/test/fixtures/overlay-catalog-conformance';
+
+overlayCatalogConformance('vue2', async (tree) => {
+  const host = document.createElement('div');
+  document.body.append(host);
+  const adapt = createVue2Adapter(Vue2RuntimeAny);
+  const components = new Map(
+    tree
+      .flatMap(function flatten(node): OverlayTree[] {
+        return [node, ...(node.children ?? []).flatMap(flatten)];
+      })
+      .map((node) => [node.proto, adapt(node.proto)])
+  );
+  const App = Vue2Any.extend({
+    render(h: (component: unknown, data: unknown, children?: unknown[]) => unknown) {
+      const render = (node: OverlayTree): unknown =>
+        h(
+          components.get(node.proto),
+          { key: node.proto.name, class: 'user-overlay-class' },
+          (node.children ?? []).map(render)
+        );
+      return h('div', {}, tree.map(render));
+    },
+  });
+  const vm = new App().$mount();
+  host.append(vm.$el);
+  return {
+    host,
+    async dispatch(target, event) {
+      target.dispatchEvent(event);
+    },
+    async flush() {
+      await flushVue2();
+      await flushVue2();
+    },
+    async unmount() {
+      vm.$destroy();
+      await flushVue2();
+      host.remove();
+    },
+  };
+});

--- a/packages/adapters/vue2/test/scroll-catalog.integration.test.ts
+++ b/packages/adapters/vue2/test/scroll-catalog.integration.test.ts
@@ -1,0 +1,47 @@
+import { createVue2Adapter } from '../src/adapt';
+import { Vue2Any, Vue2RuntimeAny, flushVue2 } from './utils/vue2';
+import {
+  scrollCatalogConformance,
+  type ScrollTree,
+} from '../../base/test/fixtures/scroll-catalog-conformance';
+
+scrollCatalogConformance('vue2', async (tree) => {
+  const host = document.createElement('div');
+  document.body.append(host);
+  const adapt = createVue2Adapter(Vue2RuntimeAny);
+  const components = new Map(
+    tree
+      .flatMap(function flatten(node): ScrollTree[] {
+        return [node, ...(node.children ?? []).flatMap(flatten)];
+      })
+      .map((node) => [node.proto, adapt(node.proto)])
+  );
+  const App = Vue2Any.extend({
+    render(h: (component: unknown, data: unknown, children?: unknown[]) => unknown) {
+      const render = (node: ScrollTree): unknown =>
+        h(
+          components.get(node.proto),
+          { key: node.proto.name, class: 'user-scroll-class' },
+          (node.children ?? []).map(render)
+        );
+      return h('div', {}, tree.map(render));
+    },
+  });
+  const vm = new App().$mount();
+  host.append(vm.$el);
+  return {
+    host,
+    async dispatch(target, event) {
+      target.dispatchEvent(event);
+    },
+    async flush() {
+      await flushVue2();
+      await flushVue2();
+    },
+    async unmount() {
+      vm.$destroy();
+      await flushVue2();
+      host.remove();
+    },
+  };
+});

--- a/packages/adapters/web-component/src/runtime/modules.ts
+++ b/packages/adapters/web-component/src/runtime/modules.ts
@@ -34,6 +34,7 @@ import { EFFECTS_CAP } from '@proto.ui/module-feedback';
 import {
   EVENT_CANCEL_DEFAULT_ACTION_CAP,
   EVENT_GLOBAL_TARGET_CAP,
+  EVENT_GLOBAL_INPUT_SCOPE_CAP,
   EVENT_ROOT_TARGET_CAP,
 } from '@proto.ui/module-event';
 import { EXPOSE_EVENT_SINK_CAP } from '@proto.ui/module-expose-event';
@@ -66,6 +67,7 @@ import {
   OVERLAY_GLOBAL_MOUNT_CAP,
   OVERLAY_LAYER_SCHEDULER_CAP,
   OVERLAY_MODAL_CAP,
+  createWebOverlayModal,
   type OverlayLayerScheduler,
 } from '@proto.ui/module-overlay';
 import {
@@ -128,10 +130,6 @@ function resolveWebComponentTriggerSurface(
     surface = next;
   }
 }
-
-type BodyWithOverflowSnapshot = HTMLElement & {
-  __proto_ui_original_overflow?: string;
-};
 
 type WebComponentOwnerModulesArgs<Props extends PropsBaseType> = {
   el: HTMLElement;
@@ -361,6 +359,7 @@ export function createWebComponentModules<Props extends PropsBaseType>(args: {
     .use('event', [
       [EVENT_ROOT_TARGET_CAP, () => router.rootTarget],
       [EVENT_GLOBAL_TARGET_CAP, () => router.globalTarget],
+      [EVENT_GLOBAL_INPUT_SCOPE_CAP, () => el.ownerDocument],
       [EVENT_CANCEL_DEFAULT_ACTION_CAP, cancelWebEventDefaultAction],
     ])
     .use('expose-event', [
@@ -536,23 +535,7 @@ export function createWebComponentModules<Props extends PropsBaseType>(args: {
           },
         },
       ],
-      [
-        OVERLAY_MODAL_CAP,
-        {
-          lock() {
-            const body = document.body as BodyWithOverflowSnapshot;
-            const original = body.style.overflow;
-            body.__proto_ui_original_overflow = original;
-            body.style.overflow = 'hidden';
-          },
-          unlock() {
-            const body = document.body as BodyWithOverflowSnapshot;
-            const original = body.__proto_ui_original_overflow ?? '';
-            body.style.overflow = original;
-            delete body.__proto_ui_original_overflow;
-          },
-        },
-      ],
+      [OVERLAY_MODAL_CAP, createWebOverlayModal(el.ownerDocument)],
       ...(args.overlayLayerScheduler
         ? [[OVERLAY_LAYER_SCHEDULER_CAP, args.overlayLayerScheduler] as const]
         : []),

--- a/packages/adapters/web-component/test/overlay-catalog.integration.test.ts
+++ b/packages/adapters/web-component/test/overlay-catalog.integration.test.ts
@@ -1,0 +1,32 @@
+import { AdaptToWebComponent } from '../src';
+import {
+  overlayCatalogConformance,
+  type OverlayTree,
+} from '../../base/test/fixtures/overlay-catalog-conformance';
+
+overlayCatalogConformance('wc', async (tree) => {
+  const host = document.createElement('div');
+  const render = (node: OverlayTree): HTMLElement => {
+    if (!customElements.get(node.proto.name)) AdaptToWebComponent(node.proto);
+    const el = document.createElement(node.proto.name);
+    el.className = 'user-overlay-class';
+    el.append(...(node.children ?? []).map(render));
+    return el;
+  };
+  host.append(...tree.map(render));
+  document.body.append(host);
+  const flush = async () => {
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+  };
+  return {
+    host,
+    async dispatch(target, event) {
+      target.dispatchEvent(event);
+    },
+    flush,
+    async unmount() {
+      host.remove();
+      await flush();
+    },
+  };
+});

--- a/packages/adapters/web-component/test/scroll-catalog.integration.test.ts
+++ b/packages/adapters/web-component/test/scroll-catalog.integration.test.ts
@@ -1,0 +1,32 @@
+import { AdaptToWebComponent } from '../src';
+import {
+  scrollCatalogConformance,
+  type ScrollTree,
+} from '../../base/test/fixtures/scroll-catalog-conformance';
+
+scrollCatalogConformance('wc', async (tree) => {
+  const host = document.createElement('div');
+  const render = (node: ScrollTree): HTMLElement => {
+    if (!customElements.get(node.proto.name)) AdaptToWebComponent(node.proto);
+    const el = document.createElement(node.proto.name);
+    el.className = 'user-scroll-class';
+    el.append(...(node.children ?? []).map(render));
+    return el;
+  };
+  host.append(...tree.map(render));
+  document.body.append(host);
+  const flush = async () => {
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+  };
+  return {
+    host,
+    async dispatch(target, event) {
+      target.dispatchEvent(event);
+    },
+    flush,
+    async unmount() {
+      host.remove();
+      await flush();
+    },
+  };
+});

--- a/packages/modules/event/src/caps.ts
+++ b/packages/modules/event/src/caps.ts
@@ -23,3 +23,8 @@ export type EventDefaultActionCancel = (request: EventDefaultActionCancelRequest
 export const EVENT_CANCEL_DEFAULT_ACTION_CAP = cap<EventDefaultActionCancel>(
   '@proto.ui/event/cancelDefaultAction'
 );
+
+/** Shared input source identity for adapters whose global binding target is a per-instance proxy. */
+export const EVENT_GLOBAL_INPUT_SCOPE_CAP = cap<() => object | null>(
+  '@proto.ui/event/getGlobalInputScope'
+);

--- a/packages/modules/event/src/create.ts
+++ b/packages/modules/event/src/create.ts
@@ -30,6 +30,8 @@ export function createEventModule(ctx: ModuleFactoryArgs): EventModule {
           onProtoPhase: (p) => impl.onProtoPhase(p),
         },
         port: {
+          getGlobalInputScope: () => impl.getGlobalInputScope(),
+          getInputContext: (payload) => impl.getInputContext(payload),
           on: ((type: EventTypeV0, cb: EventInternalCallback, options?: HostEventListenerOptions) =>
             impl.onInternal(type, cb, options)) as EventPort['on'],
           onGlobal: ((

--- a/packages/modules/event/src/impl.ts
+++ b/packages/modules/event/src/impl.ts
@@ -4,7 +4,7 @@ import { illegalPhase } from '@proto.ui/core';
 
 import { ModuleBase } from '@proto.ui/module-base';
 
-import type { EventDispatch, EventInternalCallback } from './types';
+import type { EventDispatch, EventInternalCallback, EventInputContext } from './types';
 import { EventKernel } from './kernel';
 import type {
   EventListenerToken,
@@ -16,6 +16,7 @@ import type {
 import {
   EVENT_CANCEL_DEFAULT_ACTION_CAP,
   EVENT_GLOBAL_TARGET_CAP,
+  EVENT_GLOBAL_INPUT_SCOPE_CAP,
   EVENT_ROOT_TARGET_CAP,
   EXPOSE_EVENT_SINK_CAP,
 } from './caps';
@@ -93,8 +94,33 @@ function isEventTargetLike(x: any): x is EventTarget {
   );
 }
 
+const inputTokens = new WeakMap<object, object>();
+function opaqueInputToken(source: object): object {
+  let token = inputTokens.get(source);
+  if (!token) {
+    token = Object.freeze({});
+    inputTokens.set(source, token);
+  }
+  return token;
+}
+
 export class EventModuleImpl extends ModuleBase {
   private readonly kernel = new EventKernel();
+  private readonly inputContexts = new WeakMap<object, EventInputContext>();
+
+  getGlobalInputScope(): object | null {
+    if (!this.kernel.hasAny('global')) return null;
+    const source = this.caps.has(EVENT_GLOBAL_INPUT_SCOPE_CAP)
+      ? this.caps.get(EVENT_GLOBAL_INPUT_SCOPE_CAP)()
+      : this.caps.has(EVENT_GLOBAL_TARGET_CAP)
+        ? this.caps.get(EVENT_GLOBAL_TARGET_CAP)()
+        : null;
+    return source ? opaqueInputToken(source) : null;
+  }
+
+  getInputContext(payload: ProtoEventPayload): EventInputContext | null {
+    return this.inputContexts.get(payload) ?? null;
+  }
   private readonly prototypeName: string;
 
   private overriddenRootTarget: EventTarget | null = null;
@@ -307,9 +333,19 @@ export class EventModuleImpl extends ModuleBase {
         },
       });
       const payload = createPortableEventPayload(type, raw, control);
+      const scope = this.getGlobalInputScope();
+      const source = eventDataSource(raw);
+      const native = source.nativeEvent ?? raw;
+      if (scope && native && (typeof native === 'object' || typeof native === 'function')) {
+        this.inputContexts.set(
+          payload,
+          Object.freeze({ scope, sample: opaqueInputToken(native as object) })
+        );
+      }
       try {
         dispatch(id, payload);
       } finally {
+        this.inputContexts.delete(payload);
         active = false;
       }
     };

--- a/packages/modules/event/src/types.ts
+++ b/packages/modules/event/src/types.ts
@@ -36,7 +36,13 @@ export type EventModule = ModuleInstance<EventFacade> & {
   scope: 'instance';
 };
 
+export type EventInputContext = Readonly<{ scope: object; sample: object }>;
+
 export type EventPort = ModulePort & {
+  /** Opaque shared scope; neither the scope nor sample token exposes host objects. */
+  getGlobalInputScope?(): object | null;
+  /** Available only during the synchronous dispatch of this exact payload. */
+  getInputContext?(payload: ProtoEventPayload): EventInputContext | null;
   /**
    * Setup-only module-facing listener registration.
    *

--- a/packages/modules/image-view/README.md
+++ b/packages/modules/image-view/README.md
@@ -3,3 +3,7 @@
 Proto UI portable image-view host protocol module.
 
 This module owns the host boundary for a semantic host-owned image presentation requirement: opaque URI source, a11y binary input (informative/decorative), fit, generation-bound lease lifecycle, loading status transitions, and stale completion rejection.
+
+The draft catalog is `M-IMAGE-VIEW-0001` → `HC-IMAGE-VIEW-0001` → `T-IMAGE-VIEW-0001`. Web Component, React, Vue 3 and Vue 2 now have bounded physical-image and generation-lifetime evidence. This does not certify non-Web loading readiness.
+
+Listener registration and its returned cancellation are setup-only. Runtime synchronization and status transitions use callback scope. Asset resolution, alternate readiness definitions and broader A11y API redesign remain separate work.

--- a/packages/modules/image-view/src/create.ts
+++ b/packages/modules/image-view/src/create.ts
@@ -105,6 +105,7 @@ export class ImageViewModuleImpl extends ModuleBase {
     };
     this.listeners = this.listeners.concat(listener);
     return () => {
+      this.sys.ensureSetup('imageView.off');
       this.listeners = this.listeners.filter((candidate) => candidate !== listener);
     };
   }

--- a/packages/modules/image-view/test/impl-spec.test.ts
+++ b/packages/modules/image-view/test/impl-spec.test.ts
@@ -363,7 +363,7 @@ describe('module-image-view', () => {
     warn.mockRestore();
   });
 
-  it('accepts one terminal completion and keeps listener dispatch stable under unsubscribe', () => {
+  it('accepts one terminal completion and rejects runtime listener cancellation', () => {
     const fake = createFakeHost();
     const harness = createHarness(fake.host);
     const image = harness.module.facade.declare();
@@ -372,7 +372,7 @@ describe('module-image-view', () => {
     offFirst = image.on('loadingStatusChange', (_run, event) => {
       if (event.status === 'loaded') {
         calls.push('first');
-        offFirst();
+        expect(offFirst).toThrow();
       }
     });
     image.on('loadingStatusChange', (_run, event) => {
@@ -429,4 +429,14 @@ describe('module-image-view', () => {
     complete(remounted, 'loaded');
     expect(image.snapshot()).toBeNull();
   });
+});
+
+it('T-IMAGE-VIEW-0001-CASE-CANCEL: listener cancellation is setup-only', () => {
+  const h = createHarness(createFakeHost().host);
+  const image = h.module.facade.declare();
+  const off = image.on('loadingStatusChange', () => {});
+  off();
+  off();
+  h.sys.phase = 'callback';
+  expect(off).toThrow();
 });

--- a/packages/modules/overlay/src/escape-coordinator.ts
+++ b/packages/modules/overlay/src/escape-coordinator.ts
@@ -1,0 +1,33 @@
+/** Overlay policy owns arbitration; Event contributes only opaque input identity. */
+const scopes = new WeakMap<object, Set<object>>();
+const selections = new WeakMap<object, Map<object, { owner: object | null; delivered: boolean }>>();
+
+export function joinEscapeScope(scope: object, owner: object): () => void {
+  let owners = scopes.get(scope);
+  if (!owners) {
+    owners = new Set();
+    scopes.set(scope, owners);
+  }
+  owners.add(owner);
+  return () => {
+    owners.delete(owner);
+  };
+}
+
+export function ownsEscapeSample(scope: object, sample: object, owner: object): boolean {
+  let byScope = selections.get(sample);
+  if (!byScope) {
+    byScope = new Map();
+    selections.set(sample, byScope);
+  }
+  if (!byScope.has(scope)) {
+    byScope.set(scope, {
+      owner: Array.from(scopes.get(scope) ?? []).at(-1) ?? null,
+      delivered: false,
+    });
+  }
+  const selection = byScope.get(scope)!;
+  if (selection.delivered || selection.owner !== owner) return false;
+  selection.delivered = true;
+  return true;
+}

--- a/packages/modules/overlay/src/impl.ts
+++ b/packages/modules/overlay/src/impl.ts
@@ -1,3 +1,4 @@
+import { joinEscapeScope, ownsEscapeSample } from './escape-coordinator';
 import type {
   BoundaryHandle,
   CapsVaultView,
@@ -133,6 +134,20 @@ export class OverlayModuleImpl extends ModuleBase {
   };
   private readonly offBoundaryOutside: (() => void) | null;
   private escapeSamplingInstalled = false;
+  private escapeScope: object | null = null;
+  private leaveEscapeScope: (() => void) | null = null;
+  private readonly escapeOwner = {};
+
+  private syncEscapeCandidate(): void {
+    const scope =
+      this.isOpen() && this.viewActive && this.mountPhase === 'mounted' && this.config.closeOnEscape
+        ? (this.eventPort.getGlobalInputScope?.() ?? null)
+        : null;
+    if (scope === this.escapeScope) return;
+    this.leaveEscapeScope?.();
+    this.escapeScope = scope;
+    this.leaveEscapeScope = scope ? joinEscapeScope(scope, this.escapeOwner) : null;
+  }
 
   constructor(
     caps: CapsVaultView,
@@ -163,6 +178,9 @@ export class OverlayModuleImpl extends ModuleBase {
       this.eventPort.onGlobal('key.down', (event) => {
         if (!this.isOpen() || !this.config.closeOnEscape) return;
         if (event.key !== 'Escape') return;
+        const input = this.eventPort.getInputContext?.(event);
+        if (!input || this.escapeScope !== input.scope) return;
+        if (!ownsEscapeSample(input.scope, input.sample, this.escapeOwner)) return;
         this.close('escape');
       });
     }
@@ -170,11 +188,15 @@ export class OverlayModuleImpl extends ModuleBase {
 
   protected override onCapsEpoch(_epoch: number): void {
     this.refreshHostCaps();
+    this.syncEscapeCandidate();
   }
 
   override onProtoPhase(phase: ProtoPhase): void {
     super.onProtoPhase(phase);
     if (phase !== 'unmounted') return;
+    this.leaveEscapeScope?.();
+    this.leaveEscapeScope = null;
+    this.escapeScope = null;
     this.teardownMountedViewSideEffects();
     this.clearBoundaryRegistrations();
     this.offBoundaryOutside?.();
@@ -182,6 +204,7 @@ export class OverlayModuleImpl extends ModuleBase {
 
   override onMountPhase(phase: MountPhase, epoch: number): void {
     super.onMountPhase(phase, epoch);
+    this.syncEscapeCandidate();
     if (phase === 'unmounting' || phase === 'detached') {
       this.teardownMountedViewSideEffects();
       this.boundary.setStackActive(false);
@@ -194,13 +217,21 @@ export class OverlayModuleImpl extends ModuleBase {
   }
 
   private refreshHostCaps(): void {
-    this.globalMount = this.caps.has(OVERLAY_GLOBAL_MOUNT_CAP)
+    const globalMount = this.caps.has(OVERLAY_GLOBAL_MOUNT_CAP)
       ? this.caps.get(OVERLAY_GLOBAL_MOUNT_CAP)
       : null;
-    this.modalLock = this.caps.has(OVERLAY_MODAL_CAP) ? this.caps.get(OVERLAY_MODAL_CAP) : null;
-    this.layerScheduler = this.caps.has(OVERLAY_LAYER_SCHEDULER_CAP)
+    const modalLock = this.caps.has(OVERLAY_MODAL_CAP) ? this.caps.get(OVERLAY_MODAL_CAP) : null;
+    const layerScheduler = this.caps.has(OVERLAY_LAYER_SCHEDULER_CAP)
       ? this.caps.get(OVERLAY_LAYER_SCHEDULER_CAP)
       : null;
+    // Release through the provider that acquired each resource before replacing it.
+    if (globalMount !== this.globalMount) this.unmountGlobalIfNeeded();
+    if (modalLock !== this.modalLock) this.unlockModalIfNeeded();
+    if (layerScheduler !== this.layerScheduler) this.clearLayer();
+    this.globalMount = globalMount;
+    this.modalLock = modalLock;
+    this.layerScheduler = layerScheduler;
+    if (this.viewActive) this.reconcileViewResourcesAfterCallback();
   }
 
   private ensureSetup(op: string) {
@@ -318,7 +349,13 @@ export class OverlayModuleImpl extends ModuleBase {
       return;
     }
 
+    if (!next) {
+      this.leaveEscapeScope?.();
+      this.leaveEscapeScope = null;
+      this.escapeScope = null;
+    }
     this.openState.set(next, reason);
+    this.syncEscapeCandidate();
 
     if (next) {
       this.boundary.setStackActive(true);
@@ -342,6 +379,7 @@ export class OverlayModuleImpl extends ModuleBase {
     }
 
     this.viewActive = active;
+    this.syncEscapeCandidate();
     this.viewReconciliationVersion += 1;
     if (active) {
       if (this.mountPhase === 'mounted') this.lockModalIfNeeded();

--- a/packages/modules/overlay/src/index.ts
+++ b/packages/modules/overlay/src/index.ts
@@ -11,3 +11,5 @@ export {
   createZIndexOverlayLayerScheduler,
   type OverlayZIndexLayerSchedulerOptions,
 } from './web/z-index-layer-scheduler';
+
+export { createWebOverlayModal } from './web/modal-lock';

--- a/packages/modules/overlay/src/web/modal-lock.ts
+++ b/packages/modules/overlay/src/web/modal-lock.ts
@@ -1,0 +1,39 @@
+import type { OverlayModal } from '../caps';
+
+type Lock = { owners: Set<object>; value: string; priority: string };
+const locks = new WeakMap<HTMLElement, Lock>();
+
+/** Web scroll-lock realization; one owner cannot release another owner's lock. */
+export function createWebOverlayModal(doc: Document): OverlayModal {
+  const owner = {};
+  let body: HTMLElement | null = null;
+  return {
+    lock() {
+      if (body || !doc.body) return;
+      body = doc.body;
+      let lock = locks.get(body);
+      if (!lock) {
+        lock = {
+          owners: new Set(),
+          value: body.style.getPropertyValue('overflow'),
+          priority: body.style.getPropertyPriority('overflow'),
+        };
+        locks.set(body, lock);
+        body.style.setProperty('overflow', 'hidden', lock.priority);
+      }
+      lock.owners.add(owner);
+    },
+    unlock() {
+      if (!body) return;
+      const target = body;
+      body = null;
+      const lock = locks.get(target);
+      if (!lock) return;
+      lock.owners.delete(owner);
+      if (lock.owners.size) return;
+      if (lock.value) target.style.setProperty('overflow', lock.value, lock.priority);
+      else target.style.removeProperty('overflow');
+      locks.delete(target);
+    },
+  };
+}

--- a/packages/modules/overlay/src/web/z-index-layer-scheduler.ts
+++ b/packages/modules/overlay/src/web/z-index-layer-scheduler.ts
@@ -44,12 +44,16 @@ export function createZIndexOverlayLayerScheduler(
 
       const hadInline = target.style.getPropertyValue('z-index').length > 0;
       const prev = target.style.zIndex;
+      const priority = target.style.getPropertyPriority('z-index');
+      let active = true;
 
-      target.style.zIndex = String(zIndex);
+      target.style.setProperty('z-index', String(zIndex), priority);
 
       return () => {
+        if (!active) return;
+        active = false;
         if (hadInline) {
-          target.style.zIndex = prev;
+          target.style.setProperty('z-index', prev, priority);
           return;
         }
         target.style.removeProperty('z-index');

--- a/packages/modules/overlay/test/resource-lifetime.test.ts
+++ b/packages/modules/overlay/test/resource-lifetime.test.ts
@@ -1,0 +1,81 @@
+import { expect, it, vi } from 'vitest';
+import { CapsVault, SYS_CAP } from '@proto.ui/module-base';
+import { HOST_ELEMENT_CAP } from '@proto.ui/core';
+import { OverlayModuleImpl } from '../src/impl';
+import {
+  OVERLAY_GLOBAL_MOUNT_CAP,
+  OVERLAY_MODAL_CAP,
+  OVERLAY_LAYER_SCHEDULER_CAP,
+} from '../src/caps';
+
+it('T-OVERLAY-CATALOG-0001-CASE-RESOURCES: replaces providers through their original owners and releases at detach', () => {
+  const caps = new CapsVault();
+  caps.attachBase([
+    [
+      SYS_CAP,
+      {
+        ensureSetup() {},
+        deferAfterCallback(fn: () => void) {
+          fn();
+        },
+      } as any,
+    ],
+  ]);
+  const boundary = {
+    subscribeOutside: () => () => {},
+    setStackActive() {},
+    registerRegion: () => () => {},
+  };
+  const position = { disconnect: vi.fn() };
+  const module = new OverlayModuleImpl(
+    caps,
+    'overlay-resources',
+    boundary as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    position as any
+  );
+  const host = document.createElement('div');
+  const provider = () => {
+    const detach = vi.fn();
+    return {
+      mount: vi.fn(),
+      unmount: vi.fn(),
+      lock: vi.fn(),
+      unlock: vi.fn(),
+      attach: vi.fn(() => detach),
+      detach,
+    };
+  };
+  const a = provider(),
+    b = provider();
+  const install = (p: ReturnType<typeof provider>) =>
+    caps.attach([
+      [HOST_ELEMENT_CAP, host],
+      [OVERLAY_GLOBAL_MOUNT_CAP, p],
+      [OVERLAY_MODAL_CAP, p],
+      [OVERLAY_LAYER_SCHEDULER_CAP, p],
+    ]);
+  install(a);
+  module.configure({ defaultOpen: true, portal: true, modal: true });
+  module.setViewActive(true);
+  module.onMountPhase('mounted', 1);
+  expect(a.mount).toHaveBeenCalledTimes(1);
+  expect(a.lock).toHaveBeenCalledTimes(1);
+  install(b);
+  expect(a.unmount).toHaveBeenCalledWith(host);
+  expect(a.unlock).toHaveBeenCalledTimes(1);
+  expect(a.detach).toHaveBeenCalledTimes(1);
+  expect(b.mount).toHaveBeenCalledWith(host);
+  expect(b.lock).toHaveBeenCalledTimes(1);
+  install(b);
+  expect(b.mount).toHaveBeenCalledTimes(1);
+  module.onMountPhase('detached', 1);
+  expect(b.unmount).toHaveBeenCalledTimes(1);
+  expect(b.unlock).toHaveBeenCalledTimes(1);
+  expect(b.detach).toHaveBeenCalledTimes(1);
+  caps.resetAttached();
+  module.onProtoPhase('unmounted');
+  expect(b.unlock).toHaveBeenCalledTimes(1);
+});

--- a/packages/modules/scroll/README.md
+++ b/packages/modules/scroll/README.md
@@ -4,7 +4,11 @@ Proto UI module that provides host-mediated scroll capability for adapters.
 
 ## Purpose
 
-Provides host-mediated scroll capability to adapters running Proto UI prototypes.
+Owns stable logical surface identity, observed normalized facts, requests and system/composed projection negotiation. State stores facts; Context and Anatomy bind composed Scrollbar/Thumb controls to the same session. The host owns geometry, scrolling engine, physics and input integration.
+
+Only current mounted session facts are accepted. Host replacement, detach and terminal disposal invalidate previous callbacks and release the lease. Missing host support leaves projection unresolved; an unavailable required projection diagnoses rather than silently downgrading.
+
+The draft `M-SCROLL-0001`, `HC-SCROLL-SURFACE-0001` and `T-SCROLL-0001` graph covers four Web Adapters, including composed Thumb Move Gesture. Simulated geometry evidence does not certify browser physics or non-Web accessibility. Virtualization and A11y API redesign remain separate work.
 
 ## Package Role
 

--- a/packages/modules/scroll/src/impl.ts
+++ b/packages/modules/scroll/src/impl.ts
@@ -52,6 +52,7 @@ export class ScrollModuleImpl extends ModuleBase {
   private offAnatomyTargets: Unsubscribe | null = null;
   private lease: ScrollSurfaceHostLease | null = null;
   private mounted = false;
+  private leaseEpoch = 0;
 
   private readonly axesOwned: OwnedStateHandle<ScrollAxes>;
   private readonly scrollingOwned: OwnedStateHandle<boolean>;
@@ -218,7 +219,10 @@ export class ScrollModuleImpl extends ModuleBase {
 
   override onProtoPhase(phase: ProtoPhase): void {
     super.onProtoPhase(phase);
-    if (phase === 'unmounted') this.disconnect();
+    if (phase === 'unmounted') {
+      this.mounted = false;
+      this.disconnect();
+    }
     if (phase === 'unmounted') {
       this.offAnatomyOrder?.();
       this.offAnatomyOrder = null;
@@ -232,8 +236,10 @@ export class ScrollModuleImpl extends ModuleBase {
   }
 
   private attach(): void {
-    this.lease?.dispose();
+    this.leaseEpoch += 1;
+    const previous = this.lease;
     this.lease = null;
+    previous?.dispose();
     const host = this.getHost();
     if (!host) {
       this.set(this.projectionOwned, 'unresolved');
@@ -241,15 +247,24 @@ export class ScrollModuleImpl extends ModuleBase {
     }
     const projection = resolveScrollProjection(this.config, host.support, host.preference);
     this.set(this.projectionOwned, projection);
-    this.lease = host.attach(this.createHostAttachment());
+    const epoch = this.leaseEpoch;
+    const lease = host.attach(this.createHostAttachment());
+    if (epoch !== this.leaseEpoch || !this.mounted) {
+      lease.dispose();
+      return;
+    }
+    this.lease = lease;
   }
 
   private createHostAttachment(): ScrollSurfaceHostAttachment {
+    const epoch = this.leaseEpoch;
     const composedChrome = this.resolveComposedChrome();
     const attachment: ScrollSurfaceHostAttachment = {
       config: this.config,
       projection: this.projectionOwned.get() as Exclude<ScrollResolvedProjection, 'unresolved'>,
-      onFacts: (snapshot) => this.applySnapshot(snapshot),
+      onFacts: (snapshot) => {
+        if (epoch === this.leaseEpoch && this.mounted) this.applySnapshot(snapshot);
+      },
       ...(composedChrome ? { composedChrome } : {}),
     };
     return Object.freeze(attachment);
@@ -334,8 +349,10 @@ export class ScrollModuleImpl extends ModuleBase {
   }
 
   disconnect(): void {
-    this.lease?.dispose();
+    this.leaseEpoch += 1;
+    const previous = this.lease;
     this.lease = null;
+    previous?.dispose();
     this.set(this.scrollingOwned, false);
     this.set(this.projectionOwned, 'unresolved');
   }

--- a/packages/modules/scroll/test/session-lifetime.test.ts
+++ b/packages/modules/scroll/test/session-lifetime.test.ts
@@ -1,0 +1,66 @@
+import { expect, it, vi } from 'vitest';
+import { CapsVault, SYS_CAP } from '@proto.ui/module-base';
+import { StateModuleImpl } from '../../state/src/impl';
+import { createSysCaps } from '../../context/test/utils/fake-caps';
+import { ScrollModuleImpl } from '../src/impl';
+import { SCROLL_SURFACE_HOST_CAP, type ScrollSurfaceHostAttachment } from '../src/caps';
+
+it('T-SCROLL-0001-CASE-LIFETIME: replacement, detach and terminal disposal reject late facts', () => {
+  const sys = createSysCaps();
+  const caps = new CapsVault();
+  caps.attachBase([[SYS_CAP, sys]]);
+  const state = new StateModuleImpl(sys);
+  const module = new ScrollModuleImpl(
+    caps,
+    'scroll-session',
+    state.port,
+    state.facade,
+    {} as any,
+    {} as any
+  );
+  const surface = module.getSurface();
+  const connections: ScrollSurfaceHostAttachment[] = [];
+  const dispose = vi.fn();
+  const install = () =>
+    caps.attach([
+      [
+        SCROLL_SURFACE_HOST_CAP,
+        {
+          support: { system: true, composed: true },
+          attach(c: ScrollSurfaceHostAttachment) {
+            connections.push(c);
+            return { update() {}, request() {}, dispose };
+          },
+        },
+      ],
+    ]);
+  const facts = (position: number) => ({
+    axes: 'vertical' as const,
+    horizontal: { position: 0, visibleRatio: 1, canScrollBefore: false, canScrollAfter: false },
+    vertical: { position, visibleRatio: 0.2, canScrollBefore: true, canScrollAfter: true },
+    scrolling: true,
+    projection: 'system' as const,
+  });
+  sys.__setExecPhase('callback');
+  install();
+  module.onMountPhase('mounted', 1);
+  connections[0].onFacts(facts(0.3));
+  expect(surface.vertical.position.get()).toBe(0.3);
+  install();
+  expect(dispose).toHaveBeenCalledTimes(1);
+  connections[0].onFacts(facts(0.9));
+  expect(surface.vertical.position.get()).toBe(0.3);
+  connections[1].onFacts(facts(0.4));
+  expect(surface.vertical.position.get()).toBe(0.4);
+  module.onMountPhase('detached', 1);
+  connections[1].onFacts(facts(0.8));
+  expect(surface.vertical.position.get()).toBe(0.4);
+  expect(surface.projection.get()).toBe('unresolved');
+  module.onMountPhase('mounted', 2);
+  expect(module.getSurface()).toBe(surface);
+  module.onProtoPhase('unmounted');
+  connections.at(-1)!.onFacts(facts(0.7));
+  expect(surface.vertical.position.get()).toBe(0.4);
+  expect(surface.projection.get()).toBe('unresolved');
+  state.dispose();
+});

--- a/packages/modules/text-control/README.md
+++ b/packages/modules/text-control/README.md
@@ -4,11 +4,11 @@ Portable host-mediated single-line and multiline text-control protocol for Proto
 
 ## Purpose
 
-Owns the host boundary for a semantic plain-text, line-mode-aware, host-owned editing requirement: stable controlled or uncontrolled value ownership, normalized input/change/IME composition events, live property projection, and physical focus access. Adapters select the physical host editor; the current Web profile resolves single-line declarations to `HTMLInputElement` and multiline declarations to `HTMLTextAreaElement`. The module does not own labels, form submission, validation messages, rich text, auto-resize policy, system selection handles, or edit menus.
+Owns the host boundary for a semantic plain-text, line-mode-aware, host-owned editing requirement: stable controlled or uncontrolled value ownership, normalized input/change/IME composition events, live property projection, and the bounded editing lease. Physical focus access is coordinated through the separate Focus bridge. Adapters select the physical host editor; the current Web profile resolves single-line declarations to `HTMLInputElement` and multiline declarations to `HTMLTextAreaElement`. The module does not own labels, form submission, validation messages, rich text, auto-resize policy, system selection handles, or edit menus.
 
 ## Package role
 
-Adapter-facing dependency used by Base Textarea, the admitted Base Input prerequisite path, and official Web Component, React, and Vue adapters. Host integrations provide a `TextControlHost`; Web hosts can use `resolveWebTextControlLocalName` and `createWebTextControlHost`. The three current adapters are one Web-host profile, not multi-host conformance.
+Adapter-facing dependency used by Base Textarea, the admitted Base Input prerequisite path, and official Web Component, React, Vue 3, and Vue 2 adapters. Host integrations provide a `TextControlHost`; Web hosts can use `resolveWebTextControlLocalName` and `createWebTextControlHost`. These four Adapter realizations provide Web-host evidence; non-Web editing conformance remains open.
 
 ## Install
 
@@ -37,3 +37,7 @@ npm install @proto.ui/module-text-control@0.3.0-alpha.0
 ## License
 
 MIT
+
+## Catalog boundary
+
+`M-TEXT-CONTROL-0001`, `HC-TEXT-CONTROL-0001`, and `T-TEXT-CONTROL-0001` remain draft. The Module retains declaration/value ownership across view leases and rejects stale lease input. Listener registration and returned cancellation are setup-only; runtime value synchronization requires callback scope. Portable selection requests and edit-menu customization remain separate future work.

--- a/packages/modules/text-control/src/impl.ts
+++ b/packages/modules/text-control/src/impl.ts
@@ -43,6 +43,7 @@ export class TextControlModuleImpl extends ModuleBase {
   private listeners: Listener[] = [];
   private host: TextControlHost | null = null;
   private lease: TextControlHostLease | null = null;
+  private leaseEpoch = 0;
 
   constructor(
     caps: CapsVaultView,
@@ -89,6 +90,7 @@ export class TextControlModuleImpl extends ModuleBase {
     };
     this.listeners = this.listeners.concat(listener);
     return () => {
+      this.sys.ensureSetup('textControl.off');
       this.listeners = this.listeners.filter((candidate) => candidate !== listener);
     };
   }
@@ -156,15 +158,20 @@ export class TextControlModuleImpl extends ModuleBase {
   private attachLease(): void {
     this.disposeLease();
     if (!this.declared || !this.host || this.mountPhase !== 'mounted') return;
+    const epoch = this.leaseEpoch;
     this.lease = this.host.attach({
       patch: this.effectivePatch(),
-      onEvent: (event) => this.receive(event),
+      onEvent: (event) => {
+        if (epoch === this.leaseEpoch) this.receive(event);
+      },
     });
   }
 
   private disposeLease(): void {
-    this.lease?.dispose();
+    this.leaseEpoch += 1;
+    const lease = this.lease;
     this.lease = null;
+    lease?.dispose();
   }
 
   private effectivePatch(): TextControlPatch {
@@ -208,7 +215,10 @@ export class TextControlModuleImpl extends ModuleBase {
       this.valueMode === 'controlled' &&
       ((event.type === 'input' && !event.composing) || event.type === 'compositionend');
     if (!mustRestoreControlledValue) return;
-    queueMicrotask(() => this.syncLease());
+    const epoch = this.leaseEpoch;
+    queueMicrotask(() => {
+      if (epoch === this.leaseEpoch) this.syncLease();
+    });
   }
 
   private canonicalize(value: string): string {

--- a/packages/modules/text-control/test/impl-spec.test.ts
+++ b/packages/modules/text-control/test/impl-spec.test.ts
@@ -304,3 +304,34 @@ describe('module-text-control', () => {
     expect(control.snapshot()?.value).toBe('retained');
   });
 });
+
+it('T-TEXT-CONTROL-0001-CASE-LIFETIME: stale lease events cannot change current value or invoke listeners', () => {
+  const h = createHarness();
+  const control = h.module.facade.declare();
+  const values: string[] = [];
+  control.on('input', (_run, event) => values.push(event.value));
+  h.module.hooks.onMountPhase?.('mounted', 1);
+  h.sys.phase = 'callback';
+  control.sync({ defaultValue: 'initial' });
+  const old = h.connectionBox.current!;
+  h.module.hooks.onMountPhase?.('detached', 1);
+  h.module.hooks.onMountPhase?.('mounted', 2);
+  old.onEvent(event('input', 'stale'));
+  expect(control.snapshot()?.value).toBe('initial');
+  expect(values).toEqual([]);
+  h.connectionBox.current!.onEvent(event('input', 'current'));
+  expect(values).toEqual(['current']);
+  h.module.hooks.dispose?.();
+  h.connectionBox.current!.onEvent(event('input', 'disposed'));
+  expect(values).toEqual(['current']);
+});
+
+it('T-TEXT-CONTROL-0001-CASE-CANCEL: listener cancellation is setup-only', () => {
+  const h = createHarness();
+  const control = h.module.facade.declare();
+  const off = control.on('input', () => {});
+  off();
+  off();
+  h.sys.phase = 'callback';
+  expect(off).toThrow('illegal phase');
+});

--- a/packages/prototypes/base/test/overlay-dismissal.test.ts
+++ b/packages/prototypes/base/test/overlay-dismissal.test.ts
@@ -1,0 +1,56 @@
+import { expect, it } from 'vitest';
+import { AdaptToWebComponent, setElementProps } from '@proto.ui/adapter-web-component';
+import { dialogRoot, dialogContent, dialogTrigger } from '../src/dialog';
+import { dropdownRoot, dropdownContent, dropdownTrigger } from '../src/dropdown';
+
+for (const proto of [
+  dialogRoot,
+  dialogContent,
+  dialogTrigger,
+  dropdownRoot,
+  dropdownContent,
+  dropdownTrigger,
+])
+  AdaptToWebComponent(proto as any);
+const flush = async () => {
+  for (let i = 0; i < 8; i++) await Promise.resolve();
+};
+
+it.each(['dialog', 'dropdown'])(
+  'T-OVERLAY-CATALOG-0001-CASE-CONSUMER: nested controlled %s requests stay with the selected Root',
+  async (kind) => {
+    function create() {
+      const root = document.createElement(`base-${kind}-root`) as any;
+      const trigger = document.createElement(`base-${kind}-trigger`);
+      const content = document.createElement(`base-${kind}-content`) as any;
+      setElementProps(root, { open: true });
+      root.append(trigger, content);
+      const requests: any[] = [];
+      root.addEventListener('openChange', (event: Event) => {
+        if (event.target === root) requests.push((event as CustomEvent).detail);
+      });
+      return { root, content, requests };
+    }
+    const outer = create();
+    document.body.append(outer.root);
+    await flush();
+    const inner = create();
+    outer.content.append(inner.root);
+    await flush();
+    try {
+      for (let i = 1; i <= 2; i++) {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+        await flush();
+        expect(outer.requests).toEqual([]);
+        expect(inner.requests).toHaveLength(i);
+        expect(inner.requests[i - 1]).toMatchObject({ open: false, reason: 'escape' });
+        expect(inner.root.getExposes().open.get()).toBe(true);
+        expect(outer.root.getExposes().open.get()).toBe(true);
+      }
+    } finally {
+      inner.root.remove();
+      outer.root.remove();
+      await flush();
+    }
+  }
+);

--- a/packages/runtime/test/contract/overlay.escape.contract.test.ts
+++ b/packages/runtime/test/contract/overlay.escape.contract.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+import { definePrototype, type OverlayHandle } from '@proto.ui/core';
+import { asOverlay } from '@proto.ui/hooks';
+import { EVENT_GLOBAL_TARGET_CAP, type EventPort } from '@proto.ui/module-event';
+import { createRuntimeSession, type RuntimeHost } from '../../src';
+
+async function create(
+  name: string,
+  target: EventTarget,
+  options: { controlled?: boolean; escape?: boolean } = {}
+) {
+  let overlay!: OverlayHandle;
+  let requests = 0;
+  const proto = definePrototype({
+    name,
+    setup() {
+      overlay = asOverlay();
+      overlay.configure({ defaultOpen: true, closeOnEscape: options.escape ?? true });
+      overlay.open.watch((_r, e) => {
+        if (e.type !== 'next' || e.next || e.reason !== 'escape') return;
+        requests++;
+        if (options.controlled) overlay.openOverlay('controlled.sync');
+      });
+      return (r) => r.el('div');
+    },
+  });
+  const host: RuntimeHost<any> = {
+    prototypeName: name,
+    getRawProps: () => ({}),
+    commit(_c, signal) {
+      signal?.done();
+    },
+    schedule(task) {
+      task();
+    },
+    onRuntimeReady(wiring) {
+      wiring.attach('event', [[EVENT_GLOBAL_TARGET_CAP, () => target]]);
+    },
+  };
+  const session = createRuntimeSession(proto, host);
+  await session.mount();
+  return { overlay, session, requests: () => requests };
+}
+function escape(target: EventTarget) {
+  target.dispatchEvent(new CustomEvent('key.down', { detail: { key: 'Escape' } }));
+}
+
+describe('C-AS-OVERLAY-0001-P: scoped single-sample Escape', async () => {
+  it('chooses the latest active candidate and skips opt-out while fixing ownership before close', async () => {
+    const target = new EventTarget();
+    const lower = await create('escape-lower', target);
+    const upper = await create('escape-upper', target);
+    const optOut = await create('escape-opt-out', target, { escape: false });
+    try {
+      escape(target);
+      expect([lower.requests(), upper.requests(), optOut.requests()]).toEqual([0, 1, 0]);
+      escape(target);
+      expect([lower.requests(), upper.requests()]).toEqual([1, 1]);
+    } finally {
+      await optOut.session.dispose();
+      await upper.session.dispose();
+      await lower.session.dispose();
+    }
+  });
+  it('controlled synchronous reopen consumes the sample once and cannot close the lower owner', async () => {
+    const target = new EventTarget();
+    const lower = await create('escape-controlled-lower', target);
+    const upper = await create('escape-controlled-upper', target, { controlled: true });
+    try {
+      escape(target);
+      escape(target);
+      expect(upper.requests()).toBe(2);
+      expect(lower.requests()).toBe(0);
+      expect(upper.overlay.isOpen()).toBe(true);
+    } finally {
+      await upper.session.dispose();
+      await lower.session.dispose();
+    }
+  });
+  it('isolates input scopes and removes disposed candidates', async () => {
+    const a = new EventTarget(),
+      b = new EventTarget();
+    const first = await create('escape-scope-a', a);
+    const second = await create('escape-scope-b', b);
+    try {
+      escape(a);
+      expect(first.requests()).toBe(1);
+      expect(second.requests()).toBe(0);
+      const third = await create('escape-scope-b-new', b);
+      await third.session.dispose();
+      escape(b);
+      expect(second.requests()).toBe(1);
+    } finally {
+      await second.session.dispose();
+      await first.session.dispose();
+    }
+  });
+  it('keeps repeated-open order, removes detached views and re-enters retained owners', async () => {
+    const target = new EventTarget();
+    const lower = await create('escape-retained-lower', target, { controlled: true });
+    const upper = await create('escape-retained-upper', target, { controlled: true });
+    try {
+      lower.session.invokeInCallbackScope(() => lower.overlay.openOverlay('programmatic'));
+      escape(target);
+      expect([lower.requests(), upper.requests()]).toEqual([0, 1]);
+      await upper.session.unmount();
+      escape(target);
+      expect(lower.requests()).toBe(1);
+      await upper.session.mount();
+      escape(target);
+      expect([lower.requests(), upper.requests()]).toEqual([1, 2]);
+    } finally {
+      await upper.session.dispose();
+      await lower.session.dispose();
+    }
+  });
+
+  it('M-EVENT-0001-K: input metadata is opaque, shared and callback-scoped without changing author payloads', async () => {
+    const target = new EventTarget();
+    const observations: Array<{ payload: any; context: any; port: EventPort }> = [];
+    const sessions = [0, 1].map((index) => {
+      let port: EventPort;
+      const proto = definePrototype({
+        name: `input-identity-${index}`,
+        setup(def) {
+          def.event.onGlobal('key.down', (_run, payload) => {
+            observations.push({ payload, context: port.getInputContext!(payload), port });
+            expect(Object.keys(payload).sort()).toEqual(['control', 'key', 'type']);
+            expect(Object.isFrozen(payload)).toBe(true);
+          });
+          return (r) => r.el('div');
+        },
+      });
+      const session = createRuntimeSession(proto, {
+        prototypeName: proto.name,
+        getRawProps: () => ({}),
+        commit: (_c, signal) => signal?.done(),
+        schedule: (task) => task(),
+        onRuntimeReady(wiring) {
+          wiring.attach('event', [[EVENT_GLOBAL_TARGET_CAP, () => target]]);
+        },
+      });
+      port = session.caps.getPort<EventPort>('event')!;
+      return session;
+    });
+    try {
+      for (const session of sessions) await session.mount();
+      escape(target);
+      expect(observations).toHaveLength(2);
+      expect(observations[0].payload).not.toBe(observations[1].payload);
+      expect(observations[0].context.sample).toBe(observations[1].context.sample);
+      expect(observations[0].context.scope).toBe(observations[1].context.scope);
+      expect(observations[0].context.scope).not.toBe(target);
+      expect(Object.keys(observations[0].context.sample)).toEqual([]);
+      for (const observation of observations)
+        expect(observation.port.getInputContext!(observation.payload)).toBeNull();
+      escape(target);
+      expect(observations[2].context.sample).not.toBe(observations[0].context.sample);
+    } finally {
+      for (const session of sessions) await session.dispose();
+    }
+  });
+});
+
+it('HC-EVENT-BINDING-0001-D: root-only delivery never reads the global input source', async () => {
+  const root = new EventTarget();
+  let deliveries = 0;
+  let globalReads = 0;
+  const proto = definePrototype({
+    name: 'root-only-input-scope',
+    setup(def) {
+      def.event.on('key.down', () => {
+        deliveries++;
+      });
+      return (r) => r.el('div');
+    },
+  });
+  const { EVENT_ROOT_TARGET_CAP, EVENT_GLOBAL_INPUT_SCOPE_CAP } =
+    await import('@proto.ui/module-event');
+  const session = createRuntimeSession(proto, {
+    prototypeName: proto.name,
+    getRawProps: () => ({}),
+    commit(_c: unknown, signal: any) {
+      signal?.done();
+    },
+    schedule(task: () => void) {
+      task();
+    },
+    onRuntimeReady(wiring: any) {
+      wiring.attach('event', [
+        [EVENT_ROOT_TARGET_CAP, () => root],
+        [
+          EVENT_GLOBAL_INPUT_SCOPE_CAP,
+          () => {
+            globalReads++;
+            return {};
+          },
+        ],
+      ]);
+    },
+  });
+  try {
+    await session.mount();
+    root.dispatchEvent(new CustomEvent('key.down', { detail: { key: 'Enter' } }));
+    expect(deliveries).toBe(1);
+    expect(globalReads).toBe(0);
+  } finally {
+    await session.dispose();
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,6 +429,9 @@ importers:
       '@proto.ui/module-hit-participation':
         specifier: workspace:*
         version: link:../../modules/hit-participation
+      '@proto.ui/module-image-view':
+        specifier: workspace:*
+        version: link:../../modules/image-view
       '@proto.ui/module-overlay':
         specifier: workspace:*
         version: link:../../modules/overlay

--- a/scripts/analysis/package-budgets.mjs
+++ b/scripts/analysis/package-budgets.mjs
@@ -16,7 +16,9 @@ const cases = [
   ['runtime root', 'packages/runtime/src/index.ts', 60_000],
   ['adapter-react root', 'packages/adapters/react/src/index.ts', 75_000],
   ['adapter-vue root', 'packages/adapters/vue/src/index.ts', 75_000],
-  ['adapter-web-component root', 'packages/adapters/web-component/src/index.ts', 75_000],
+  // PR #634 adds scoped Escape arbitration and shared Overlay resource ownership.
+  // CI measured 75,115 gzip bytes; retain a bounded allowance for this semantic slice.
+  ['adapter-web-component root', 'packages/adapters/web-component/src/index.ts', 76_000],
   ['prototypes-base/button', 'packages/prototypes/base/src/button/index.ts', 6_000],
   ['prototypes-shadcn/button', 'packages/prototypes/shadcn/src/button/index.ts', 7_000],
 ];

--- a/spec/adapters/A-REACT-18-19-0001.yaml
+++ b/spec/adapters/A-REACT-18-19-0001.yaml
@@ -137,6 +137,10 @@ criteria:
     text:
       en: The Web Adapter resolves a static Image View declaration to one physical image, projects portable properties, and retires obsolete decode completions on source replacement or unmount. Completion uses the existing callback bridge; native image events are not a second author transition protocol.
       zh-CN: Web Adapter 将静态 Image View declaration 解析为一个物理 image，投射 portable property，并在 source 替换或 unmount 后撤销过期 decode completion。completion 使用既有 callback bridge；native image event 不是第二套 author transition 协议。
+  - id: A-REACT-18-19-0001-SCROLL
+    text:
+      en: The standard Adapter wires Scroll with host-owned overflow and the current root, translates normalized requests/facts, and restores owned styles and listeners on teardown. Composed Thumb geometry and Move Gesture remain attached to the same Context/Anatomy-resolved surface; evidence uses simulated Web geometry, not native physics certification.
+      zh-CN: standard Adapter 将 Scroll 接入 host-owned overflow 与当前 root，翻译 normalized request/fact，并在 teardown 恢复拥有的样式、释放 listener。composed Thumb geometry 与 Move Gesture 附着到同一个 Context/Anatomy 解析的 surface；证据使用模拟 Web geometry，不是 native physics 认证。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -211,6 +215,9 @@ supports:
       since: 0.3.0-alpha.0
       role: required-module
       note: Installed by standard Runtime; author use requires a static declaration.
+    - id: M-SCROLL-0001
+      since: 0.3.0-alpha.0
+      role: required-module
 provides:
   hostCaps:
     - id: HC-ANCHORED-POSITION-0001
@@ -285,6 +292,13 @@ provides:
     - id: HC-TEXT-CONTROL-0001
       since: 0.3.0-alpha.0
       role: translated-capability
+    - id: HC-SCROLL-SURFACE-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+    - id: HC-MOVE-GESTURE-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Bounded Scroll composed Thumb realization; this relation is not general Drag and Drop support.
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -329,6 +343,10 @@ verifies:
     - id: T-OVERLAY-CATALOG-0001
       since: 0.3.0-alpha.0
     - id: T-TEXT-CONTROL-0001
+      since: 0.3.0-alpha.0
+    - id: T-SCROLL-0001
+      since: 0.3.0-alpha.0
+    - id: T-SCROLL-COMPOSED-CONTROL-0001
       since: 0.3.0-alpha.0
 sources:
   - path: packages/adapters/react/test/rule-expose-state-web.integration.test.ts
@@ -430,4 +448,7 @@ revisions:
   - version: 0.3.0-alpha.0
     change: clarified
     summary: Connected Image View support to bounded Adapter generation evidence.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Cataloged Scroll session projection and composed Thumb evidence through real Adapter wiring.
 tags: [adapter, react, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-REACT-18-19-0001.yaml
+++ b/spec/adapters/A-REACT-18-19-0001.yaml
@@ -129,6 +129,10 @@ criteria:
     text:
       en: The standard Adapter installs Overlay, provides renderer-appropriate Portal and shared Web modal scroll locking, and maps global input identity to the owning document independently of its per-instance Event router. Nested Escape and controlled reopen select one owner per sample; tests use simulated DOM, not browser layout certification.
       zh-CN: standard Adapter 安装 Overlay，提供 renderer 对应 Portal、共享 Web modal scroll lock，并将 global input identity 映射到 owner document，独立于每 instance Event router。嵌套 Escape 与 controlled reopen 每 sample 选择一个 owner；测试为模拟 DOM，不是 browser layout 认证。
+  - id: A-REACT-18-19-0001-TEXT-CONTROL
+    text:
+      en: The standard Web Adapter installs Text Control and resolves static line mode to one physical input or textarea before rendering. It projects common hints and normalized input, owns callback scope and releases the editing lease. Web Component retains its logical wrapper; native frameworks use the physical editor root.
+      zh-CN: standard Web Adapter 安装 Text Control，在 render 前将静态 line mode 解析为一个物理 input 或 textarea，投射 common hint 与 normalized input，提供 callback scope 并释放 editing lease。Web Component 保留 logical wrapper，原生框架使用物理 editor root。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -199,6 +203,10 @@ supports:
     - id: M-OVERLAY-0001
       since: 0.3.0-alpha.0
       role: required-module
+    - id: M-TEXT-CONTROL-0001
+      since: 0.3.0-alpha.0
+      role: required-module
+      note: Installed by standard Runtime; author use requires a static declaration.
 provides:
   hostCaps:
     - id: HC-ANCHORED-POSITION-0001
@@ -270,6 +278,9 @@ provides:
       since: 0.3.0-alpha.0
       role: translated-capability
       note: Optional configured scheduler; the Adapter passes it through, and does not promise a default absolute hierarchy.
+    - id: HC-TEXT-CONTROL-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -312,6 +323,8 @@ verifies:
     - id: T-EXPOSE-STATE-WEB-0001
       since: 0.3.0-alpha.0
     - id: T-OVERLAY-CATALOG-0001
+      since: 0.3.0-alpha.0
+    - id: T-TEXT-CONTROL-0001
       since: 0.3.0-alpha.0
 sources:
   - path: packages/adapters/react/test/rule-expose-state-web.integration.test.ts
@@ -407,4 +420,7 @@ revisions:
   - version: 0.3.0-alpha.0
     change: extended
     summary: Cataloged bounded Overlay wiring, scoped Escape and concurrent modal cleanup evidence.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Cataloged existing single-line and multiline Text Control realization with executable Adapter evidence.
 tags: [adapter, react, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-REACT-18-19-0001.yaml
+++ b/spec/adapters/A-REACT-18-19-0001.yaml
@@ -125,6 +125,10 @@ criteria:
     text:
       en: The standard Web Adapter installs this partial Rule optimization slice with its native-variant policy. Bounded State selectors, default fallbacks and view cleanup have evidence; live replanning and full CSS equivalence remain open.
       zh-CN: standard Web Adapter 安装此 partial Rule optimization slice 并提供 native-variant policy。有界 State selector、default fallback 和 view cleanup 已有证据；live replanning 与完整 CSS 等价仍 open。
+  - id: A-REACT-18-19-0001-OVERLAY
+    text:
+      en: The standard Adapter installs Overlay, provides renderer-appropriate Portal and shared Web modal scroll locking, and maps global input identity to the owning document independently of its per-instance Event router. Nested Escape and controlled reopen select one owner per sample; tests use simulated DOM, not browser layout certification.
+      zh-CN: standard Adapter 安装 Overlay，提供 renderer 对应 Portal、共享 Web modal scroll lock，并将 global input identity 映射到 owner document，独立于每 instance Event router。嵌套 Escape 与 controlled reopen 每 sample 选择一个 owner；测试为模拟 DOM，不是 browser layout 认证。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -192,6 +196,9 @@ supports:
       since: 0.3.0-alpha.0
       role: required-module
       note: Required in this standard Web profile; not a cross-host requirement.
+    - id: M-OVERLAY-0001
+      since: 0.3.0-alpha.0
+      role: required-module
 provides:
   hostCaps:
     - id: HC-ANCHORED-POSITION-0001
@@ -253,6 +260,16 @@ provides:
       since: 0.3.0-alpha.0
       role: translated-capability
       note: Canonical boundary; ordinary presentation surface coincides with it.
+    - id: HC-OVERLAY-PORTAL-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+    - id: HC-OVERLAY-MODAL-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+    - id: HC-OVERLAY-LAYER-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Optional configured scheduler; the Adapter passes it through, and does not promise a default absolute hierarchy.
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -293,6 +310,8 @@ verifies:
     - id: T-CONTEXT-0003
       since: 0.3.0-alpha.0
     - id: T-EXPOSE-STATE-WEB-0001
+      since: 0.3.0-alpha.0
+    - id: T-OVERLAY-CATALOG-0001
       since: 0.3.0-alpha.0
 sources:
   - path: packages/adapters/react/test/rule-expose-state-web.integration.test.ts
@@ -385,4 +404,7 @@ revisions:
   - version: 0.3.0-alpha.0
     change: revised
     summary: Added the reviewed Context identity/ancestry slice and real-framework nested-scope evidence; other unlisted modules remain uncataloged.
+  - version: 0.3.0-alpha.0
+    change: extended
+    summary: Cataloged bounded Overlay wiring, scoped Escape and concurrent modal cleanup evidence.
 tags: [adapter, react, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-REACT-18-19-0001.yaml
+++ b/spec/adapters/A-REACT-18-19-0001.yaml
@@ -133,6 +133,10 @@ criteria:
     text:
       en: The standard Web Adapter installs Text Control and resolves static line mode to one physical input or textarea before rendering. It projects common hints and normalized input, owns callback scope and releases the editing lease. Web Component retains its logical wrapper; native frameworks use the physical editor root.
       zh-CN: standard Web Adapter 安装 Text Control，在 render 前将静态 line mode 解析为一个物理 input 或 textarea，投射 common hint 与 normalized input，提供 callback scope 并释放 editing lease。Web Component 保留 logical wrapper，原生框架使用物理 editor root。
+  - id: A-REACT-18-19-0001-IMAGE-VIEW
+    text:
+      en: The Web Adapter resolves a static Image View declaration to one physical image, projects portable properties, and retires obsolete decode completions on source replacement or unmount. Completion uses the existing callback bridge; native image events are not a second author transition protocol.
+      zh-CN: Web Adapter 将静态 Image View declaration 解析为一个物理 image，投射 portable property，并在 source 替换或 unmount 后撤销过期 decode completion。completion 使用既有 callback bridge；native image event 不是第二套 author transition 协议。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -423,4 +427,7 @@ revisions:
   - version: 0.3.0-alpha.0
     change: clarified
     summary: Cataloged existing single-line and multiline Text Control realization with executable Adapter evidence.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Connected Image View support to bounded Adapter generation evidence.
 tags: [adapter, react, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-VUE-2-0001.yaml
+++ b/spec/adapters/A-VUE-2-0001.yaml
@@ -133,6 +133,10 @@ criteria:
     text:
       en: The Web Adapter resolves a static Image View declaration to one physical image, projects portable properties, and retires obsolete decode completions on source replacement or unmount. Completion uses the existing callback bridge; native image events are not a second author transition protocol.
       zh-CN: Web Adapter 将静态 Image View declaration 解析为一个物理 image，投射 portable property，并在 source 替换或 unmount 后撤销过期 decode completion。completion 使用既有 callback bridge；native image event 不是第二套 author transition 协议。
+  - id: A-VUE-2-0001-SCROLL
+    text:
+      en: The standard Adapter wires Scroll with host-owned overflow and the current root, translates normalized requests/facts, and restores owned styles and listeners on teardown. Composed Thumb geometry and Move Gesture remain attached to the same Context/Anatomy-resolved surface; evidence uses simulated Web geometry, not native physics certification.
+      zh-CN: standard Adapter 将 Scroll 接入 host-owned overflow 与当前 root，翻译 normalized request/fact，并在 teardown 恢复拥有的样式、释放 listener。composed Thumb geometry 与 Move Gesture 附着到同一个 Context/Anatomy 解析的 surface；证据使用模拟 Web geometry，不是 native physics 认证。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -207,6 +211,9 @@ supports:
       since: 0.3.0-alpha.0
       role: required-module
       note: Standard Runtime installs the Module; author use requires static declaration.
+    - id: M-SCROLL-0001
+      since: 0.3.0-alpha.0
+      role: required-module
 provides:
   hostCaps:
     - id: HC-ANCHORED-POSITION-0001
@@ -280,6 +287,13 @@ provides:
     - id: HC-IMAGE-VIEW-0001
       since: 0.3.0-alpha.0
       role: translated-capability
+    - id: HC-SCROLL-SURFACE-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+    - id: HC-MOVE-GESTURE-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Bounded Scroll composed Thumb realization; this relation is not general Drag and Drop support.
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -324,6 +338,10 @@ verifies:
     - id: T-TEXT-CONTROL-0001
       since: 0.3.0-alpha.0
     - id: T-IMAGE-VIEW-0001
+      since: 0.3.0-alpha.0
+    - id: T-SCROLL-0001
+      since: 0.3.0-alpha.0
+    - id: T-SCROLL-COMPOSED-CONTROL-0001
       since: 0.3.0-alpha.0
 sources:
   - path: packages/adapters/vue2/test/rule-expose-state-web.integration.test.ts
@@ -391,4 +409,7 @@ revisions:
   - version: 0.3.0-alpha.0
     change: clarified
     summary: Connected Image View support to bounded Adapter generation evidence.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Cataloged Scroll session projection and composed Thumb evidence through real Adapter wiring.
 tags: [adapter, vue2, vue, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-VUE-2-0001.yaml
+++ b/spec/adapters/A-VUE-2-0001.yaml
@@ -121,6 +121,10 @@ criteria:
     text:
       en: The standard Web Adapter installs this partial Rule optimization slice with its native-variant policy. Bounded State selectors, default fallbacks and view cleanup have evidence; live replanning and full CSS equivalence remain open.
       zh-CN: standard Web Adapter 安装此 partial Rule optimization slice 并提供 native-variant policy。有界 State selector、default fallback 和 view cleanup 已有证据；live replanning 与完整 CSS 等价仍 open。
+  - id: A-VUE-2-0001-OVERLAY
+    text:
+      en: The standard Adapter installs Overlay, provides renderer-appropriate Portal and shared Web modal scroll locking, and maps global input identity to the owning document independently of its per-instance Event router. Nested Escape and controlled reopen select one owner per sample; tests use simulated DOM, not browser layout certification.
+      zh-CN: standard Adapter 安装 Overlay，提供 renderer 对应 Portal、共享 Web modal scroll lock，并将 global input identity 映射到 owner document，独立于每 instance Event router。嵌套 Escape 与 controlled reopen 每 sample 选择一个 owner；测试为模拟 DOM，不是 browser layout 认证。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -184,6 +188,9 @@ supports:
       since: 0.3.0-alpha.0
       role: required-module
       note: Required in this standard Web profile; not a cross-host requirement.
+    - id: M-OVERLAY-0001
+      since: 0.3.0-alpha.0
+      role: required-module
 provides:
   hostCaps:
     - id: HC-ANCHORED-POSITION-0001
@@ -241,6 +248,16 @@ provides:
       since: 0.3.0-alpha.0
       role: translated-capability
       note: Canonical boundary; ordinary presentation surface coincides with it.
+    - id: HC-OVERLAY-PORTAL-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+    - id: HC-OVERLAY-MODAL-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+    - id: HC-OVERLAY-LAYER-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Optional configured scheduler; the Adapter passes it through, and does not promise a default absolute hierarchy.
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -279,6 +296,8 @@ verifies:
     - id: T-CONTEXT-0003
       since: 0.3.0-alpha.0
     - id: T-EXPOSE-STATE-WEB-0001
+      since: 0.3.0-alpha.0
+    - id: T-OVERLAY-CATALOG-0001
       since: 0.3.0-alpha.0
 sources:
   - path: packages/adapters/vue2/test/rule-expose-state-web.integration.test.ts
@@ -337,4 +356,7 @@ revisions:
   - version: 0.3.0-alpha.0
     change: revised
     summary: Added the reviewed Context identity/ancestry slice and real-framework nested-scope evidence; other unlisted modules remain uncataloged.
+  - version: 0.3.0-alpha.0
+    change: extended
+    summary: Cataloged bounded Overlay wiring, scoped Escape and concurrent modal cleanup evidence.
 tags: [adapter, vue2, vue, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-VUE-2-0001.yaml
+++ b/spec/adapters/A-VUE-2-0001.yaml
@@ -129,6 +129,10 @@ criteria:
     text:
       en: The standard Web Adapter installs Text Control and resolves static line mode to one physical input or textarea before rendering. It projects common hints and normalized input, owns callback scope and releases the editing lease. Web Component retains its logical wrapper; native frameworks use the physical editor root.
       zh-CN: standard Web Adapter 安装 Text Control，在 render 前将静态 line mode 解析为一个物理 input 或 textarea，投射 common hint 与 normalized input，提供 callback scope 并释放 editing lease。Web Component 保留 logical wrapper，原生框架使用物理 editor root。
+  - id: A-VUE-2-0001-IMAGE-VIEW
+    text:
+      en: The Web Adapter resolves a static Image View declaration to one physical image, projects portable properties, and retires obsolete decode completions on source replacement or unmount. Completion uses the existing callback bridge; native image events are not a second author transition protocol.
+      zh-CN: Web Adapter 将静态 Image View declaration 解析为一个物理 image，投射 portable property，并在 source 替换或 unmount 后撤销过期 decode completion。completion 使用既有 callback bridge；native image event 不是第二套 author transition 协议。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -199,6 +203,10 @@ supports:
       since: 0.3.0-alpha.0
       role: required-module
       note: Installed by standard Runtime; author use requires a static declaration.
+    - id: M-IMAGE-VIEW-0001
+      since: 0.3.0-alpha.0
+      role: required-module
+      note: Standard Runtime installs the Module; author use requires static declaration.
 provides:
   hostCaps:
     - id: HC-ANCHORED-POSITION-0001
@@ -269,6 +277,9 @@ provides:
     - id: HC-TEXT-CONTROL-0001
       since: 0.3.0-alpha.0
       role: translated-capability
+    - id: HC-IMAGE-VIEW-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -311,6 +322,8 @@ verifies:
     - id: T-OVERLAY-CATALOG-0001
       since: 0.3.0-alpha.0
     - id: T-TEXT-CONTROL-0001
+      since: 0.3.0-alpha.0
+    - id: T-IMAGE-VIEW-0001
       since: 0.3.0-alpha.0
 sources:
   - path: packages/adapters/vue2/test/rule-expose-state-web.integration.test.ts
@@ -375,4 +388,7 @@ revisions:
   - version: 0.3.0-alpha.0
     change: clarified
     summary: Cataloged existing single-line and multiline Text Control realization with executable Adapter evidence.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Connected Image View support to bounded Adapter generation evidence.
 tags: [adapter, vue2, vue, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-VUE-2-0001.yaml
+++ b/spec/adapters/A-VUE-2-0001.yaml
@@ -125,6 +125,10 @@ criteria:
     text:
       en: The standard Adapter installs Overlay, provides renderer-appropriate Portal and shared Web modal scroll locking, and maps global input identity to the owning document independently of its per-instance Event router. Nested Escape and controlled reopen select one owner per sample; tests use simulated DOM, not browser layout certification.
       zh-CN: standard Adapter 安装 Overlay，提供 renderer 对应 Portal、共享 Web modal scroll lock，并将 global input identity 映射到 owner document，独立于每 instance Event router。嵌套 Escape 与 controlled reopen 每 sample 选择一个 owner；测试为模拟 DOM，不是 browser layout 认证。
+  - id: A-VUE-2-0001-TEXT-CONTROL
+    text:
+      en: The standard Web Adapter installs Text Control and resolves static line mode to one physical input or textarea before rendering. It projects common hints and normalized input, owns callback scope and releases the editing lease. Web Component retains its logical wrapper; native frameworks use the physical editor root.
+      zh-CN: standard Web Adapter 安装 Text Control，在 render 前将静态 line mode 解析为一个物理 input 或 textarea，投射 common hint 与 normalized input，提供 callback scope 并释放 editing lease。Web Component 保留 logical wrapper，原生框架使用物理 editor root。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -191,6 +195,10 @@ supports:
     - id: M-OVERLAY-0001
       since: 0.3.0-alpha.0
       role: required-module
+    - id: M-TEXT-CONTROL-0001
+      since: 0.3.0-alpha.0
+      role: required-module
+      note: Installed by standard Runtime; author use requires a static declaration.
 provides:
   hostCaps:
     - id: HC-ANCHORED-POSITION-0001
@@ -258,6 +266,9 @@ provides:
       since: 0.3.0-alpha.0
       role: translated-capability
       note: Optional configured scheduler; the Adapter passes it through, and does not promise a default absolute hierarchy.
+    - id: HC-TEXT-CONTROL-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -298,6 +309,8 @@ verifies:
     - id: T-EXPOSE-STATE-WEB-0001
       since: 0.3.0-alpha.0
     - id: T-OVERLAY-CATALOG-0001
+      since: 0.3.0-alpha.0
+    - id: T-TEXT-CONTROL-0001
       since: 0.3.0-alpha.0
 sources:
   - path: packages/adapters/vue2/test/rule-expose-state-web.integration.test.ts
@@ -359,4 +372,7 @@ revisions:
   - version: 0.3.0-alpha.0
     change: extended
     summary: Cataloged bounded Overlay wiring, scoped Escape and concurrent modal cleanup evidence.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Cataloged existing single-line and multiline Text Control realization with executable Adapter evidence.
 tags: [adapter, vue2, vue, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-VUE-3-0001.yaml
+++ b/spec/adapters/A-VUE-3-0001.yaml
@@ -133,6 +133,10 @@ criteria:
     text:
       en: The standard Web Adapter installs Text Control and resolves static line mode to one physical input or textarea before rendering. It projects common hints and normalized input, owns callback scope and releases the editing lease. Web Component retains its logical wrapper; native frameworks use the physical editor root.
       zh-CN: standard Web Adapter 安装 Text Control，在 render 前将静态 line mode 解析为一个物理 input 或 textarea，投射 common hint 与 normalized input，提供 callback scope 并释放 editing lease。Web Component 保留 logical wrapper，原生框架使用物理 editor root。
+  - id: A-VUE-3-0001-IMAGE-VIEW
+    text:
+      en: The Web Adapter resolves a static Image View declaration to one physical image, projects portable properties, and retires obsolete decode completions on source replacement or unmount. Completion uses the existing callback bridge; native image events are not a second author transition protocol.
+      zh-CN: Web Adapter 将静态 Image View declaration 解析为一个物理 image，投射 portable property，并在 source 替换或 unmount 后撤销过期 decode completion。completion 使用既有 callback bridge；native image event 不是第二套 author transition 协议。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -421,4 +425,7 @@ revisions:
   - version: 0.3.0-alpha.0
     change: clarified
     summary: Cataloged existing single-line and multiline Text Control realization with executable Adapter evidence.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Connected Image View support to bounded Adapter generation evidence.
 tags: [adapter, vue, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-VUE-3-0001.yaml
+++ b/spec/adapters/A-VUE-3-0001.yaml
@@ -129,6 +129,10 @@ criteria:
     text:
       en: The standard Adapter installs Overlay, provides renderer-appropriate Portal and shared Web modal scroll locking, and maps global input identity to the owning document independently of its per-instance Event router. Nested Escape and controlled reopen select one owner per sample; tests use simulated DOM, not browser layout certification.
       zh-CN: standard Adapter 安装 Overlay，提供 renderer 对应 Portal、共享 Web modal scroll lock，并将 global input identity 映射到 owner document，独立于每 instance Event router。嵌套 Escape 与 controlled reopen 每 sample 选择一个 owner；测试为模拟 DOM，不是 browser layout 认证。
+  - id: A-VUE-3-0001-TEXT-CONTROL
+    text:
+      en: The standard Web Adapter installs Text Control and resolves static line mode to one physical input or textarea before rendering. It projects common hints and normalized input, owns callback scope and releases the editing lease. Web Component retains its logical wrapper; native frameworks use the physical editor root.
+      zh-CN: standard Web Adapter 安装 Text Control，在 render 前将静态 line mode 解析为一个物理 input 或 textarea，投射 common hint 与 normalized input，提供 callback scope 并释放 editing lease。Web Component 保留 logical wrapper，原生框架使用物理 editor root。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -199,6 +203,10 @@ supports:
     - id: M-OVERLAY-0001
       since: 0.3.0-alpha.0
       role: required-module
+    - id: M-TEXT-CONTROL-0001
+      since: 0.3.0-alpha.0
+      role: required-module
+      note: Installed by standard Runtime; author use requires a static declaration.
 provides:
   hostCaps:
     - id: HC-ANCHORED-POSITION-0001
@@ -270,6 +278,9 @@ provides:
       since: 0.3.0-alpha.0
       role: translated-capability
       note: Optional configured scheduler; the Adapter passes it through, and does not promise a default absolute hierarchy.
+    - id: HC-TEXT-CONTROL-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -312,6 +323,8 @@ verifies:
     - id: T-EXPOSE-STATE-WEB-0001
       since: 0.3.0-alpha.0
     - id: T-OVERLAY-CATALOG-0001
+      since: 0.3.0-alpha.0
+    - id: T-TEXT-CONTROL-0001
       since: 0.3.0-alpha.0
 sources:
   - path: packages/adapters/vue/test/rule-expose-state-web.integration.test.ts
@@ -405,4 +418,7 @@ revisions:
   - version: 0.3.0-alpha.0
     change: extended
     summary: Cataloged bounded Overlay wiring, scoped Escape and concurrent modal cleanup evidence.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Cataloged existing single-line and multiline Text Control realization with executable Adapter evidence.
 tags: [adapter, vue, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-VUE-3-0001.yaml
+++ b/spec/adapters/A-VUE-3-0001.yaml
@@ -125,6 +125,10 @@ criteria:
     text:
       en: The standard Web Adapter installs this partial Rule optimization slice with its native-variant policy. Bounded State selectors, default fallbacks and view cleanup have evidence; live replanning and full CSS equivalence remain open.
       zh-CN: standard Web Adapter 安装此 partial Rule optimization slice 并提供 native-variant policy。有界 State selector、default fallback 和 view cleanup 已有证据；live replanning 与完整 CSS 等价仍 open。
+  - id: A-VUE-3-0001-OVERLAY
+    text:
+      en: The standard Adapter installs Overlay, provides renderer-appropriate Portal and shared Web modal scroll locking, and maps global input identity to the owning document independently of its per-instance Event router. Nested Escape and controlled reopen select one owner per sample; tests use simulated DOM, not browser layout certification.
+      zh-CN: standard Adapter 安装 Overlay，提供 renderer 对应 Portal、共享 Web modal scroll lock，并将 global input identity 映射到 owner document，独立于每 instance Event router。嵌套 Escape 与 controlled reopen 每 sample 选择一个 owner；测试为模拟 DOM，不是 browser layout 认证。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -192,6 +196,9 @@ supports:
       since: 0.3.0-alpha.0
       role: required-module
       note: Required in this standard Web profile; not a cross-host requirement.
+    - id: M-OVERLAY-0001
+      since: 0.3.0-alpha.0
+      role: required-module
 provides:
   hostCaps:
     - id: HC-ANCHORED-POSITION-0001
@@ -253,6 +260,16 @@ provides:
       since: 0.3.0-alpha.0
       role: translated-capability
       note: Canonical boundary; ordinary presentation surface coincides with it.
+    - id: HC-OVERLAY-PORTAL-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+    - id: HC-OVERLAY-MODAL-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+    - id: HC-OVERLAY-LAYER-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Optional configured scheduler; the Adapter passes it through, and does not promise a default absolute hierarchy.
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -293,6 +310,8 @@ verifies:
     - id: T-CONTEXT-0003
       since: 0.3.0-alpha.0
     - id: T-EXPOSE-STATE-WEB-0001
+      since: 0.3.0-alpha.0
+    - id: T-OVERLAY-CATALOG-0001
       since: 0.3.0-alpha.0
 sources:
   - path: packages/adapters/vue/test/rule-expose-state-web.integration.test.ts
@@ -383,4 +402,7 @@ revisions:
   - version: 0.3.0-alpha.0
     change: revised
     summary: Added the reviewed Context identity/ancestry slice and real-framework nested-scope evidence; other unlisted modules remain uncataloged.
+  - version: 0.3.0-alpha.0
+    change: extended
+    summary: Cataloged bounded Overlay wiring, scoped Escape and concurrent modal cleanup evidence.
 tags: [adapter, vue, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-VUE-3-0001.yaml
+++ b/spec/adapters/A-VUE-3-0001.yaml
@@ -137,6 +137,10 @@ criteria:
     text:
       en: The Web Adapter resolves a static Image View declaration to one physical image, projects portable properties, and retires obsolete decode completions on source replacement or unmount. Completion uses the existing callback bridge; native image events are not a second author transition protocol.
       zh-CN: Web Adapter 将静态 Image View declaration 解析为一个物理 image，投射 portable property，并在 source 替换或 unmount 后撤销过期 decode completion。completion 使用既有 callback bridge；native image event 不是第二套 author transition 协议。
+  - id: A-VUE-3-0001-SCROLL
+    text:
+      en: The standard Adapter wires Scroll with host-owned overflow and the current root, translates normalized requests/facts, and restores owned styles and listeners on teardown. Composed Thumb geometry and Move Gesture remain attached to the same Context/Anatomy-resolved surface; evidence uses simulated Web geometry, not native physics certification.
+      zh-CN: standard Adapter 将 Scroll 接入 host-owned overflow 与当前 root，翻译 normalized request/fact，并在 teardown 恢复拥有的样式、释放 listener。composed Thumb geometry 与 Move Gesture 附着到同一个 Context/Anatomy 解析的 surface；证据使用模拟 Web geometry，不是 native physics 认证。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -211,6 +215,9 @@ supports:
       since: 0.3.0-alpha.0
       role: required-module
       note: Installed by standard Runtime; author use requires a static declaration.
+    - id: M-SCROLL-0001
+      since: 0.3.0-alpha.0
+      role: required-module
 provides:
   hostCaps:
     - id: HC-ANCHORED-POSITION-0001
@@ -285,6 +292,13 @@ provides:
     - id: HC-TEXT-CONTROL-0001
       since: 0.3.0-alpha.0
       role: translated-capability
+    - id: HC-SCROLL-SURFACE-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+    - id: HC-MOVE-GESTURE-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Bounded Scroll composed Thumb realization; this relation is not general Drag and Drop support.
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -329,6 +343,10 @@ verifies:
     - id: T-OVERLAY-CATALOG-0001
       since: 0.3.0-alpha.0
     - id: T-TEXT-CONTROL-0001
+      since: 0.3.0-alpha.0
+    - id: T-SCROLL-0001
+      since: 0.3.0-alpha.0
+    - id: T-SCROLL-COMPOSED-CONTROL-0001
       since: 0.3.0-alpha.0
 sources:
   - path: packages/adapters/vue/test/rule-expose-state-web.integration.test.ts
@@ -428,4 +446,7 @@ revisions:
   - version: 0.3.0-alpha.0
     change: clarified
     summary: Connected Image View support to bounded Adapter generation evidence.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Cataloged Scroll session projection and composed Thumb evidence through real Adapter wiring.
 tags: [adapter, vue, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-WEB-COMPONENT-0001.yaml
+++ b/spec/adapters/A-WEB-COMPONENT-0001.yaml
@@ -128,6 +128,10 @@ criteria:
     text:
       en: The standard Adapter installs Overlay, provides renderer-appropriate Portal and shared Web modal scroll locking, and maps global input identity to the owning document independently of its per-instance Event router. Nested Escape and controlled reopen select one owner per sample; tests use simulated DOM, not browser layout certification.
       zh-CN: standard Adapter 安装 Overlay，提供 renderer 对应 Portal、共享 Web modal scroll lock，并将 global input identity 映射到 owner document，独立于每 instance Event router。嵌套 Escape 与 controlled reopen 每 sample 选择一个 owner；测试为模拟 DOM，不是 browser layout 认证。
+  - id: A-WEB-COMPONENT-0001-TEXT-CONTROL
+    text:
+      en: The standard Web Adapter installs Text Control and resolves static line mode to one physical input or textarea before rendering. It projects common hints and normalized input, owns callback scope and releases the editing lease. Web Component retains its logical wrapper; native frameworks use the physical editor root.
+      zh-CN: standard Web Adapter 安装 Text Control，在 render 前将静态 line mode 解析为一个物理 input 或 textarea，投射 common hint 与 normalized input，提供 callback scope 并释放 editing lease。Web Component 保留 logical wrapper，原生框架使用物理 editor root。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -198,6 +202,10 @@ supports:
     - id: M-OVERLAY-0001
       since: 0.3.0-alpha.0
       role: required-module
+    - id: M-TEXT-CONTROL-0001
+      since: 0.3.0-alpha.0
+      role: required-module
+      note: Installed by standard Runtime; author use requires a static declaration.
 provides:
   hostCaps:
     - id: HC-ANCHORED-POSITION-0001
@@ -269,6 +277,9 @@ provides:
       since: 0.3.0-alpha.0
       role: translated-capability
       note: Optional configured scheduler; the Adapter passes it through, and does not promise a default absolute hierarchy.
+    - id: HC-TEXT-CONTROL-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -311,6 +322,8 @@ verifies:
     - id: T-EXPOSE-STATE-WEB-0001
       since: 0.3.0-alpha.0
     - id: T-OVERLAY-CATALOG-0001
+      since: 0.3.0-alpha.0
+    - id: T-TEXT-CONTROL-0001
       since: 0.3.0-alpha.0
 openQuestions:
   - id: A-WEB-COMPONENT-0001-Q-INGRESS-PRECEDENCE
@@ -415,5 +428,8 @@ revisions:
   - version: 0.3.0-alpha.0
     change: extended
     summary: Cataloged bounded Overlay wiring, scoped Escape and concurrent modal cleanup evidence.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Cataloged existing single-line and multiline Text Control realization with executable Adapter evidence.
 tags:
   [adapter, web-component, custom-elements, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-WEB-COMPONENT-0001.yaml
+++ b/spec/adapters/A-WEB-COMPONENT-0001.yaml
@@ -132,6 +132,10 @@ criteria:
     text:
       en: The standard Web Adapter installs Text Control and resolves static line mode to one physical input or textarea before rendering. It projects common hints and normalized input, owns callback scope and releases the editing lease. Web Component retains its logical wrapper; native frameworks use the physical editor root.
       zh-CN: standard Web Adapter 安装 Text Control，在 render 前将静态 line mode 解析为一个物理 input 或 textarea，投射 common hint 与 normalized input，提供 callback scope 并释放 editing lease。Web Component 保留 logical wrapper，原生框架使用物理 editor root。
+  - id: A-WEB-COMPONENT-0001-IMAGE-VIEW
+    text:
+      en: The Web Adapter resolves a static Image View declaration to one physical image, projects portable properties, and retires obsolete decode completions on source replacement or unmount. Completion uses the existing callback bridge; native image events are not a second author transition protocol.
+      zh-CN: Web Adapter 将静态 Image View declaration 解析为一个物理 image，投射 portable property，并在 source 替换或 unmount 后撤销过期 decode completion。completion 使用既有 callback bridge；native image event 不是第二套 author transition 协议。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -431,5 +435,8 @@ revisions:
   - version: 0.3.0-alpha.0
     change: clarified
     summary: Cataloged existing single-line and multiline Text Control realization with executable Adapter evidence.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Connected Image View support to bounded Adapter generation evidence.
 tags:
   [adapter, web-component, custom-elements, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-WEB-COMPONENT-0001.yaml
+++ b/spec/adapters/A-WEB-COMPONENT-0001.yaml
@@ -136,6 +136,10 @@ criteria:
     text:
       en: The Web Adapter resolves a static Image View declaration to one physical image, projects portable properties, and retires obsolete decode completions on source replacement or unmount. Completion uses the existing callback bridge; native image events are not a second author transition protocol.
       zh-CN: Web Adapter 将静态 Image View declaration 解析为一个物理 image，投射 portable property，并在 source 替换或 unmount 后撤销过期 decode completion。completion 使用既有 callback bridge；native image event 不是第二套 author transition 协议。
+  - id: A-WEB-COMPONENT-0001-SCROLL
+    text:
+      en: The standard Adapter wires Scroll with host-owned overflow and the current root, translates normalized requests/facts, and restores owned styles and listeners on teardown. Composed Thumb geometry and Move Gesture remain attached to the same Context/Anatomy-resolved surface; evidence uses simulated Web geometry, not native physics certification.
+      zh-CN: standard Adapter 将 Scroll 接入 host-owned overflow 与当前 root，翻译 normalized request/fact，并在 teardown 恢复拥有的样式、释放 listener。composed Thumb geometry 与 Move Gesture 附着到同一个 Context/Anatomy 解析的 surface；证据使用模拟 Web geometry，不是 native physics 认证。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -210,6 +214,9 @@ supports:
       since: 0.3.0-alpha.0
       role: required-module
       note: Installed by standard Runtime; author use requires a static declaration.
+    - id: M-SCROLL-0001
+      since: 0.3.0-alpha.0
+      role: required-module
 provides:
   hostCaps:
     - id: HC-ANCHORED-POSITION-0001
@@ -284,6 +291,13 @@ provides:
     - id: HC-TEXT-CONTROL-0001
       since: 0.3.0-alpha.0
       role: translated-capability
+    - id: HC-SCROLL-SURFACE-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+    - id: HC-MOVE-GESTURE-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Bounded Scroll composed Thumb realization; this relation is not general Drag and Drop support.
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -328,6 +342,10 @@ verifies:
     - id: T-OVERLAY-CATALOG-0001
       since: 0.3.0-alpha.0
     - id: T-TEXT-CONTROL-0001
+      since: 0.3.0-alpha.0
+    - id: T-SCROLL-0001
+      since: 0.3.0-alpha.0
+    - id: T-SCROLL-COMPOSED-CONTROL-0001
       since: 0.3.0-alpha.0
 openQuestions:
   - id: A-WEB-COMPONENT-0001-Q-INGRESS-PRECEDENCE
@@ -438,5 +456,8 @@ revisions:
   - version: 0.3.0-alpha.0
     change: clarified
     summary: Connected Image View support to bounded Adapter generation evidence.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Cataloged Scroll session projection and composed Thumb evidence through real Adapter wiring.
 tags:
   [adapter, web-component, custom-elements, web, props, event, lifecycle, state, expose, official]

--- a/spec/adapters/A-WEB-COMPONENT-0001.yaml
+++ b/spec/adapters/A-WEB-COMPONENT-0001.yaml
@@ -124,6 +124,10 @@ criteria:
     text:
       en: The standard Web Adapter installs this partial Rule optimization slice with its native-variant policy. Bounded State selectors, default fallbacks and view cleanup have evidence; live replanning and full CSS equivalence remain open.
       zh-CN: standard Web Adapter 安装此 partial Rule optimization slice 并提供 native-variant policy。有界 State selector、default fallback 和 view cleanup 已有证据；live replanning 与完整 CSS 等价仍 open。
+  - id: A-WEB-COMPONENT-0001-OVERLAY
+    text:
+      en: The standard Adapter installs Overlay, provides renderer-appropriate Portal and shared Web modal scroll locking, and maps global input identity to the owning document independently of its per-instance Event router. Nested Escape and controlled reopen select one owner per sample; tests use simulated DOM, not browser layout certification.
+      zh-CN: standard Adapter 安装 Overlay，提供 renderer 对应 Portal、共享 Web modal scroll lock，并将 global input identity 映射到 owner document，独立于每 instance Event router。嵌套 Escape 与 controlled reopen 每 sample 选择一个 owner；测试为模拟 DOM，不是 browser layout 认证。
 supports:
   modules:
     - id: M-POSITIONING-0001
@@ -191,6 +195,9 @@ supports:
       since: 0.3.0-alpha.0
       role: required-module
       note: Required in this standard Web profile; not a cross-host requirement.
+    - id: M-OVERLAY-0001
+      since: 0.3.0-alpha.0
+      role: required-module
 provides:
   hostCaps:
     - id: HC-ANCHORED-POSITION-0001
@@ -252,6 +259,16 @@ provides:
       since: 0.3.0-alpha.0
       role: translated-capability
       note: Canonical boundary plus presentation mirror for split host-owned controls.
+    - id: HC-OVERLAY-PORTAL-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+    - id: HC-OVERLAY-MODAL-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+    - id: HC-OVERLAY-LAYER-0001
+      since: 0.3.0-alpha.0
+      role: translated-capability
+      note: Optional configured scheduler; the Adapter passes it through, and does not promise a default absolute hierarchy.
 relates:
   decisions:
     - D-ADAPTER-PROFILE-0001
@@ -292,6 +309,8 @@ verifies:
     - id: T-CONTEXT-0003
       since: 0.3.0-alpha.0
     - id: T-EXPOSE-STATE-WEB-0001
+      since: 0.3.0-alpha.0
+    - id: T-OVERLAY-CATALOG-0001
       since: 0.3.0-alpha.0
 openQuestions:
   - id: A-WEB-COMPONENT-0001-Q-INGRESS-PRECEDENCE
@@ -393,5 +412,8 @@ revisions:
   - version: 0.3.0-alpha.0
     change: revised
     summary: Added the reviewed Context identity/ancestry slice and real-framework nested-scope evidence; other unlisted modules remain uncataloged.
+  - version: 0.3.0-alpha.0
+    change: extended
+    summary: Cataloged bounded Overlay wiring, scoped Escape and concurrent modal cleanup evidence.
 tags:
   [adapter, web-component, custom-elements, web, props, event, lifecycle, state, expose, official]

--- a/spec/contracts/C-AS-OVERLAY-0001.yaml
+++ b/spec/contracts/C-AS-OVERLAY-0001.yaml
@@ -74,6 +74,10 @@ criteria:
     text:
       zh-CN: positioning lease 必须跟随 bound Presence 的 active view，而非仅跟随 logical open；Portal、layer 与 positioning 的建立必须在最外层 runtime callback 完成后协调。
       en: The positioning lease must follow the bound Presence active view rather than logical open alone; Portal, layer, and positioning establishment must be reconciled after the outermost runtime callback completes.
+  - id: C-AS-OVERLAY-0001-P
+    text:
+      en: 'Within one global input scope, one Escape sample selects at most the most recently activated eligible Overlay. Eligibility requires logical open, active presence, a mounted view and closeOnEscape opt-in. Opted-out or detached instances do not block eligible instances. Selection is fixed before callbacks: closing, disposing or synchronously reopening the selected instance cannot deliver that sample to another candidate. Logical activation order is independent of z-index; repeated open on an already eligible instance does not reorder it.'
+      zh-CN: 同一 global input scope 中，一次 Escape sample 至多选择最近激活的合格 Overlay。资格要求 logical open、active presence、mounted view 与 closeOnEscape opt-in。未启用或 detached 实例不阻挡合格实例。调用 callback 前固定选择；被选实例关闭、销毁或同步重新打开，都不能将同一 sample 传给另一候选。逻辑激活顺序独立于 z-index；已合格实例重复 open 不改变顺序。
 sources:
   - path: internal/contracts/overlay/as-overlay.v0.md
   - path: packages/hooks/src/as-overlay.ts
@@ -103,6 +107,8 @@ dependsOn:
 verifies:
   tests:
     - T-AS-OVERLAY-0001
+    - id: T-OVERLAY-CATALOG-0001
+      since: 0.3.0-alpha.0
 revisions:
   - version: 0.1.0
     change: introduced
@@ -125,6 +131,9 @@ revisions:
   - version: 0.2.0-rc.0
     change: refined
     summary: Required resolved Anatomy anchors to remain shared by Positioning and Boundary classification.
+  - version: 0.3.0-alpha.0
+    change: extended
+    summary: Added scope-bound single-sample Escape coordination without changing portable author payloads.
 tags:
   - overlay
   - as-hook

--- a/spec/host-caps/HC-EVENT-BINDING-0001.yaml
+++ b/spec/host-caps/HC-EVENT-BINDING-0001.yaml
@@ -38,6 +38,10 @@ criteria:
     text:
       zh-CN: instance unmount、terminal disposal 或 registration removal 必须释放对应宿主 listener、observer、delegate 与其它 binding resource。
       en: Instance unmount, terminal disposal, or registration removal must release the corresponding host listener, observer, delegate, and other binding resources.
+  - id: HC-EVENT-BINDING-0001-G
+    text:
+      en: The standard Web binding supplies the shared owning-document input scope independently of per-instance router proxies. Wrappers for the same native input retain common source identity for privileged opaque sample tokens; neither identity nor raw host references enter portable author payloads. This does not change ordinary Event broadcast.
+      zh-CN: standard Web binding 提供共享 owner document input scope，独立于 per-instance router proxy。同一 native input 的 wrapper 保留共同 source identity，供 privileged opaque sample token 使用；identity 与 raw host reference 均不进入 portable author payload，也不改变普通 Event broadcast。
 relates:
   contracts:
     - C-EVENT-0002
@@ -55,6 +59,8 @@ relates:
 verifies:
   tests:
     - T-EVENT-0003
+    - id: T-OVERLAY-CATALOG-0001
+      since: 0.3.0-alpha.0
 sources:
   - path: internal/records/2026-08-14-event-module-host-cap-adapter-audit.zh-CN.md
   - path: internal/contracts/event/event.v0.md
@@ -85,4 +91,7 @@ revisions:
   - version: 0.2.0-rc.7
     change: introduced
     summary: Cataloged host-neutral scoped Event binding, translation, conditional availability, rebinding, and cleanup while recording the current EventTarget realization as portability debt.
+  - version: 0.3.0-alpha.0
+    change: extended
+    summary: Added privileged shared input identity wiring for Overlay arbitration.
 tags: [host-capability, event, binding, adapter, lifecycle]

--- a/spec/host-caps/HC-IMAGE-VIEW-0001.yaml
+++ b/spec/host-caps/HC-IMAGE-VIEW-0001.yaml
@@ -33,6 +33,15 @@ revisions:
       Cataloged the Image View host lease for one host-owned image presentation target with generation-bound lifecycle.
 
 
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Made request-bound Web realization and cleanup addressable without generalizing readiness across hosts.
+
 tags:
   - image
   - host-capability
+criteria:
+  - id: HC-IMAGE-VIEW-0001-A
+    text:
+      en: The host owns one image target and immutable request identity, projects current source/alternative text/fit, and clears replaced visuals. Web completion comes from a complete displayable image or request-bound decode settlement; stale settlements and native load/error events cannot become current portable transitions. Disposal releases the target and listeners.
+      zh-CN: host 拥有一个 image target 与不可变 request identity，投射当前 source/alternative text/fit 并清除被替换视觉。Web completion 来自 complete 且可展示图像或绑定 request 的 decode settlement；旧 settlement 与 native load/error 不得成为当前 portable transition。dispose 释放 target 与 listener。

--- a/spec/host-caps/HC-OVERLAY-LAYER-0001.yaml
+++ b/spec/host-caps/HC-OVERLAY-LAYER-0001.yaml
@@ -1,0 +1,27 @@
+id: HC-OVERLAY-LAYER-0001
+type: host-cap
+title: Host projects Overlay layer requests
+status: draft
+since: 0.3.0-alpha.0
+summary: A layer scheduler owns a bounded host style contribution; numeric Web ordering does not arbitrate Escape.
+criteria:
+  - id: HC-OVERLAY-LAYER-0001-A
+    text:
+      en: attach receives the current target and layer request and returns an idempotent disposer. The Web scheduler projects base plus activation sequence times step plus role and instance offsets; disposal restores the original inline z-index value and priority. This arithmetic is not an absolute role hierarchy or logical Escape activation order.
+      zh-CN: attach 接受当前 target 与 layer request，并返回幂等 disposer。Web scheduler 投射 base + sequence × step + role/instance offset；dispose 恢复原 inline z-index 值与 priority。该算式不构成绝对 role hierarchy，也不是 Escape logical activation order。
+relates:
+  contracts:
+    - C-AS-OVERLAY-0001
+verifies:
+  tests:
+    - T-OVERLAY-CATALOG-0001
+sources:
+  - path: packages/modules/overlay/src/caps.ts
+  - path: packages/modules/overlay/src/web/z-index-layer-scheduler.ts
+revisions:
+  - version: 0.3.0-alpha.0
+    change: introduced
+    summary: Cataloged the bounded Overlay host resource and cleanup responsibility.
+tags:
+  - overlay
+  - host-capability

--- a/spec/host-caps/HC-OVERLAY-MODAL-0001.yaml
+++ b/spec/host-caps/HC-OVERLAY-MODAL-0001.yaml
@@ -1,0 +1,27 @@
+id: HC-OVERLAY-MODAL-0001
+type: host-cap
+title: Host maintains Overlay modal activity resources
+status: draft
+since: 0.3.0-alpha.0
+summary: The current Web modal realization owns shared body scroll locking, not a complete modal interaction policy.
+criteria:
+  - id: HC-OVERLAY-MODAL-0001-A
+    text:
+      en: Each Web modal provider owns one idempotent body scroll lock. Concurrent owners share the original inline overflow value and priority; only the last owner restores it. Unlock uses the body captured at acquisition. This capability does not promise inertness, focus trapping, backdrop or A11y policy.
+      zh-CN: 每个 Web modal provider 拥有一个幂等 body scroll lock；并发 owner 共享原 overflow 值与 priority，仅最后一个 owner 恢复。unlock 使用获取时的 body。本能力不承诺 inert、focus trap、backdrop 或 A11y policy。
+relates:
+  contracts:
+    - C-AS-OVERLAY-0001
+verifies:
+  tests:
+    - T-OVERLAY-CATALOG-0001
+sources:
+  - path: packages/modules/overlay/src/caps.ts
+  - path: packages/modules/overlay/src/web/modal-lock.ts
+revisions:
+  - version: 0.3.0-alpha.0
+    change: introduced
+    summary: Cataloged the bounded Overlay host resource and cleanup responsibility.
+tags:
+  - overlay
+  - host-capability

--- a/spec/host-caps/HC-OVERLAY-PORTAL-0001.yaml
+++ b/spec/host-caps/HC-OVERLAY-PORTAL-0001.yaml
@@ -1,0 +1,26 @@
+id: HC-OVERLAY-PORTAL-0001
+type: host-cap
+title: Host projects Overlay into a global view location
+status: draft
+since: 0.3.0-alpha.0
+summary: Portal projection follows renderer ownership and is revoked through its acquiring provider.
+criteria:
+  - id: HC-OVERLAY-PORTAL-0001-A
+    text:
+      en: A portal bridge projects a mounted Overlay target into a host-global location and revokes that projection on view detach or provider replacement. Renderer-owned targets use renderer projection primitives; the logical instance and ancestry remain intact.
+      zh-CN: Portal bridge 将 mounted Overlay target 投射到宿主全局位置，并在 view detach 或 provider 替换时撤销。renderer-owned target 使用 renderer projection primitive；logical instance 与 ancestry 保持有效。
+relates:
+  contracts:
+    - C-AS-OVERLAY-0001
+verifies:
+  tests:
+    - T-OVERLAY-CATALOG-0001
+sources:
+  - path: packages/modules/overlay/src/caps.ts
+revisions:
+  - version: 0.3.0-alpha.0
+    change: introduced
+    summary: Cataloged the bounded Overlay host resource and cleanup responsibility.
+tags:
+  - overlay
+  - host-capability

--- a/spec/host-caps/HC-TEXT-CONTROL-0001.yaml
+++ b/spec/host-caps/HC-TEXT-CONTROL-0001.yaml
@@ -40,6 +40,7 @@ revisions:
     summary: >-
       Made the host capability line-mode-aware (single or multiline), resolving to HTMLInputElement for single-line or HTMLTextAreaElement for multiline on the Web profile.
 
+
   - version: 0.3.0-alpha.0
     change: clarified
     summary: Made host editing-session projection and cleanup addressable without adding a portable selection API.

--- a/spec/host-caps/HC-TEXT-CONTROL-0001.yaml
+++ b/spec/host-caps/HC-TEXT-CONTROL-0001.yaml
@@ -40,8 +40,16 @@ revisions:
     summary: >-
       Made the host capability line-mode-aware (single or multiline), resolving to HTMLInputElement for single-line or HTMLTextAreaElement for multiline on the Web profile.
 
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Made host editing-session projection and cleanup addressable without adding a portable selection API.
 
 tags:
   - text-control
   - textarea
   - host-capability
+criteria:
+  - id: HC-TEXT-CONTROL-0001-A
+    text:
+      en: The host resolves one declared single-line or multiline editor and leases property projection, normalized native-order events and snapshots. Unchanged value updates preserve selection/cursor; composition retains host editing ownership. Disposal releases listeners and target references.
+      zh-CN: host 解析一个声明的单行或多行 editor，提供 property projection、原生顺序的 normalized event 与 snapshot lease。未改变 value 的更新保留 selection/cursor；composition 保持 host editing ownership；dispose 释放 listener 与 target reference。

--- a/spec/modules/M-EVENT-0001.yaml
+++ b/spec/modules/M-EVENT-0001.yaml
@@ -55,8 +55,14 @@ criteria:
       zh-CN: >-
         listener attachment 失败时，runtime 必须回滚本次 binding attempt 已建立的全部 host listener，并保证每个受影响 registration 保持逻辑 unbound（diagnostics 记为 unbound），显式 bind retry 能完整重装。cleanup/unbind 必须幂等：重复 cleanup 不得遗留 listener。rollback 的 removeEventListener 自身失败不得掩盖原始 attachment 错误，并必须 fail closed（不得让部分 listener 视为已绑定）。portable 事件 callback 收到的是 data-only、immutable 的新 view，不得 alias 或修改 host event/detail；default-action control 仅在当前同步 callback window 内有效，window 结束后调用须 fail closed；同一 host sample 的多次 default-action request 在宿主边界去重。semantic（非 host:*）registration 不得携带 DOM listener options。宿主绑定事件保持 raw host event。
 
+
       en: >-
         When listener attachment fails, the runtime must roll back every host listener already attached by that binding attempt, keep each affected registration logically unbound (reported as unbound in diagnostics), and let an explicit bind retry reinstall the full set. Cleanup/unbind must be idempotent: repeated cleanup must not leave listeners behind. A rollback removeEventListener failure must not mask the original attachment error and must fail closed (no partial listener set may be treated as bound). A portable event callback receives a new, immutable, data-only view and must never alias or mutate the host event/detail; the default-action control is live only for the current synchronous callback window, and a call after the window must fail closed; multiple default-action requests for the same host sample are deduplicated at the host boundary. Semantic (non-host:*) registrations must not carry DOM listener options. Host-bound events stay raw host events.
+
+  - id: M-EVENT-0001-K
+    text:
+      en: Privileged consumers may obtain an opaque global-input scope and, only during synchronous portable dispatch, the opaque identity of that input sample. Adapter wrappers for the same native sample preserve that identity. This metadata is not added to the author payload, gives no host access, and does not change broadcast or default-action behavior. Scope uses the explicitly wired shared input source when available, otherwise the current global binding target.
+      zh-CN: 特权消费者可读取不透明 global-input scope，并仅在 portable dispatch 的同步窗口内读取该次 input sample 的不透明身份。同一 native sample 的 Adapter wrapper 保持同一身份。metadata 不加入作者 payload、不提供 host 访问，也不改变广播或 default-action 行为。scope 优先使用显式接入的共享输入源，否则使用当前 global binding target。
 
 satisfies:
   contracts:
@@ -83,6 +89,8 @@ verifies:
     - T-EVENT-0002
     - id: T-EVENT-0003
       since: 0.2.0-rc.7
+    - id: T-OVERLAY-CATALOG-0001
+      since: 0.3.0-alpha.0
 dependsOn:
   contracts:
     - C-LIFECYCLE-0001
@@ -143,4 +151,7 @@ revisions:
   - version: 0.2.0
     change: strengthened
     summary: Required target preflight before listener attachment, zero new listeners on target-resolution failure, and an explicit complete-plan retry without automatic recovery semantics.
+  - version: 0.3.0-alpha.0
+    change: extended
+    summary: Added scope-bound single-sample Escape coordination without changing portable author payloads.
 tags: [event, module, required, adapter, lifecycle]

--- a/spec/modules/M-EVENT-0001.yaml
+++ b/spec/modules/M-EVENT-0001.yaml
@@ -59,6 +59,7 @@ criteria:
       en: >-
         When listener attachment fails, the runtime must roll back every host listener already attached by that binding attempt, keep each affected registration logically unbound (reported as unbound in diagnostics), and let an explicit bind retry reinstall the full set. Cleanup/unbind must be idempotent: repeated cleanup must not leave listeners behind. A rollback removeEventListener failure must not mask the original attachment error and must fail closed (no partial listener set may be treated as bound). A portable event callback receives a new, immutable, data-only view and must never alias or mutate the host event/detail; the default-action control is live only for the current synchronous callback window, and a call after the window must fail closed; multiple default-action requests for the same host sample are deduplicated at the host boundary. Semantic (non-host:*) registrations must not carry DOM listener options. Host-bound events stay raw host events.
 
+
   - id: M-EVENT-0001-K
     text:
       en: Privileged consumers may obtain an opaque global-input scope and, only during synchronous portable dispatch, the opaque identity of that input sample. Adapter wrappers for the same native sample preserve that identity. This metadata is not added to the author payload, gives no host access, and does not change broadcast or default-action behavior. Scope uses the explicitly wired shared input source when available, otherwise the current global binding target.

--- a/spec/modules/M-IMAGE-VIEW-0001.yaml
+++ b/spec/modules/M-IMAGE-VIEW-0001.yaml
@@ -25,6 +25,27 @@ revisions:
       Added the draft Image View module for generation-bound image presentation with loading status transitions and stale completion rejection.
 
 
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Made generation ownership, callback scope and setup cancellation addressable.
+
 tags:
   - image
   - module
+criteria:
+  - id: M-IMAGE-VIEW-0001-A
+    text:
+      en: The instance owns source, fit, validated informative/decorative input and loading status. Source changes start a generation before host work; only one terminal result of the current generation and attachment may update state or emit a transition.
+      zh-CN: instance 拥有 source、fit、校验后的 informative/decorative input 与 loading status。source 改变先建立 generation 再启动 host work；仅当前 generation/attachment 的首次 terminal result 可改写 state 或派发 transition。
+  - id: M-IMAGE-VIEW-0001-B
+    text:
+      en: Static declaration permits one setup handle. Missing hosts retain logical facts; replacement, view detach and disposal retire old leases, and remount starts a current loading generation. Native image readiness and rendering remain host-owned.
+      zh-CN: 静态 declaration 允许一个 setup handle。缺失 host 保留 logical facts；替换、view detach、dispose 撤销旧 lease，remount 启动当前 loading generation。native image readiness/rendering 归 host。
+  - id: M-IMAGE-VIEW-0001-C
+    text:
+      en: Listener registration and returned cancellation are setup-only. Runtime sync and transition delivery require valid callback scope; an absent or invalid async callback bridge diagnoses instead of silently dropping listeners.
+      zh-CN: listener 注册及返回取消函数仅 setup 可用。runtime sync 与 transition delivery 要求有效 callback scope；异步 callback bridge 缺失或无效时诊断，不静默丢失 listener。
+dependsOn:
+  contracts:
+    - id: C-CORE-SYNTAX-0007
+      since: 0.3.0-alpha.0

--- a/spec/modules/M-OVERLAY-0001.yaml
+++ b/spec/modules/M-OVERLAY-0001.yaml
@@ -1,0 +1,68 @@
+id: M-OVERLAY-0001
+type: module
+title: Overlay owns logical open and active-view resource coordination
+status: draft
+since: 0.3.0-alpha.0
+summary: Overlay coordinates one Presence driver, explicit dismissal and optional host resources while delegating outside classification, geometry and input transport.
+criteria:
+  - id: M-OVERLAY-0001-A
+    text:
+      en: One instance retains logical open, merged setup configuration and registrations. The privileged once hook chooses one immediate or bound Presence driver. Logical open, active presence and mounted view are distinct; Boundary follows logical open, positioning/modal activity follows active view, and Portal/layer final teardown follows view detach.
+      zh-CN: 每个 instance 保留 logical open、setup 合并配置和 registration。privileged once hook 选择唯一 immediate 或 bound Presence driver。logical open、active presence、mounted view 分离；Boundary 跟随 logical open，positioning/modal activity 跟随 active view，Portal/layer 最终清理跟随 view detach。
+  - id: M-OVERLAY-0001-B
+    text:
+      en: Escape candidates and per-sample selection belong to Overlay and obey C-AS-OVERLAY-0001-P using privileged Event input identities. Outside press delegates to Boundary; anchored geometry delegates to Positioning, with Anatomy part resolution confined to internal ports.
+      zh-CN: Escape 候选与每 sample 选择归 Overlay，使用 Event privileged input identity 遵循 C-AS-OVERLAY-0001-P。outside press 委托 Boundary，anchored geometry 委托 Positioning，Anatomy part 解析限制在内部 port。
+  - id: M-OVERLAY-0001-C
+    text:
+      en: Optional absent Portal, modal or layer providers acquire no corresponding resource. Provider replacement releases each contribution through its previous owner and reconciles the active mounted view through the current provider; detach and terminal unmount release owned resources without duplicate cleanup.
+      zh-CN: 可选 Portal、modal、layer provider 缺失时不获取对应资源。provider 替换通过旧 owner 释放贡献，再通过当前 provider 协调 active mounted view；detach 与 terminal unmount 释放资源且不重复清理。
+  - id: M-OVERLAY-0001-D
+    text:
+      en: Generic entry, restore, closeOnAnchorPress and closeOnTriggerPress are retained configuration, not implemented automatic policies. Focus-outside remains deferred. Consumer-specific focus and Root request protocols remain consumer-owned; Overlay does not implement Hit Participation, A11y or complete modal semantics.
+      zh-CN: 通用 entry、restore、closeOnAnchorPress、closeOnTriggerPress 仅保留配置，尚非已实现自动策略。focus-outside deferred。消费者 focus 与 Root request 协议归消费者；Overlay 不实现 Hit Participation、A11y 或完整 modal 语义。
+satisfies:
+  contracts:
+    - C-AS-OVERLAY-0001
+dependsOn:
+  modules:
+    - M-EVENT-0001
+    - M-BOUNDARY-0001
+    - M-ANATOMY-0001
+    - M-POSITIONING-0001
+requires:
+  hostCaps:
+    - id: HC-OVERLAY-PORTAL-0001
+      note: Conditionally consumed when available and opted in; absence does not invent a host fallback.
+    - id: HC-OVERLAY-MODAL-0001
+      note: Conditionally consumed when available and opted in; absence does not invent a host fallback.
+    - id: HC-OVERLAY-LAYER-0001
+      note: Conditionally consumed when available and opted in; absence does not invent a host fallback.
+verifies:
+  tests:
+    - T-OVERLAY-CATALOG-0001
+    - T-AS-OVERLAY-0001
+sources:
+  - path: packages/modules/overlay/src/create.ts
+  - path: packages/modules/overlay/src/impl.ts
+  - path: packages/modules/overlay/src/escape-coordinator.ts
+  - path: packages/hooks/src/as-overlay.ts
+openQuestions:
+  - id: M-OVERLAY-0001-Q-POLICY
+    question:
+      en: What governed use cases should admit generic focus entry/restore, anchor/trigger dismissal and a stronger layer hierarchy?
+      zh-CN: 哪些治理后的需求应推动通用 focus entry/restore、anchor/trigger dismissal 和更强 layer hierarchy？
+    context:
+      en: Stored configuration and numeric role offsets are not evidence of these policies. Presence legacy compatibility is a separate inventory.
+      zh-CN: 已有配置和数字 role offset 不能证明这些策略已实现；旧 Presence compatibility 另行盘点。
+    blocks:
+      - generic-overlay-policy-evolution
+revisions:
+  - version: 0.3.0-alpha.0
+    change: introduced
+    summary: Cataloged accepted scoped Escape and existing resource ownership with bounded host responsibilities.
+tags:
+  - overlay
+  - module
+  - presence
+  - dismissal

--- a/spec/modules/M-SCROLL-0001.yaml
+++ b/spec/modules/M-SCROLL-0001.yaml
@@ -61,4 +61,25 @@ revisions:
   - version: 0.2.0-rc.7
     change: introduced
     summary: Cataloged the planned Scroll module as owner of logical sessions, facts, requests, negotiation, and host-lease lifetime.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Connected State/Context/Anatomy ownership and enforced current-session facts at replacement and detach.
 tags: [scroll, module, session, negotiation]
+dependsOn:
+  modules:
+    - id: M-STATE-0001
+      since: 0.3.0-alpha.0
+    - id: M-CONTEXT-0001
+      since: 0.3.0-alpha.0
+    - id: M-ANATOMY-0001
+      since: 0.3.0-alpha.0
+openQuestions:
+  - id: M-SCROLL-0001-Q-HOST-EVOLUTION
+    question:
+      en: Which concrete non-Web or accessibility use cases require additional scroll projection capabilities?
+      zh-CN: 哪些具体非 Web 或 accessibility 场景需要额外 scroll projection 能力？
+    context:
+      en: Current evidence covers normalized sessions and four Web Adapters. Physics, virtualization and a redesigned A11y author API are outside this slice.
+      zh-CN: 当前证据覆盖 normalized session 与四 Web Adapter；physics、virtualization 及重设计的 A11y author API 不在本切片内。
+    blocks:
+      - non-web-scroll-certification

--- a/spec/modules/M-TEXT-CONTROL-0001.yaml
+++ b/spec/modules/M-TEXT-CONTROL-0001.yaml
@@ -30,9 +30,29 @@ revisions:
     summary: >-
       Made the module line-mode-aware (single or multiline), added common inputMode and enterKeyHint hints, and required CR/LF canonicalization at the module boundary. Single-line mode projects the shared shape, while multiline mode also projects rows and wrap.
 
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Expanded module ownership, current-lease delivery and setup-only cancellation criteria.
 
 tags:
   - text-control
   - textarea
   - module
   - editing
+criteria:
+  - id: M-TEXT-CONTROL-0001-A
+    text:
+      en: A static plain-text line-mode declaration permits one setup control. The first sync fixes value ownership; Module canonicalizes line endings and reconciles controlled proposals without overwriting active composition. Selection, physical editing engine and native target belong to the host.
+      zh-CN: 静态 plain-text line-mode declaration 允许一个 setup control；首次 sync 固定 value ownership。Module 归一化换行并协调 controlled proposal，避免覆盖 active composition。selection、物理 editing engine 与 native target 归 host。
+  - id: M-TEXT-CONTROL-0001-B
+    text:
+      en: Declaration and current value survive missing or replaced hosts and view detach. Only the current mounted lease may deliver events or restore values; stale callbacks cannot update state. Detach/disposal revoke the lease.
+      zh-CN: 缺失或替换 host、view detach 时保留 declaration 与当前值。仅当前 mounted lease 可以派发事件或恢复值，stale callback 不得改变 state；detach/disposal 撤销 lease。
+  - id: M-TEXT-CONTROL-0001-C
+    text:
+      en: Listener registration and its returned cancellation are setup-only under C-CORE-SYNTAX-0007; sync requires runtime callback scope. The internal callback bridge supplies RunHandle without exposing native events.
+      zh-CN: listener 注册及其返回的取消函数遵循 C-CORE-SYNTAX-0007，仅可 setup 使用；sync 要求 runtime callback scope。内部 callback bridge 提供 RunHandle，不暴露 native event。
+dependsOn:
+  contracts:
+    - id: C-CORE-SYNTAX-0007
+      since: 0.3.0-alpha.0

--- a/spec/modules/M-TEXT-CONTROL-0001.yaml
+++ b/spec/modules/M-TEXT-CONTROL-0001.yaml
@@ -30,6 +30,7 @@ revisions:
     summary: >-
       Made the module line-mode-aware (single or multiline), added common inputMode and enterKeyHint hints, and required CR/LF canonicalization at the module boundary. Single-line mode projects the shared shape, while multiline mode also projects rows and wrap.
 
+
   - version: 0.3.0-alpha.0
     change: clarified
     summary: Expanded module ownership, current-lease delivery and setup-only cancellation criteria.

--- a/spec/tests/T-AS-OVERLAY-0001.yaml
+++ b/spec/tests/T-AS-OVERLAY-0001.yaml
@@ -65,6 +65,11 @@ cases:
       - C-AS-OVERLAY-0001-N
       - C-AS-OVERLAY-0001-O
     expectation: overlay-delegates-positioning-and-boundary-classification-without-exposing-anatomy-target
+  - id: T-AS-OVERLAY-0001-CASE-MODULE
+    title: Overlay coordination boundary
+    covers:
+      - M-OVERLAY-0001-A
+    expectation: one-logical-owner-and-one-presence-driver-with-distinct-view-lifetime
 implementations:
   - id: runtime-overlay-contract
     kind: runtime-test
@@ -79,6 +84,7 @@ implementations:
       - T-AS-OVERLAY-0001-CASE-DISMISS
       - T-AS-OVERLAY-0001-CASE-POST-CALLBACK-RECONCILE
       - T-AS-OVERLAY-0001-CASE-ANCHORED
+      - T-AS-OVERLAY-0001-CASE-MODULE
   - id: base-overlay-transition-contract
     kind: runtime-test
     status: passing
@@ -87,6 +93,7 @@ implementations:
     consumesCases:
       - T-AS-OVERLAY-0001-CASE-BOUND
       - T-AS-OVERLAY-0001-CASE-CONFLICT
+      - T-AS-OVERLAY-0001-CASE-MODULE
   - id: base-dropdown-overlay-anchor-boundary-contract
     kind: module-test
     status: passing
@@ -144,6 +151,11 @@ verifies:
     - id: C-LIFECYCLE-0008
       anchors:
         - C-LIFECYCLE-0008-E
+  modules:
+    - id: M-OVERLAY-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - M-OVERLAY-0001-A
 exercises:
   decisions:
     - id: D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001

--- a/spec/tests/T-IMAGE-VIEW-0001.yaml
+++ b/spec/tests/T-IMAGE-VIEW-0001.yaml
@@ -24,6 +24,7 @@ cases:
     title: New source creates new generation and loading state before host work
     covers:
       - C-IMAGE-VIEW-0001-E
+      - M-IMAGE-VIEW-0001-A
     expectation: new-source-creates-generation-and-loading-before-host-work
   - id: T-IMAGE-VIEW-0001-CASE-STATUS-TRANSITION
     title: loadingStatus and loadingStatusChange are the only status and transition surfaces
@@ -45,6 +46,7 @@ cases:
     title: Lease boundary revokes listeners on detach and disposal
     covers:
       - C-IMAGE-VIEW-0001-H
+      - M-IMAGE-VIEW-0001-B
     expectation: lease-boundary-revokes-listeners-on-detach-and-dispose
   - id: T-IMAGE-VIEW-0001-CASE-WEB-PROJECTION
     title: Official Web adapters materialize one physical img and split boundary, surface, and a11y ownership
@@ -62,7 +64,22 @@ cases:
       - C-IMAGE-VIEW-0001-G
       - C-IMAGE-VIEW-0001-H
       - D-IMAGE-VIEW-PROJECTION-0001-F
+      - HC-IMAGE-VIEW-0001-A
+      - A-REACT-18-19-0001-IMAGE-VIEW
+      - A-VUE-3-0001-IMAGE-VIEW
+      - A-WEB-COMPONENT-0001-IMAGE-VIEW
     expectation: web-image-leases-map-cache-hit-or-request-scoped-decode-to-terminal-status-and-retire-old-settlements-on-replacement-or-detach
+  - id: T-IMAGE-VIEW-0001-CASE-CANCEL
+    title: Setup cancellation and explicit callback scope
+    covers:
+      - M-IMAGE-VIEW-0001-C
+      - C-CORE-SYNTAX-0007-A
+    expectation: runtime-removal-rejected-and-async-dispatch-requires-valid-callback-scope
+  - id: T-IMAGE-VIEW-0001-CASE-VUE2
+    title: Vue 2 physical image, source replacement and pending completion retirement
+    covers:
+      - A-VUE-2-0001-IMAGE-VIEW
+    expectation: one-current-source-and-no-late-transition-after-unmount
 implementations:
   - id: module-image-view-impl-contract
     kind: module-test
@@ -78,6 +95,7 @@ implementations:
       - T-IMAGE-VIEW-0001-CASE-REPLACEMENT
       - T-IMAGE-VIEW-0001-CASE-STALE-COMPLETION
       - T-IMAGE-VIEW-0001-CASE-LEASE-BOUNDARY
+      - T-IMAGE-VIEW-0001-CASE-CANCEL
     exercises:
       - M-IMAGE-VIEW-0001
       - HC-IMAGE-VIEW-0001
@@ -137,6 +155,13 @@ implementations:
       - M-IMAGE-VIEW-0001
       - HC-IMAGE-VIEW-0001
       - P-BASE-IMAGE
+  - id: adapter-vue2-image-view
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue2/test/image-view.integration.test.ts
+    required: true
+    consumesCases:
+      - T-IMAGE-VIEW-0001-CASE-VUE2
 verifies:
   contracts:
     - id: C-IMAGE-VIEW-0001
@@ -148,6 +173,39 @@ verifies:
         - C-IMAGE-VIEW-0001-F
         - C-IMAGE-VIEW-0001-G
         - C-IMAGE-VIEW-0001-H
+    - id: C-CORE-SYNTAX-0007
+      since: 0.3.0-alpha.0
+      anchors:
+        - C-CORE-SYNTAX-0007-A
+  modules:
+    - id: M-IMAGE-VIEW-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - M-IMAGE-VIEW-0001-A
+        - M-IMAGE-VIEW-0001-B
+        - M-IMAGE-VIEW-0001-C
+  hostCaps:
+    - id: HC-IMAGE-VIEW-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - HC-IMAGE-VIEW-0001-A
+  adapters:
+    - id: A-REACT-18-19-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-REACT-18-19-0001-IMAGE-VIEW
+    - id: A-VUE-3-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-VUE-3-0001-IMAGE-VIEW
+    - id: A-VUE-2-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-VUE-2-0001-IMAGE-VIEW
+    - id: A-WEB-COMPONENT-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-WEB-COMPONENT-0001-IMAGE-VIEW
 exercises:
   modules:
     - M-IMAGE-VIEW-0001
@@ -172,6 +230,10 @@ revisions:
     summary: >-
       Introduced Image View declaration, module, fake-host, Base runtime, and bounded Web Component, React, and Vue evidence for portable properties, request-scoped readiness, source replacement, stale completion, detach/rematerialization, disposal, terminal-once, and transition ordering.
 
+
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Connected M/HC/A criteria and added Vue 2 current-generation and setup-removal evidence.
 
 tags:
   - image

--- a/spec/tests/T-OVERLAY-CATALOG-0001.yaml
+++ b/spec/tests/T-OVERLAY-CATALOG-0001.yaml
@@ -1,0 +1,186 @@
+id: T-OVERLAY-CATALOG-0001
+type: test
+title: Overlay scoped dismissal and host resource catalog evidence
+status: draft
+since: 0.3.0-alpha.0
+summary: Runtime input identity, real Adapter wiring with simulated DOM, resource replacement and shared modal locks; no generic focus or full modal certification.
+cases:
+  - id: T-OVERLAY-CATALOG-0001-CASE-ESCAPE
+    title: One scoped Escape owner and immutable privileged input metadata
+    covers:
+      - C-AS-OVERLAY-0001-P
+      - M-OVERLAY-0001-B
+      - M-EVENT-0001-K
+      - HC-EVENT-BINDING-0001-G
+    expectation: one-owner-per-sample-with-controlled-reopen-and-detach-cleanup
+  - id: T-OVERLAY-CATALOG-0001-CASE-RESOURCES
+    title: Original provider cleanup and current provider reacquisition
+    covers:
+      - M-OVERLAY-0001-C
+    expectation: no-resource-left-with-replaced-provider
+  - id: T-OVERLAY-CATALOG-0001-CASE-LAYER
+    title: Layer style priority and idempotent disposal
+    covers:
+      - HC-OVERLAY-LAYER-0001-A
+    expectation: original-style-restored-once
+  - id: T-OVERLAY-CATALOG-0001-CASE-ADAPTER
+    title: Four Adapter nested Escape and concurrent modal ownership
+    covers:
+      - A-REACT-18-19-0001-OVERLAY
+      - A-VUE-3-0001-OVERLAY
+      - A-VUE-2-0001-OVERLAY
+      - A-WEB-COMPONENT-0001-OVERLAY
+      - HC-OVERLAY-MODAL-0001-A
+    expectation: translated-input-selects-one-owner-and-last-modal-restores-overflow
+  - id: T-OVERLAY-CATALOG-0001-CASE-PORTAL
+    title: Renderer-owned Portal and retained view reentry
+    covers:
+      - HC-OVERLAY-PORTAL-0001-A
+    expectation: renderer-projects-owned-host-and-retained-logical-instance-reenters
+  - id: T-OVERLAY-CATALOG-0001-CASE-CONSUMER
+    title: Nested controlled Dialog and Dropdown Root requests
+    covers:
+      - C-AS-OVERLAY-0001-P
+    expectation: only-selected-root-receives-escape-request-while-owner-keeps-open
+implementations:
+  - id: runtime-overlay-escape
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/overlay.escape.contract.test.ts
+    required: true
+    consumesCases:
+      - T-OVERLAY-CATALOG-0001-CASE-ESCAPE
+  - id: overlay-resources
+    kind: module-test
+    status: passing
+    path: packages/modules/overlay/test/resource-lifetime.test.ts
+    required: true
+    consumesCases:
+      - T-OVERLAY-CATALOG-0001-CASE-RESOURCES
+  - id: overlay-layer
+    kind: module-test
+    status: passing
+    path: packages/adapters/base/test/overlay-layer-scheduler.test.ts
+    required: true
+    consumesCases:
+      - T-OVERLAY-CATALOG-0001-CASE-LAYER
+  - id: react-overlay
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/react/test/overlay-catalog.integration.test.ts
+    required: true
+    consumesCases:
+      - T-OVERLAY-CATALOG-0001-CASE-ADAPTER
+  - id: vue-overlay
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue/test/overlay-catalog.integration.test.ts
+    required: true
+    consumesCases:
+      - T-OVERLAY-CATALOG-0001-CASE-ADAPTER
+  - id: vue2-overlay
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue2/test/overlay-catalog.integration.test.ts
+    required: true
+    consumesCases:
+      - T-OVERLAY-CATALOG-0001-CASE-ADAPTER
+  - id: web-component-overlay
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/overlay-catalog.integration.test.ts
+    required: true
+    consumesCases:
+      - T-OVERLAY-CATALOG-0001-CASE-ADAPTER
+  - id: react-overlay-portal
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/react/test/overlay-portal-ownership.test.ts
+    required: true
+    consumesCases:
+      - T-OVERLAY-CATALOG-0001-CASE-PORTAL
+  - id: vue-overlay-portal
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue/test/overlay-portal-ownership.test.ts
+    required: true
+    consumesCases:
+      - T-OVERLAY-CATALOG-0001-CASE-PORTAL
+  - id: vue2-overlay-portal
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue2/test/overlay-portal-ownership.test.ts
+    required: true
+    consumesCases:
+      - T-OVERLAY-CATALOG-0001-CASE-PORTAL
+  - id: overlay-nested-consumers
+    kind: adapter-test
+    status: passing
+    path: packages/prototypes/base/test/overlay-dismissal.test.ts
+    required: true
+    consumesCases:
+      - T-OVERLAY-CATALOG-0001-CASE-CONSUMER
+  - id: overlay-renderer-reentry-0
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/react/test/dialog.test.ts
+    required: true
+    consumesCases:
+      - T-OVERLAY-CATALOG-0001-CASE-PORTAL
+  - id: overlay-renderer-reentry-1
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue/test/previewer-dialog.demo.test.ts
+    required: true
+    consumesCases:
+      - T-OVERLAY-CATALOG-0001-CASE-PORTAL
+verifies:
+  contracts:
+    - id: C-AS-OVERLAY-0001
+      anchors:
+        - C-AS-OVERLAY-0001-P
+  modules:
+    - id: M-OVERLAY-0001
+      anchors:
+        - M-OVERLAY-0001-B
+        - M-OVERLAY-0001-C
+    - id: M-EVENT-0001
+      anchors:
+        - M-EVENT-0001-K
+  hostCaps:
+    - id: HC-OVERLAY-PORTAL-0001
+      anchors:
+        - HC-OVERLAY-PORTAL-0001-A
+    - id: HC-OVERLAY-MODAL-0001
+      anchors:
+        - HC-OVERLAY-MODAL-0001-A
+    - id: HC-OVERLAY-LAYER-0001
+      anchors:
+        - HC-OVERLAY-LAYER-0001-A
+    - id: HC-EVENT-BINDING-0001
+      anchors:
+        - HC-EVENT-BINDING-0001-G
+  adapters:
+    - id: A-REACT-18-19-0001
+      anchors:
+        - A-REACT-18-19-0001-OVERLAY
+    - id: A-VUE-3-0001
+      anchors:
+        - A-VUE-3-0001-OVERLAY
+    - id: A-VUE-2-0001
+      anchors:
+        - A-VUE-2-0001-OVERLAY
+    - id: A-WEB-COMPONENT-0001
+      anchors:
+        - A-WEB-COMPONENT-0001-OVERLAY
+exercises:
+  modules:
+    - M-OVERLAY-0001
+revisions:
+  - version: 0.3.0-alpha.0
+    change: introduced
+    summary: Added scoped input arbitration and bounded Overlay host cleanup coverage.
+tags:
+  - overlay
+  - test
+  - adapter

--- a/spec/tests/T-SCROLL-0001.yaml
+++ b/spec/tests/T-SCROLL-0001.yaml
@@ -3,13 +3,14 @@ type: test
 title: Scroll domain, module, and host capability conformance
 status: draft
 since: 0.2.0-rc.7
-summary: Covers privileged surface identity, host-owned facts, request causality, projection negotiation, session cleanup, and cross-host accessibility boundaries.
+summary: Covers stable surface identity, host facts and requests, projection negotiation, current-session cleanup and bounded Web accessibility neutrality; non-Web conformance remains open.
 cases:
   - id: T-SCROLL-0001-CASE-SINGLETON
     title: asScrollSurface installs once and returns one stable handle
     covers:
       - C-AS-SCROLL-SURFACE-0001-A
       - C-AS-SCROLL-SURFACE-0001-B
+      - M-SCROLL-0001-A
     expectation: no-arg-scroll-surface-singleton-with-setup-only-configuration
   - id: T-SCROLL-0001-CASE-FACTS
     title: host facts remain observed and cannot be author-written
@@ -18,6 +19,8 @@ cases:
       - C-SCROLL-0001-D
       - C-AS-SCROLL-SURFACE-0001-C
       - C-AS-SCROLL-SURFACE-0001-E
+      - M-SCROLL-0001-B
+      - HC-SCROLL-SURFACE-0001-B
     expectation: host-reported-normalized-scroll-facts-without-raw-target-access
   - id: T-SCROLL-0001-CASE-REQUEST
     title: requests apply through the host before facts change
@@ -35,6 +38,7 @@ cases:
       - D-SCROLL-PROJECTION-0001-D
       - HC-SCROLL-SURFACE-0001-A
       - C-AS-SCROLL-SURFACE-0001-F
+      - M-SCROLL-0001-C
     expectation: adapter-preference-and-host-support-resolve-one-projection
   - id: T-SCROLL-0001-CASE-LIFETIME
     title: detach and replacement revoke the old host session
@@ -44,11 +48,19 @@ cases:
       - M-SCROLL-0001-D
     expectation: old-scroll-session-disposed-and-late-facts-ignored
   - id: T-SCROLL-0001-CASE-A11Y
-    title: neutral scroll semantics do not require ARIA on non-Web hosts
+    title: Web projection leaves accessibility ownership separate
     covers:
       - C-SCROLL-0001-G
       - HC-SCROLL-SURFACE-0001-E
-    expectation: host-specific-accessibility-projection-from-neutral-scroll-semantics
+    expectation: no-invented-aria-role-in-web-host-helper-not-non-web-certification
+  - id: T-SCROLL-0001-CASE-ADAPTER
+    title: Four real Adapter request/fact and cleanup paths
+    covers:
+      - A-REACT-18-19-0001-SCROLL
+      - A-VUE-3-0001-SCROLL
+      - A-VUE-2-0001-SCROLL
+      - A-WEB-COMPONENT-0001-SCROLL
+    expectation: host-request-changes-physical-offset-then-observed-facts-and-cleanup-stops-input
 implementations:
   - id: scroll-module-projection-negotiation
     kind: module-test
@@ -91,12 +103,80 @@ implementations:
     path: packages/adapters/vue/test/scroll.test.ts
     required: true
     consumesCases: [T-SCROLL-0001-CASE-PROJECTION]
+  - id: scroll-session-lifetime
+    kind: module-test
+    status: passing
+    path: packages/modules/scroll/test/session-lifetime.test.ts
+    required: true
+    consumesCases:
+      - T-SCROLL-0001-CASE-LIFETIME
+  - id: react-scroll-catalog
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/react/test/scroll-catalog.integration.test.ts
+    required: true
+    consumesCases:
+      - T-SCROLL-0001-CASE-ADAPTER
+  - id: vue-scroll-catalog
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue/test/scroll-catalog.integration.test.ts
+    required: true
+    consumesCases:
+      - T-SCROLL-0001-CASE-ADAPTER
+  - id: vue2-scroll-catalog
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue2/test/scroll-catalog.integration.test.ts
+    required: true
+    consumesCases:
+      - T-SCROLL-0001-CASE-ADAPTER
+  - id: web-component-scroll-catalog
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/scroll-catalog.integration.test.ts
+    required: true
+    consumesCases:
+      - T-SCROLL-0001-CASE-ADAPTER
 verifies:
   contracts:
     - C-SCROLL-0001
     - C-AS-SCROLL-SURFACE-0001
   decisions:
     - D-SCROLL-PROJECTION-0001
+  modules:
+    - id: M-SCROLL-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - M-SCROLL-0001-A
+        - M-SCROLL-0001-B
+        - M-SCROLL-0001-C
+        - M-SCROLL-0001-D
+  hostCaps:
+    - id: HC-SCROLL-SURFACE-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - HC-SCROLL-SURFACE-0001-A
+        - HC-SCROLL-SURFACE-0001-B
+        - HC-SCROLL-SURFACE-0001-C
+        - HC-SCROLL-SURFACE-0001-D
+  adapters:
+    - id: A-REACT-18-19-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-REACT-18-19-0001-SCROLL
+    - id: A-VUE-3-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-VUE-3-0001-SCROLL
+    - id: A-VUE-2-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-VUE-2-0001-SCROLL
+    - id: A-WEB-COMPONENT-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-WEB-COMPONENT-0001-SCROLL
 exercises:
   modules:
     - M-SCROLL-0001
@@ -106,4 +186,7 @@ revisions:
   - version: 0.2.0-rc.7
     change: introduced
     summary: Planned the executable conformance surface for Scroll facts, requests, projection negotiation, lifetime, and accessibility.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Added explicit M/HC/A mappings and failing-to-passing stale-session evidence; narrowed accessibility evidence wording.
 tags: [scroll, test, module, host-capability]

--- a/spec/tests/T-SCROLL-COMPOSED-CHROME-0001.yaml
+++ b/spec/tests/T-SCROLL-COMPOSED-CHROME-0001.yaml
@@ -9,6 +9,7 @@ cases:
     title: Context scope and Anatomy relation bind the correct controls
     covers:
       - C-SCROLL-COMPOSED-CHROME-0001-A
+      - M-SCROLL-0001-E
     expectation: nearest-scroll-area-scope-binds-each-scrollbar-to-its-descendant-thumb
   - id: T-SCROLL-COMPOSED-CHROME-0001-CASE-GEOMETRY
     title: Thumb size and offset derive from host facts and track geometry
@@ -16,6 +17,7 @@ cases:
       - C-SCROLL-COMPOSED-CHROME-0001-B
       - C-SCROLL-COMPOSED-CHROME-0001-C
       - C-SCROLL-COMPOSED-CHROME-0001-D
+      - HC-SCROLL-SURFACE-0001-F
     expectation: visible-ratio-projects-size-and-normalized-position-projects-travel
   - id: T-SCROLL-COMPOSED-CHROME-0001-CASE-LIFETIME
     title: Resize, replacement, and disposal keep projection current and bounded
@@ -51,6 +53,16 @@ verifies:
     - C-SCROLL-COMPOSED-CHROME-0001
   decisions:
     - D-SCROLL-COMPOSED-PROJECTION-0001
+  modules:
+    - id: M-SCROLL-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - M-SCROLL-0001-E
+  hostCaps:
+    - id: HC-SCROLL-SURFACE-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - HC-SCROLL-SURFACE-0001-F
 exercises:
   modules:
     - M-SCROLL-0001
@@ -68,4 +80,7 @@ revisions:
   - version: 0.2.0-rc.7
     change: introduced
     summary: Added executable coverage for passive composed Thumb geometry and family-session ownership.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Connected the existing family binding and host geometry evidence to module/capability criteria.
 tags: [test, scroll, composed-chrome, geometry, accessibility]

--- a/spec/tests/T-SCROLL-COMPOSED-CONTROL-0001.yaml
+++ b/spec/tests/T-SCROLL-COMPOSED-CONTROL-0001.yaml
@@ -15,6 +15,12 @@ cases:
     covers:
       - C-SCROLL-COMPOSED-CONTROL-0001-B
       - C-SCROLL-COMPOSED-CONTROL-0001-C
+      - M-SCROLL-0001-F
+      - HC-SCROLL-SURFACE-0001-G
+      - A-REACT-18-19-0001-SCROLL
+      - A-VUE-3-0001-SCROLL
+      - A-VUE-2-0001-SCROLL
+      - A-WEB-COMPONENT-0001-SCROLL
     expectation: thumb-drag-produces-normalized-control-request-without-jump-or-optimistic-state
   - id: T-SCROLL-COMPOSED-CONTROL-0001-CASE-GUARDS
     title: Unavailable geometry rejects start and cancellation preserves host facts
@@ -43,6 +49,33 @@ implementations:
       - T-SCROLL-COMPOSED-CONTROL-0001-CASE-GUARDS
 verifies:
   contracts: [C-SCROLL-COMPOSED-CONTROL-0001]
+  modules:
+    - id: M-SCROLL-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - M-SCROLL-0001-F
+  hostCaps:
+    - id: HC-SCROLL-SURFACE-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - HC-SCROLL-SURFACE-0001-G
+  adapters:
+    - id: A-REACT-18-19-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-REACT-18-19-0001-SCROLL
+    - id: A-VUE-3-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-VUE-3-0001-SCROLL
+    - id: A-VUE-2-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-VUE-2-0001-SCROLL
+    - id: A-WEB-COMPONENT-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-WEB-COMPONENT-0001-SCROLL
 exercises:
   hostCaps: [HC-MOVE-GESTURE-0001, HC-SCROLL-SURFACE-0001]
   modules: [M-SCROLL-0001]
@@ -56,4 +89,7 @@ revisions:
   - version: 0.2.0-rc.7
     change: introduced
     summary: Added executable coverage for the first Move Gesture-backed Scroll composed control.
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Connected four-Adapter composed Thumb journey to M/HC/A ownership criteria.
 tags: [test, scroll, thumb, move, drag]

--- a/spec/tests/T-TEXT-CONTROL-0001.yaml
+++ b/spec/tests/T-TEXT-CONTROL-0001.yaml
@@ -276,6 +276,7 @@ revisions:
     summary: >-
       Added single-line input projection and clearing, common inputMode/enterKeyHint projection to both Web controls, text-compatible target validation, owning-realm editing-session and native-event payload coverage, declaration-driven mode compatibility, complete-patch preservation, line-mode value canonicalization, and cross-adapter single-line evidence across Web Component, React, Vue 3, and Vue 2.
 
+
   - version: 0.3.0-alpha.0
     change: clarified
     summary: Connected M/HC/A criteria to existing editor evidence and added stale-lease/setup-cancel regressions.

--- a/spec/tests/T-TEXT-CONTROL-0001.yaml
+++ b/spec/tests/T-TEXT-CONTROL-0001.yaml
@@ -16,6 +16,10 @@ cases:
       - C-TEXT-CONTROL-0001-A
       - C-TEXT-CONTROL-0001-B
       - C-TEXT-CONTROL-0001-I
+      - A-REACT-18-19-0001-TEXT-CONTROL
+      - A-VUE-3-0001-TEXT-CONTROL
+      - A-VUE-2-0001-TEXT-CONTROL
+      - A-WEB-COMPONENT-0001-TEXT-CONTROL
     expectation: single-line-requirement-resolves-to-one-web-input-projects-common-hints-and-canonicalizes-line-breaks
   - id: T-TEXT-CONTROL-0001-CASE-SINGLE-LINE-PROPERTIES
     title: Portable patches project common inputMode and enterKeyHint hints on input and textarea, plus the line-mode-specific fields
@@ -66,6 +70,7 @@ cases:
     covers:
       - C-TEXT-CONTROL-0001-D
       - C-TEXT-CONTROL-0001-E
+      - M-TEXT-CONTROL-0001-A
     expectation: logical-value-mode-is-stable-and-controlled-restoration-is-composition-safe
   - id: T-TEXT-CONTROL-0001-CASE-LEASE-BOUNDARY
     title: Web Component native events remain contained and detach revokes target listeners
@@ -76,6 +81,7 @@ cases:
     title: Ordinary patches preserve active selection and controlled composition candidates
     covers:
       - C-TEXT-CONTROL-0001-G
+      - HC-TEXT-CONTROL-0001-A
     expectation: web-host-patches-preserve-selection-cursor-and-active-composition
   - id: T-TEXT-CONTROL-0001-CASE-PRESENTATION-SURFACE
     title: Wrapper-backed Web Component projection keeps boundary metadata on the custom element and visual intent on the textarea
@@ -84,6 +90,17 @@ cases:
       - C-HOST-SURFACE-PROJECTION-0001-B
       - C-HOST-SURFACE-PROJECTION-0001-C
     expectation: wc-text-control-wrapper-is-logical-only-while-textarea-is-the-presentation-surface
+  - id: T-TEXT-CONTROL-0001-CASE-LIFETIME
+    title: Stale and disposed lease callbacks are inert
+    covers:
+      - M-TEXT-CONTROL-0001-B
+    expectation: lifetime-boundary-enforced
+  - id: T-TEXT-CONTROL-0001-CASE-CANCEL
+    title: Listener cancellation remains setup-only
+    covers:
+      - M-TEXT-CONTROL-0001-C
+      - C-CORE-SYNTAX-0007-A
+    expectation: cancel-boundary-enforced
 implementations:
   - id: module-text-control-web-contract
     kind: module-test
@@ -122,6 +139,8 @@ implementations:
       - T-TEXT-CONTROL-0001-CASE-CRLF-CANONICALIZATION
       - T-TEXT-CONTROL-0001-CASE-MODE-COMPATIBILITY
       - T-TEXT-CONTROL-0001-CASE-PATCH-PRESERVATION
+      - T-TEXT-CONTROL-0001-CASE-LIFETIME
+      - T-TEXT-CONTROL-0001-CASE-CANCEL
     exercises:
       - M-TEXT-CONTROL-0001
       - HC-TEXT-CONTROL-0001
@@ -197,6 +216,39 @@ verifies:
       anchors:
         - C-HOST-SURFACE-PROJECTION-0001-B
         - C-HOST-SURFACE-PROJECTION-0001-C
+    - id: C-CORE-SYNTAX-0007
+      since: 0.3.0-alpha.0
+      anchors:
+        - C-CORE-SYNTAX-0007-A
+  modules:
+    - id: M-TEXT-CONTROL-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - M-TEXT-CONTROL-0001-A
+        - M-TEXT-CONTROL-0001-B
+        - M-TEXT-CONTROL-0001-C
+  hostCaps:
+    - id: HC-TEXT-CONTROL-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - HC-TEXT-CONTROL-0001-A
+  adapters:
+    - id: A-REACT-18-19-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-REACT-18-19-0001-TEXT-CONTROL
+    - id: A-VUE-3-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-VUE-3-0001-TEXT-CONTROL
+    - id: A-VUE-2-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-VUE-2-0001-TEXT-CONTROL
+    - id: A-WEB-COMPONENT-0001
+      since: 0.3.0-alpha.0
+      anchors:
+        - A-WEB-COMPONENT-0001-TEXT-CONTROL
 exercises:
   modules:
     - M-TEXT-CONTROL-0001
@@ -224,6 +276,9 @@ revisions:
     summary: >-
       Added single-line input projection and clearing, common inputMode/enterKeyHint projection to both Web controls, text-compatible target validation, owning-realm editing-session and native-event payload coverage, declaration-driven mode compatibility, complete-patch preservation, line-mode value canonicalization, and cross-adapter single-line evidence across Web Component, React, Vue 3, and Vue 2.
 
+  - version: 0.3.0-alpha.0
+    change: clarified
+    summary: Connected M/HC/A criteria to existing editor evidence and added stale-lease/setup-cancel regressions.
 
 tags:
   - text-control


### PR DESCRIPTION
本批次收尾 Overlay、Text Control、Image View、Scroll 的 M／HC／A／T 编目，并修复沿证据链发现的局部漂移。所有实体保持 draft；完成这四项后结束批次，后续架构议题独立评估。

- **Overlay**：落实已接受的同 scope、同 Escape sample 唯一候选策略，覆盖受控同步 reopen 与嵌套 Dialog／Dropdown Root request；Event 仅提供内部 opaque input identity。新增 Portal／modal／layer 三个 HC，修复并发 modal overflow 锁、provider 替换释放和 layer disposer 的 priority／幂等性。
- **Text Control**：补全四 Adapter 与单行／多行编辑证据；旧 lease 回调不能再更新当前值，listener cancellation 遵循 setup-only。
- **Image View**：补全 generation 生命周期及 M／HC／A 映射；为 Vue 2 接入已有 Web physical image／host bridge，验证替换 source、旧 decode、空 source 和卸载；更新依赖、lockfile 与生成的 BOM。listener cancellation 对齐现有 Core 契约。
- **Scroll**：补全 State／Context／Anatomy 依赖及四 Adapter 普通和 composed Thumb 通路；修复替换／detach 后迟到 facts 仍能覆盖当前 session 的问题。

每个切片有独立 commit。边界与后续清单见 `internal/records/2026-09-09-overlay-and-remaining-catalog.zh-CN.md`、`internal/records/2026-09-09-ordinary-catalog-completion.zh-CN.md`。本 PR 不推进 A11y asHook 重设计、Rule Meta、Presence/deprecated State 清理、完整 modal/focus 策略或非 Web 认证。

验证：

- Spec fixture/graph：22 文件、61 项通过；catalog、完整 workspace/docs types、Agent projection、package manifests/BOM 检查通过。
- `pnpm test` 的治理、发布、public-docs、type contracts 通过；非浏览器回归 447 文件、2048 项通过，既有 3 skipped files／34 todo。
- Vue 2 package 及构建依赖通过（35 packages）。
- 浏览器首轮 40/41 断言通过：Shadcn controls 的 Adapter readiness wait 超时，Select 首屏的断言通过但清理超时。Select 定向复跑通过；Shadcn controls 在基线、诊断运行和移除诊断后的最终运行均 5/5 通过。保留首轮失败事实，**不宣称整条 `pnpm test` 一次全绿**；详细过程见完成记录，CI 需复核浏览器等待的不稳定性。
