### PR TITLE
feat(a11y)!: replace def.a11y with asAccessible

### DIFF
--- a/apps/www/src/content/docs/en/build/prototypes/writing-a-custom-primitive-prototype.md
+++ b/apps/www/src/content/docs/en/build/prototypes/writing-a-custom-primitive-prototype.md
@@ -35,7 +35,7 @@ The current implementation includes:
 - `asFocusable()` for `focused`, `focusVisible`, and the focus method;
 - `def.event.on()` for pointer routes and `press.commit`;
 - `def.expose.state()`, `def.expose.method()`, and `def.expose.event()` for outward surfaces; and
-- `def.a11y.*` for Button role, name, state, and action.
+- `asAccessible()` for Button role, name, state, and action.
 
 The former `def.state.fromInteraction()` example no longer describes the current Button implementation and must not be used as the example for this guide.
 

--- a/apps/www/src/content/docs/zh-cn/build/prototypes/writing-a-custom-primitive-prototype.md
+++ b/apps/www/src/content/docs/zh-cn/build/prototypes/writing-a-custom-primitive-prototype.md
@@ -35,7 +35,7 @@ Button 的两个官方 authoring entries 是：
 - `asFocusable()` 提供 `focused`、`focusVisible` 与 focus method；
 - `def.event.on()` 承接 pointer 与 `press.commit`；
 - `def.expose.state()`、`def.expose.method()` 和 `def.expose.event()` 提供 outward surface；
-- `def.a11y.*` 声明 Button 的 role、name、state 与 action。
+- `asAccessible()` 声明 Button 的 role、name、state 与 action。
 
 旧的 `def.state.fromInteraction()` 例子已经不代表当前 Button 实现，不应继续作为这篇指南的示例。
 

--- a/internal/records/2026-09-10-as-accessible-migration.zh-CN.md
+++ b/internal/records/2026-09-10-as-accessible-migration.zh-CN.md
@@ -1,0 +1,20 @@
+# asAccessible 作者入口迁移
+
+用户已接受在 0.3 main 直接用 `asAccessible()` / `AccessibleHandle` 替代 `def.a11y` / `A11yDefAPI`，无兼容期、无旧入口别名、不回补 0.2。
+
+统一入口返回当前逻辑实例的唯一声明 handle；setup 重复获取不重置声明，单值字段或同 key 声明最后一次生效，tree 按字段合并。声明和保存 handle 上的方法都限 setup，动态值由已有 State 驱动。没有新增 dispose、通用 runtime mutation、多对象创建或 host target API。
+
+A11y 拥有可投影的语义表达，State、Focus、Anatomy、Trigger/Event 和领域模块保留事实、行为与目标解析所有权。调用 asAccessible 不构成完整无障碍认证，也不安装键盘或焦点策略。
+
+本轮基线 e15a5adf。#625 在开始时仍 OPEN；不提前接纳其 opaque ref 或内部 relation mutation port 为公开作者 API。其合入后需要对同一 A11y 模块的增量进行集成复核。action 仍只保留现有声明边界，不声称完整辅助技术执行通路。
+
+历史 Record 和 0.2 发布记录保留原样；当前规范、作者文档、官方原型及测试随新入口迁移。
+
+## 验证进展
+
+- 新 handle、既有 A11y Runtime、Vue 2 heading 定向测试：39 项通过。
+- 全量非浏览器测试首轮：455 个文件、2164 项通过；唯一失败为新增 hook source 尚未进入 Git 索引，补入后 catalog evidence integrity 3 项通过。无运行时行为失败。
+- 43 个公开包构建中 42 个通过；Shadcn Close Icon 迁移暴露缺失直接 hooks dependency，补齐 dependency、lockfile 和生成 BOM 后，Shadcn 及其 11 包依赖闭包构建通过。
+- 完整 workspace/docs types、类型契约、Spec authoring、prototype catalog、公开 manifest、全部九个入口体积预算、release assets、Agent operations 和 public docs 检查通过；重新生成本地投影并通过 Agent doc check。
+- 新增 asAccessible 在 authored asHook 中作为 child handle 被记录；旧的 context capture bucket 不是公开语义，依 C-AS-HOOK-0005 对应测试改为检查 child handle 与实际 IR。
+- Shadcn 控件真实浏览器回归 5/5 通过，覆盖焦点、Textarea 明暗主题、Checkbox 可聚焦目标和无名 glyph。未运行完整发布/安装消费者 smoke 或全量浏览器矩阵；不将有界浏览器结果解释成完整辅助技术认证。

--- a/internal/releases/0.3.0-alpha.0/package-bom.json
+++ b/internal/releases/0.3.0-alpha.0/package-bom.json
@@ -388,7 +388,7 @@
       "path": "packages/prototypes/shadcn",
       "releaseRole": "launch-commitment",
       "publishOrder": 37,
-      "internalDependencies": ["@proto.ui/core", "@proto.ui/prototypes-base"]
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/hooks", "@proto.ui/prototypes-base"]
     },
     {
       "name": "@proto.ui/runtime",

--- a/internal/releases/0.3.0-alpha.0/release-notes.md
+++ b/internal/releases/0.3.0-alpha.0/release-notes.md
@@ -4,6 +4,12 @@
 
 Proto UI 0.3.0-alpha.0 opens the 0.3 architecture, API, and prototype evolution train. Alpha is intentional: this line may include reviewed architecture changes, top-level API changes, and new capabilities. It is not a release candidate or a stable compatibility promise.
 
+## Accessible author handle
+
+- Replaces `def.a11y` with `asAccessible()` from `@proto.ui/hooks` and replaces the core `A11yDefAPI` type with `AccessibleHandle`, without compatibility aliases.
+- Repeated setup calls share the instance handle; retained methods remain setup-only. Dynamic declarations continue to follow existing State values.
+- Migrates official prototypes and keeps A11y semantics separate from focus, keyboard interaction and structural target resolution. This is a 0.3 migration, not a 0.2 backport.
+
 ## Expose Event ownership
 
 - Adds the public `@proto.ui/module-expose-event` package and standalone `ExposeEventModuleDef`.

--- a/internal/releases/0.3.0-alpha.0/release-notes.zh-CN.md
+++ b/internal/releases/0.3.0-alpha.0/release-notes.zh-CN.md
@@ -4,6 +4,12 @@
 
 Proto UI 0.3.0-alpha.0 开启 0.3 的架构、API 与 Prototype 演进阶段。使用 alpha 是有意的：本阶段仍可接纳经过评审的架构调整、顶层 API 变化与新能力，它不是 release candidate，也不构成 stable compatibility 承诺。
 
+## Accessible 作者入口
+
+- 用 `@proto.ui/hooks` 的 `asAccessible()` 替代 `def.a11y`，用 Core 的 `AccessibleHandle` 替代 `A11yDefAPI`，不保留兼容别名。
+- setup 重复调用共享实例 handle；保存后的声明方法仍仅限 setup。动态声明继续跟随已有 State 值。
+- 同步迁移官方原型，保留 A11y 与焦点、键盘交互及结构目标解析的职责边界。本次属于 0.3 迁移，不回补 0.2。
+
 ## Expose Event ownership
 
 - 新增公开 package `@proto.ui/module-expose-event` 与独立 `ExposeEventModuleDef`。

--- a/packages/adapters/react/test/a11y-heading-level.integration.test.ts
+++ b/packages/adapters/react/test/a11y-heading-level.integration.test.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { describe, expect, it } from 'vitest';
 import { definePrototype } from '@proto.ui/core';
 import { createMountedReactAdapter } from './utils/fake-react';
@@ -7,8 +8,8 @@ const headingPrototype = definePrototype({
   setup(def) {
     const role = def.state.string('heading.role', 'heading');
     const level = def.state.numberDiscrete('heading.level', 2);
-    def.a11y.role(role);
-    def.a11y.level(level);
+    asAccessible().role(role);
+    asAccessible().level(level);
     def.expose.method('setRole', (value: string) => role.set(value, 'reason: update heading role'));
     def.expose.method('setLevel', (value: number) =>
       level.set(value, 'reason: update heading level')

--- a/packages/adapters/vue/test/a11y-heading-level.integration.test.ts
+++ b/packages/adapters/vue/test/a11y-heading-level.integration.test.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { describe, expect, it } from 'vitest';
 import { definePrototype } from '@proto.ui/core';
 import { createMountedVueAdapter, flushVue } from './utils/vue';
@@ -7,8 +8,8 @@ const headingPrototype = definePrototype({
   setup(def) {
     const role = def.state.string('heading.role', 'heading');
     const level = def.state.numberDiscrete('heading.level', 2);
-    def.a11y.role(role);
-    def.a11y.level(level);
+    asAccessible().role(role);
+    asAccessible().level(level);
     def.expose.method('setRole', (value: string) => role.set(value, 'reason: update heading role'));
     def.expose.method('setLevel', (value: number) =>
       level.set(value, 'reason: update heading level')

--- a/packages/adapters/vue2/test/a11y-heading-level.integration.test.ts
+++ b/packages/adapters/vue2/test/a11y-heading-level.integration.test.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { describe, expect, it } from 'vitest';
 import { definePrototype } from '@proto.ui/core';
 import { createMountedVue2Adapter, flushVue2 } from './utils/vue2';
@@ -7,8 +8,8 @@ const headingPrototype = definePrototype({
   setup(def) {
     const role = def.state.string('heading.role', 'heading');
     const level = def.state.numberDiscrete('heading.level', 2);
-    def.a11y.role(role);
-    def.a11y.level(level);
+    asAccessible().role(role);
+    asAccessible().level(level);
     def.expose.method('setRole', (value: string) => role.set(value, 'reason: update heading role'));
     def.expose.method('setLevel', (value: number) =>
       level.set(value, 'reason: update heading level')

--- a/packages/adapters/web-component/test/contract/a11y.v0.contract.test.ts
+++ b/packages/adapters/web-component/test/contract/a11y.v0.contract.test.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import type { A11ySemanticObjectSnapshot, Prototype } from '@proto.ui/core';
 import { definePrototype } from '@proto.ui/core';
@@ -29,17 +30,17 @@ describe('contract: adapter-web-component / a11y projection (v0)', () => {
           const hidden = def.state.bool('button.hidden', false);
           const controls = def.state.string('button.controls', 'panel-a');
           const orientation = def.state.string('button.orientation', 'vertical');
-          def.a11y.id(id);
-          def.a11y.role('button');
-          def.a11y.name(name);
-          def.a11y.description('Stores changes');
-          def.a11y.state('disabled', disabled);
-          def.a11y.state('hidden', hidden);
-          def.a11y.state('orientation', orientation);
-          def.a11y.action('activate', { event: 'click' });
-          def.a11y.relation('controls', { target: controls });
-          def.a11y.relation('labelledBy', { target: 'label-a' });
-          def.a11y.tree({ mergeChildren: true });
+          asAccessible().id(id);
+          asAccessible().role('button');
+          asAccessible().name(name);
+          asAccessible().description('Stores changes');
+          asAccessible().state('disabled', disabled);
+          asAccessible().state('hidden', hidden);
+          asAccessible().state('orientation', orientation);
+          asAccessible().action('activate', { event: 'click' });
+          asAccessible().relation('controls', { target: controls });
+          asAccessible().relation('labelledBy', { target: 'label-a' });
+          asAccessible().tree({ mergeChildren: true });
           def.props.watch(['disabled'], (_run, next) => {
             disabled.set(next.disabled);
             hidden.set(next.disabled);
@@ -106,8 +107,8 @@ describe('contract: adapter-web-component / a11y projection (v0)', () => {
       setup(def) {
         const role = def.state.string('heading.role', 'heading');
         const level = def.state.numberDiscrete('heading.level', 2);
-        def.a11y.role(role);
-        def.a11y.level(level);
+        asAccessible().role(role);
+        asAccessible().level(level);
         def.expose.method('setLevel', (value: number) =>
           level.set(value, 'reason: update heading level')
         );
@@ -169,7 +170,7 @@ describe('contract: adapter-web-component / a11y projection (v0)', () => {
 
         const hidden = def.state.bool('tree.hidden', true);
         const mergeChildren = def.state.bool('tree.mergeChildren', true);
-        def.a11y.tree({ hidden, mergeChildren });
+        asAccessible().tree({ hidden, mergeChildren });
         def.props.watch(['decorative'], (_run, next) => {
           hidden.set(next.decorative, 'reason: test tree hidden');
           mergeChildren.set(next.decorative, 'reason: test tree merge children');
@@ -208,7 +209,7 @@ describe('contract: adapter-web-component / a11y projection (v0)', () => {
       name: 'x-a11y-wc-additive-relation',
       setup(def) {
         const describedBy = def.state.string('describedBy', 'tooltip-a');
-        def.a11y.relation('describedBy', { target: describedBy, mode: 'append' });
+        asAccessible().relation('describedBy', { target: describedBy, mode: 'append' });
         def.expose.method('setDescription', (value: string) => describedBy.set(value));
         return (r) => r.el('button', 'Info');
       },
@@ -241,9 +242,9 @@ describe('contract: adapter-web-component / a11y projection (v0)', () => {
         const live = def.state.string('live', 'polite');
         const atomic = def.state.bool('atomic', true);
         const busy = def.state.bool('busy', false);
-        def.a11y.state('live', live);
-        def.a11y.state('atomic', atomic);
-        def.a11y.state('busy', busy);
+        asAccessible().state('live', live);
+        asAccessible().state('atomic', atomic);
+        asAccessible().state('busy', busy);
         def.expose.method('setLive', (value: string) => live.set(value));
         def.expose.method('setAtomic', (value: boolean) => atomic.set(value));
         def.expose.method('setBusy', (value: boolean) => busy.set(value));

--- a/packages/adapters/web-component/test/lifecycle-view-intent.test.ts
+++ b/packages/adapters/web-component/test/lifecycle-view-intent.test.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { describe, expect, it } from 'vitest';
 import { definePrototype, type RunHandle } from '@proto.ui/core';
 import { AdaptToWebComponent } from '../src/adapt';
@@ -136,7 +137,7 @@ describe('adapter-web-component: L1 view intent', () => {
       name: 'x-wc-view-intent-a11y-replay',
       setup(def) {
         const hidden = def.state.bool('hidden', true);
-        def.a11y.state('hidden', hidden);
+        asAccessible().state('hidden', hidden);
         def.lifecycle.onCreated((nextRun) => {
           run = nextRun;
           run.lifecycle.setPresent(false);

--- a/packages/core/src/a11y.ts
+++ b/packages/core/src/a11y.ts
@@ -52,7 +52,8 @@ export type A11ySemanticObjectSnapshot = {
   level?: number;
 };
 
-export type A11yDefAPI = {
+/** Setup-only declarations for the current logical instance; acquired through asAccessible(). */
+export type AccessibleHandle = {
   id(target: A11yIdentityTarget): void;
   role(role: A11yRoleTarget): void;
   name(value: A11yTextTarget): void;

--- a/packages/core/src/handles.ts
+++ b/packages/core/src/handles.ts
@@ -24,7 +24,6 @@ import {
 import type { AnatomyClaimDecl, AnatomyFamily, AnatomyOrderView, AnatomyPartView } from './anatomy';
 import { State, StateDefAPI, type BorrowedStateHandle, type OwnedStateHandle } from './state';
 import type { Unsubscribe } from './state';
-import type { A11yDefAPI } from './a11y';
 
 // 统一错误上下文，方便在 runtime 做 phase guard 时给出可诊断信息
 
@@ -289,8 +288,6 @@ export interface DefHandle<Props extends PropsBaseType, Exposes = Record<string,
       onChange: (run: RunHandle<Props>, parts: readonly AnatomyPartView[]) => void
     ): Unsubscribe;
   };
-
-  a11y: A11yDefAPI;
 }
 
 export type ContextOnChange<P extends PropsBaseType, T extends JsonObject> = (

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -8,7 +8,7 @@ Provides the built-in `as-*` hook DSL used by prototypes, while keeping runtime 
 
 ## Package Role
 
-Author-facing hook package for focus, overlay, trigger, collection, boundary, hit-participation, scroll-surface, and text-control helpers.
+Author-facing hook package for accessibility semantics, focus, overlay, trigger, collection, boundary, hit-participation, scroll-surface, and text-control helpers.
 
 ## Install
 
@@ -41,3 +41,20 @@ npm install @proto.ui/hooks@0.3.0-alpha.0
 ## License
 
 MIT
+
+## Accessibility semantics (0.3)
+
+`asAccessible()` returns the current instance's `AccessibleHandle` (exported by `@proto.ui/core`). Repeated calls during setup return the same handle without resetting declarations. All declaration methods are setup-only, even on a saved handle; runtime values follow bound State handles. Scalar fields and same-key bindings use the final setup declaration; tree patches merge by field.
+
+```ts
+import { asAccessible } from '@proto.ui/hooks';
+
+// Inside prototype setup:
+const accessible = asAccessible();
+accessible.role('button');
+accessible.nameFromContent();
+```
+
+This declares host-projectable semantics; it does not install keyboard handling, focus movement, or guarantee complete accessibility. State and interaction owners remain unchanged. The handle has no dispose, generic runtime mutation, arbitrary host target, or public internal-relation port.
+
+0.3 replaces `def.a11y` and `A11yDefAPI` directly, without compatibility aliases. 0.2 release history is unchanged; this migration is not backported.

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -58,3 +58,5 @@ accessible.nameFromContent();
 This declares host-projectable semantics; it does not install keyboard handling, focus movement, or guarantee complete accessibility. State and interaction owners remain unchanged. The handle has no dispose, generic runtime mutation, arbitrary host target, or public internal-relation port.
 
 0.3 replaces `def.a11y` and `A11yDefAPI` directly, without compatibility aliases. 0.2 release history is unchanged; this migration is not backported.
+
+A setup cannot register both an authored and a privileged hook under the same name. Runtime rejects that collision explicitly before reusing a handle or skipping setup; rename the authored hook when its name conflicts with a built-in.

--- a/packages/hooks/src/as-accessible.ts
+++ b/packages/hooks/src/as-accessible.ts
@@ -1,0 +1,15 @@
+import type { AccessibleHandle } from '@proto.ui/core';
+import type { PropsBaseType } from '@proto.ui/types';
+import { definePrivilegedAsHook } from './privileged';
+
+/** Declare accessibility semantics for this instance; does not install interaction behavior. */
+export const asAccessible = definePrivilegedAsHook<PropsBaseType, AccessibleHandle>({
+  name: 'asAccessible',
+  setup: ({ facades }) => {
+    const facade = facades.a11y as AccessibleHandle | undefined;
+    if (!facade || typeof facade.role !== 'function') {
+      throw new Error('[AsHook] a11y facade unavailable for asAccessible.');
+    }
+    return facade;
+  },
+});

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,3 +1,4 @@
+export * from './as-accessible';
 export * from './as-boundary';
 export * from './as-collection';
 export * from './as-collection-item';

--- a/packages/modules/a11y/README.md
+++ b/packages/modules/a11y/README.md
@@ -3,3 +3,5 @@
 Proto UI module that records accessibility semantic object IR for host projection.
 
 This package is intentionally not a Web ARIA wrapper. Adapters decide how to map the semantic object snapshot to their host accessibility surface.
+
+Prototype authors obtain an `AccessibleHandle` through `asAccessible()` from `@proto.ui/hooks`. The module retains the instance-scoped semantic IR and setup guards; State owns dynamic facts and the host capability owns projection. In 0.3, `def.a11y` and `A11yDefAPI` are removed without aliases.

--- a/packages/modules/a11y/src/create.ts
+++ b/packages/modules/a11y/src/create.ts
@@ -43,52 +43,52 @@ class A11yModuleImpl extends ModuleBase {
 
   readonly facade: A11yFacade = {
     id: (target) => {
-      this.ensureSetup('def.a11y.id');
+      this.ensureSetup('asAccessible.id');
       this.ir.id = target;
       this.applyProjection();
     },
     role: (role) => {
-      this.ensureSetup('def.a11y.role');
+      this.ensureSetup('asAccessible.role');
       this.ir.role = role;
       this.applyProjection();
     },
     name: (value) => {
-      this.ensureSetup('def.a11y.name');
+      this.ensureSetup('asAccessible.name');
       this.ir.name = { kind: 'text', value };
       this.applyProjection();
     },
     nameFromContent: () => {
-      this.ensureSetup('def.a11y.nameFromContent');
+      this.ensureSetup('asAccessible.nameFromContent');
       this.ir.name = { kind: 'content' };
       this.applyProjection();
     },
     description: (value) => {
-      this.ensureSetup('def.a11y.description');
+      this.ensureSetup('asAccessible.description');
       this.ir.description = { kind: 'text', value };
       this.applyProjection();
     },
     state: <V>(key: A11yStateKey, handle: State<V>) => {
-      this.ensureSetup('def.a11y.state');
+      this.ensureSetup('asAccessible.state');
       this.ir.states.set(key, { key, handle: handle as State<unknown> });
       this.applyProjection();
     },
     action: (key: A11yActionKey, spec: A11yActionSpec = {}) => {
-      this.ensureSetup('def.a11y.action');
+      this.ensureSetup('asAccessible.action');
       this.ir.actions.set(key, { ...spec });
       this.applyProjection();
     },
     relation: (key: A11yRelationKey, spec: A11yRelationSpec) => {
-      this.ensureSetup('def.a11y.relation');
+      this.ensureSetup('asAccessible.relation');
       this.ir.relations.set(key, { key, spec: { ...spec } });
       this.applyProjection();
     },
     tree: (patch: A11yTreeBehavior) => {
-      this.ensureSetup('def.a11y.tree');
+      this.ensureSetup('asAccessible.tree');
       this.ir.tree = { ...(this.ir.tree ?? {}), ...patch };
       this.applyProjection();
     },
     level: (value: number | State<number>) => {
-      this.ensureSetup('def.a11y.level');
+      this.ensureSetup('asAccessible.level');
       resolveA11yLevel(value);
       this.ir.level = value;
       this.installLevelWatch();

--- a/packages/modules/a11y/src/types.ts
+++ b/packages/modules/a11y/src/types.ts
@@ -1,7 +1,7 @@
 import type {
   A11yActionKey,
   A11yActionSpec,
-  A11yDefAPI,
+  AccessibleHandle,
   A11yIdentityTarget,
   A11yRelationKey,
   A11yRelationSpec,
@@ -16,7 +16,7 @@ import type {
   State,
 } from '@proto.ui/core';
 
-export type A11yFacade = A11yDefAPI;
+export type A11yFacade = AccessibleHandle;
 
 export type A11yStateBinding = {
   key: A11yStateKey;

--- a/packages/prototypes/base/src/async-region/root.proto.ts
+++ b/packages/prototypes/base/src/async-region/root.proto.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import type { DefHandle, RenderFn } from '@proto.ui/core';
 import { defineAsHook, definePrototype } from '@proto.ui/core';
 import type {
@@ -16,6 +17,7 @@ export type {
 function setupAsyncRegionRoot(
   def: DefHandle<AsyncRegionRootProps, AsyncRegionRootExposes>
 ): RenderFn {
+  const accessible = asAccessible();
   // P-BASE-ASYNC-REGION-BUSY
   def.props.define({
     busy: { type: 'boolean', empty: 'fallback' },
@@ -25,7 +27,7 @@ function setupAsyncRegionRoot(
   // P-BASE-ASYNC-REGION-BUSY
   const busy = def.state.bool('busy', false);
   def.expose.state('busy', busy);
-  def.a11y.state('busy', busy);
+  accessible.state('busy', busy);
 
   // P-BASE-ASYNC-REGION-BUSY, P-BASE-ASYNC-REGION-DYNAMIC
   const sync = (props: Readonly<AsyncRegionRootProps>) => {

--- a/packages/prototypes/base/src/button/button.proto.ts
+++ b/packages/prototypes/base/src/button/button.proto.ts
@@ -1,11 +1,12 @@
 import type { DefHandle } from '@proto.ui/core';
 import { defineAsHook, definePrototype } from '@proto.ui/core';
-import { asFocusable, asTrigger } from '@proto.ui/hooks';
+import { asAccessible, asFocusable, asTrigger } from '@proto.ui/hooks';
 import type { ButtonAsHookContract, ButtonExposes, ButtonProps, ButtonStateHandles } from './types';
 
 export type { ButtonProps, ButtonExposes, ButtonStateHandles, ButtonAsHookContract } from './types';
 
 function setupButton(def: DefHandle<ButtonProps, ButtonExposes>): void {
+  const accessible = asAccessible();
   // P-BASE-BUTTON-TRIGGER-SEMANTICS, P-BASE-BUTTON-NESTED-TRIGGER-ROUTE
   asTrigger();
 
@@ -20,7 +21,7 @@ function setupButton(def: DefHandle<ButtonProps, ButtonExposes>): void {
   // P-BASE-BUTTON-DISABLED-EXPOSE
   const disabled = def.state.bool('disabled', false);
   def.expose.state('disabled', disabled);
-  def.a11y.state('disabled', disabled);
+  accessible.state('disabled', disabled);
 
   // P-BASE-BUTTON-POINTER-HOVER
   const hovered = def.state.bool('hovered', false);
@@ -70,13 +71,13 @@ function setupButton(def: DefHandle<ButtonProps, ButtonExposes>): void {
   // P-BASE-BUTTON-CLICK-SIGNAL, P-BASE-BUTTON-CLICK-PROTOCOL-NAME
   def.expose.event('click', { payload: 'void' });
   // P-BASE-BUTTON-ROLE-COMMAND
-  def.a11y.action('activate', { event: 'click' });
+  accessible.action('activate', { event: 'click' });
 
   // P-BASE-BUTTON-ACCESSIBLE-ROLE
-  def.a11y.role('button');
+  accessible.role('button');
 
   // P-BASE-BUTTON-ACCESSIBLE-NAME, P-BASE-BUTTON-CONTENT-LABEL-SOURCE
-  def.a11y.nameFromContent();
+  accessible.nameFromContent();
 
   // P-BASE-BUTTON-KEYBOARD-ACTIVATION, P-BASE-BUTTON-KEYBOARD-SPACE-PREVENT-DEFAULT,
   // HC-DEFAULT-ACTION-0001: prevention is requested through the portable

--- a/packages/prototypes/base/src/checkbox/indicator.proto.ts
+++ b/packages/prototypes/base/src/checkbox/indicator.proto.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { CHECKBOX_CONTEXT, CHECKBOX_FAMILY, type CheckboxContextValue } from './shared';
 import type {
@@ -60,7 +61,7 @@ function setupCheckboxIndicator(
  * - P-BASE-CHECKBOX-INDICATOR-NO-INDETERMINATE-OWNER: indeterminate is only derived from Checkbox context.
  * - P-BASE-CHECKBOX-INDICATOR-NO-EVENT-TARGET: absence of def.event usage is the implementation.
  * - P-BASE-CHECKBOX-INDICATOR-NO-FOCUS-TARGET: absence of asFocusable/focusSelf is the implementation.
- * - P-BASE-CHECKBOX-INDICATOR-PRESENTATIONAL-A11Y: absence of def.a11y control syntax is the implementation.
+ * - P-BASE-CHECKBOX-INDICATOR-PRESENTATIONAL-A11Y: absence of asAccessible() control syntax is the implementation.
  * - P-BASE-CHECKBOX-INDICATOR-NO-FORM-INTEGRATION: no form-associated props are accepted.
  * - P-BASE-CHECKBOX-INDICATOR-NO-VISUAL-VARIANT-CORE: visual parameters are owned by downstream styled prototypes.
  */

--- a/packages/prototypes/base/src/checkbox/root.proto.ts
+++ b/packages/prototypes/base/src/checkbox/root.proto.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
-import { asFocusable, asTrigger } from '@proto.ui/hooks';
+import { asAccessible, asFocusable, asTrigger } from '@proto.ui/hooks';
 import { CHECKBOX_CONTEXT, CHECKBOX_FAMILY } from './shared';
 import type { CheckboxRootAsHookContract, CheckboxRootExposes, CheckboxRootProps } from './types';
 
@@ -8,6 +8,7 @@ function isEnterKeyboardCommit(ev: { key?: unknown } | undefined): boolean {
 }
 
 function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes>): void {
+  const accessible = asAccessible();
   // P-BASE-CHECKBOX-ROLE-CHECKED-INPUT, P-BASE-CHECKBOX-DISPLAY-AND-INPUT
   // P-BASE-CHECKBOX-ROOT-SEMANTIC-OWNER
   // P-BASE-CHECKBOX-ROOT-DOMAIN-ANCHOR
@@ -68,13 +69,13 @@ function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes
   def.expose.event('indeterminateChange', { payload: 'json' });
 
   // P-BASE-CHECKBOX-ACCESSIBLE-ROLE
-  def.a11y.role('checkbox');
+  accessible.role('checkbox');
   // P-BASE-CHECKBOX-ACCESSIBLE-NAME, P-BASE-CHECKBOX-STABLE-LABEL
-  def.a11y.nameFromContent();
+  accessible.nameFromContent();
   // P-BASE-CHECKBOX-A11Y-CHECKED, P-BASE-CHECKBOX-A11Y-MIXED
-  def.a11y.state('checked', checkedA11y);
-  def.a11y.state('disabled', disabled);
-  def.a11y.action('activate', { event: 'checkedChange' });
+  accessible.state('checked', checkedA11y);
+  accessible.state('disabled', disabled);
+  accessible.action('activate', { event: 'checkedChange' });
 
   let controlledChecked = false;
   let controlledIndeterminate = false;

--- a/packages/prototypes/base/src/dialog/command.ts
+++ b/packages/prototypes/base/src/dialog/command.ts
@@ -1,5 +1,5 @@
 import type { DefHandle, State } from '@proto.ui/core';
-import { asFocusable, asTrigger } from '@proto.ui/hooks';
+import { asAccessible, asFocusable, asTrigger } from '@proto.ui/hooks';
 
 type DialogCommandProps = { disabled?: boolean };
 
@@ -17,6 +17,7 @@ export function setupDialogCommand(
   def: DefHandle<DialogCommandProps, any>,
   reasonPrefix: string
 ): DialogCommand {
+  const accessible = asAccessible();
   // P-BASE-DIALOG-TRIGGER-NO-BUTTON-DEPENDENCY, P-BASE-DIALOG-CLOSE-NO-BUTTON-DEPENDENCY
   // P-BASE-DIALOG-TRIGGER-COMMAND, P-BASE-DIALOG-CLOSE-COMMAND
   asTrigger();
@@ -43,10 +44,10 @@ export function setupDialogCommand(
     if (disabled.get()) return;
     focusable.focusSelf(options);
   });
-  def.a11y.role('button');
-  def.a11y.nameFromContent();
-  def.a11y.state('disabled', disabled);
-  def.a11y.action('activate', { event: 'click' });
+  accessible.role('button');
+  accessible.nameFromContent();
+  accessible.state('disabled', disabled);
+  accessible.action('activate', { event: 'click' });
 
   const clearTransient = (reason: string) => {
     hovered.set(false, reason);

--- a/packages/prototypes/base/src/dialog/content.proto.ts
+++ b/packages/prototypes/base/src/dialog/content.proto.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, tw, type DefHandle } from '@proto.ui/core';
-import { asBoundary, asFocusScope, asOverlay } from '@proto.ui/hooks';
+import { asAccessible, asBoundary, asFocusScope, asOverlay } from '@proto.ui/hooks';
 import { asTransition } from '../tools';
 import {
   DIALOG_CONTEXT,
@@ -30,6 +30,7 @@ function projectDialogContentHandle(
 }
 
 function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExposes>): void {
+  const accessible = asAccessible();
   // P-BASE-DIALOG-CONTENT-PRESENCE, P-BASE-DIALOG-CONTENT-A11Y-ROLE
   def.anatomy.claim(DIALOG_FAMILY, { role: 'content' });
 
@@ -43,12 +44,12 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   const labelledBy = def.state.string('dialogLabelledBy', '');
   const describedBy = def.state.string('dialogDescribedBy', '');
   // P-BASE-DIALOG-CONTENT-A11Y-ROLE, P-BASE-DIALOG-CONTENT-A11Y-RELATIONS
-  def.a11y.id(contentId);
-  def.a11y.role(role);
-  def.a11y.name(accessibleLabel);
-  def.a11y.state('modal', modal);
-  def.a11y.relation('labelledBy', { target: labelledBy });
-  def.a11y.relation('describedBy', { target: describedBy });
+  accessible.id(contentId);
+  accessible.role(role);
+  accessible.name(accessibleLabel);
+  accessible.state('modal', modal);
+  accessible.relation('labelledBy', { target: labelledBy });
+  accessible.relation('describedBy', { target: describedBy });
 
   // P-BASE-DIALOG-CONTENT-DISMISS, P-BASE-DIALOG-CONTENT-FOCUS
   const overlay = asOverlay<DialogContentProps>();

--- a/packages/prototypes/base/src/dialog/description.proto.ts
+++ b/packages/prototypes/base/src/dialog/description.proto.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { createDialogPartId, DIALOG_CONTEXT, DIALOG_FAMILY } from './shared';
 import type {
@@ -9,10 +10,11 @@ import type {
 function setupDialogDescription(
   def: DefHandle<DialogDescriptionProps, DialogDescriptionExposes>
 ): void {
+  const accessible = asAccessible();
   // P-BASE-DIALOG-DESCRIPTION-RELATION
   def.anatomy.claim(DIALOG_FAMILY, { role: 'description' });
   const id = def.state.string('dialogDescriptionId', '');
-  def.a11y.id(id);
+  accessible.id(id);
   def.context.subscribe(DIALOG_CONTEXT, (_run, next) => {
     id.set(createDialogPartId(next.rootId, 'description'), 'reason: dialog description id sync');
   });

--- a/packages/prototypes/base/src/dialog/title.proto.ts
+++ b/packages/prototypes/base/src/dialog/title.proto.ts
@@ -1,13 +1,15 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { createDialogPartId, DIALOG_CONTEXT, DIALOG_FAMILY } from './shared';
 import type { DialogTitleAsHookContract, DialogTitleExposes, DialogTitleProps } from './types';
 
 function setupDialogTitle(def: DefHandle<DialogTitleProps, DialogTitleExposes>): void {
+  const accessible = asAccessible();
   // P-BASE-DIALOG-TITLE-LABEL
   def.anatomy.claim(DIALOG_FAMILY, { role: 'title' });
   const id = def.state.string('dialogTitleId', '');
-  def.a11y.id(id);
-  def.a11y.nameFromContent();
+  accessible.id(id);
+  accessible.nameFromContent();
   def.context.subscribe(DIALOG_CONTEXT, (_run, next) => {
     id.set(createDialogPartId(next.rootId, 'title'), 'reason: dialog title id sync');
   });

--- a/packages/prototypes/base/src/dialog/trigger.proto.ts
+++ b/packages/prototypes/base/src/dialog/trigger.proto.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { setupDialogCommand } from './command';
 import {
@@ -15,6 +16,7 @@ import type {
 } from './types';
 
 function setupDialogTrigger(def: DefHandle<DialogTriggerProps, DialogTriggerExposes>): void {
+  const accessible = asAccessible();
   // P-BASE-DIALOG-TRIGGER-COMMAND, P-BASE-DIALOG-TRIGGER-NO-BUTTON-DEPENDENCY
   def.anatomy.claim(DIALOG_FAMILY, { role: 'trigger' });
   const command = setupDialogCommand(def, 'dialog trigger');
@@ -22,9 +24,9 @@ function setupDialogTrigger(def: DefHandle<DialogTriggerProps, DialogTriggerExpo
   const hasPopup = def.state.string('dialogHasPopup', 'dialog');
   const controls = def.state.string('dialogContentId', '');
   // P-BASE-DIALOG-TRIGGER-A11Y
-  def.a11y.state('expanded', expanded);
-  def.a11y.state('hasPopup', hasPopup);
-  def.a11y.relation('controls', { target: controls });
+  accessible.state('expanded', expanded);
+  accessible.state('hasPopup', hasPopup);
+  accessible.relation('controls', { target: controls });
 
   const syncDialogFacts = (ctx: DialogContextValue) => {
     expanded.set(ctx.open, 'reason: dialog trigger expanded sync');

--- a/packages/prototypes/base/src/dropdown/content.proto.ts
+++ b/packages/prototypes/base/src/dropdown/content.proto.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, tw, type DefHandle } from '@proto.ui/core';
-import { asBoundary, asFocusRoving, asFocusScope, asOverlay } from '@proto.ui/hooks';
+import { asAccessible, asBoundary, asFocusRoving, asFocusScope, asOverlay } from '@proto.ui/hooks';
 import { useTypeaheadNavigation } from '../behaviors';
 import { asTransition } from '../tools';
 import {
@@ -32,6 +32,7 @@ function setupDropdownContent(
   _options?: void,
   api?: { store: Record<string, unknown> }
 ): void {
+  const accessible = asAccessible();
   def.anatomy.claim(DROPDOWN_FAMILY, { role: 'content' });
   def.props.define({
     side: { type: 'enum', empty: 'fallback', options: ['top', 'right', 'bottom', 'left'] },
@@ -55,9 +56,9 @@ function setupDropdownContent(
   const contentId = def.state.string('dropdownContentId', '');
   const orientation = def.state.string('dropdownOrientation', 'vertical');
   // P-BASE-DROPDOWN-MENU-CONTENT-A11Y
-  def.a11y.id(contentId);
-  def.a11y.role('menu');
-  def.a11y.state('orientation', orientation);
+  accessible.id(contentId);
+  accessible.role('menu');
+  accessible.state('orientation', orientation);
 
   let currentContext: DropdownContextValue | null = null;
   const focusScope = asFocusScope<DropdownContentProps>();

--- a/packages/prototypes/base/src/dropdown/item.proto.ts
+++ b/packages/prototypes/base/src/dropdown/item.proto.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
-import { asCollectionItem } from '@proto.ui/hooks';
+import { asAccessible, asCollectionItem } from '@proto.ui/hooks';
 import { setupDropdownCommand } from './command';
 import {
   DROPDOWN_CONTEXT,
@@ -10,6 +10,7 @@ import {
 import type { DropdownItemAsHookContract, DropdownItemExposes, DropdownItemProps } from './types';
 
 function setupDropdownItem(def: DefHandle<DropdownItemProps, DropdownItemExposes>): void {
+  const accessible = asAccessible();
   // P-BASE-DROPDOWN-MENU-ITEM-DISABLED: disabled menu items remain focusable.
   const command = setupDropdownCommand(def, 'dropdown item', { focusableWhenDisabled: true });
   const active = def.state.bool('active', false);
@@ -35,10 +36,10 @@ function setupDropdownItem(def: DefHandle<DropdownItemProps, DropdownItemExposes
   def.props.setDefaults({ disabled: false, value: '', textValue: '' });
 
   // P-BASE-DROPDOWN-MENU-ITEM-A11Y
-  def.a11y.role('menuitem');
-  def.a11y.nameFromContent();
-  def.a11y.state('disabled', command.disabled);
-  def.a11y.action('activate', { event: 'select' });
+  accessible.role('menuitem');
+  accessible.nameFromContent();
+  accessible.state('disabled', command.disabled);
+  accessible.action('activate', { event: 'select' });
   def.expose.state('active', active);
   def.expose.event('select', { payload: 'json' });
 

--- a/packages/prototypes/base/src/dropdown/trigger.proto.ts
+++ b/packages/prototypes/base/src/dropdown/trigger.proto.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { setupDropdownCommand } from './command';
 import {
@@ -14,6 +15,7 @@ import type {
 } from './types';
 
 function setupDropdownTrigger(def: DefHandle<DropdownTriggerProps, DropdownTriggerExposes>): void {
+  const accessible = asAccessible();
   // P-BASE-DROPDOWN-MENU-TRIGGER-COMMAND
   def.anatomy.claim(DROPDOWN_FAMILY, { role: 'trigger' });
   const command = setupDropdownCommand(def, 'dropdown trigger');
@@ -22,13 +24,13 @@ function setupDropdownTrigger(def: DefHandle<DropdownTriggerProps, DropdownTrigg
   const hasPopup = def.state.string('dropdownHasPopup', 'menu');
   const controls = def.state.string('dropdownContentId', '');
   // P-BASE-DROPDOWN-MENU-TRIGGER-A11Y
-  def.a11y.role('button');
-  def.a11y.nameFromContent();
-  def.a11y.state('disabled', command.disabled);
-  def.a11y.state('expanded', expanded);
-  def.a11y.state('hasPopup', hasPopup);
-  def.a11y.relation('controls', { target: controls });
-  def.a11y.action('activate', { event: 'click' });
+  accessible.role('button');
+  accessible.nameFromContent();
+  accessible.state('disabled', command.disabled);
+  accessible.state('expanded', expanded);
+  accessible.state('hasPopup', hasPopup);
+  accessible.relation('controls', { target: controls });
+  accessible.action('activate', { event: 'click' });
 
   const sync = (run: any, ctx: DropdownContextValue) => {
     command.syncDisabled(!!run.props.get().disabled || ctx.disabled);

--- a/packages/prototypes/base/src/input/root.proto.ts
+++ b/packages/prototypes/base/src/input/root.proto.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, type DefHandle, type RunHandle } from '@proto.ui/core';
-import { asFocusable, asTextControl } from '@proto.ui/hooks';
+import { asAccessible, asFocusable, asTextControl } from '@proto.ui/hooks';
 import { declareTextControl } from '@proto.ui/module-text-control';
 import type {
   InputChangeDetail,
@@ -21,6 +21,7 @@ export type {
 } from './types';
 
 function setupInputRoot(def: DefHandle<InputRootProps, InputRootExposes>) {
+  const accessible = asAccessible();
   def.props.define({
     value: { type: 'string', empty: 'fallback' },
     defaultValue: { type: 'string', empty: 'fallback' },
@@ -90,12 +91,12 @@ function setupInputRoot(def: DefHandle<InputRootProps, InputRootExposes>) {
   def.expose.event('compositionUpdate', { payload: 'json' });
   def.expose.event('compositionEnd', { payload: 'json' });
 
-  def.a11y.role('textbox');
-  def.a11y.name(ariaLabel);
-  def.a11y.state('disabled', disabled);
-  def.a11y.state('readOnly', readOnly);
-  def.a11y.relation('labelledBy', { target: labelledBy });
-  def.a11y.relation('describedBy', { target: describedBy });
+  accessible.role('textbox');
+  accessible.name(ariaLabel);
+  accessible.state('disabled', disabled);
+  accessible.state('readOnly', readOnly);
+  accessible.relation('labelledBy', { target: labelledBy });
+  accessible.relation('describedBy', { target: describedBy });
 
   const sync = (props: Readonly<InputRootProps>) => {
     const controlled = typeof props.value === 'string';

--- a/packages/prototypes/base/src/live-region/root.proto.ts
+++ b/packages/prototypes/base/src/live-region/root.proto.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import type { DefHandle, RenderFn } from '@proto.ui/core';
 import { defineAsHook, definePrototype } from '@proto.ui/core';
 import type {
@@ -15,6 +16,7 @@ export type {
 } from './types';
 
 function setupLiveRegionRoot(def: DefHandle<LiveRegionRootProps, LiveRegionRootExposes>): RenderFn {
+  const accessible = asAccessible();
   // P-BASE-LIVE-REGION-POLITENESS, P-BASE-LIVE-REGION-ATOMIC
   def.props.define({
     politeness: { type: 'enum', empty: 'fallback', options: ['polite', 'assertive'] },
@@ -26,9 +28,9 @@ function setupLiveRegionRoot(def: DefHandle<LiveRegionRootProps, LiveRegionRootE
   const role = def.state.string('role', 'status');
   const live = def.state.string('live', 'polite');
   const atomic = def.state.bool('atomic', true);
-  def.a11y.role(role);
-  def.a11y.state('live', live);
-  def.a11y.state('atomic', atomic);
+  accessible.role(role);
+  accessible.state('live', live);
+  accessible.state('atomic', atomic);
 
   // P-BASE-LIVE-REGION-SEMANTICS, P-BASE-LIVE-REGION-DYNAMIC
   const sync = (props: Readonly<LiveRegionRootProps>) => {

--- a/packages/prototypes/base/src/radio-group/item.proto.ts
+++ b/packages/prototypes/base/src/radio-group/item.proto.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, type DefHandle, type RunHandle } from '@proto.ui/core';
-import { asCollectionItem, asFocusable, asTrigger } from '@proto.ui/hooks';
+import { asAccessible, asCollectionItem, asFocusable, asTrigger } from '@proto.ui/hooks';
 import {
   createRadioGroupItemId,
   notifyRadioGroupItemsChanged,
@@ -17,6 +17,7 @@ import type {
 } from './types';
 
 function setupRadioGroupItem(def: DefHandle<RadioGroupItemProps, RadioGroupItemExposes>): void {
+  const accessible = asAccessible();
   asTrigger();
   const focusable = asFocusable<RadioGroupItemProps>();
   focusable.configure({ disabled: false });
@@ -54,11 +55,11 @@ function setupRadioGroupItem(def: DefHandle<RadioGroupItemProps, RadioGroupItemE
   def.expose.state('pressed', pressed);
   def.expose.event('select', { payload: 'json' });
 
-  def.a11y.role('radio');
-  def.a11y.nameFromContent();
-  def.a11y.state('checked', checked);
-  def.a11y.state('disabled', disabled);
-  def.a11y.action('activate', { event: 'select' });
+  accessible.role('radio');
+  accessible.nameFromContent();
+  accessible.state('checked', checked);
+  accessible.state('disabled', disabled);
+  accessible.action('activate', { event: 'select' });
 
   def.context.provide(RADIO_GROUP_ITEM_CONTEXT, { checked: false, disabled: false });
   let itemContextSnapshot = { checked: false, disabled: false };

--- a/packages/prototypes/base/src/radio-group/root.proto.ts
+++ b/packages/prototypes/base/src/radio-group/root.proto.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, type DefHandle, type RunHandle } from '@proto.ui/core';
-import { asCollection, asFocusRoving } from '@proto.ui/hooks';
+import { asAccessible, asCollection, asFocusRoving } from '@proto.ui/hooks';
 import {
   getRadioGroupItems,
   RADIO_GROUP_CONTEXT,
@@ -44,9 +44,8 @@ function sameContext(a: RadioGroupContextValue, b: RadioGroupContextValue): bool
   );
 }
 
-function setupRadioGroupRoot(
-  def: DefHandle<RadioGroupRootProps, RadioGroupRootExposes>
-): void {
+function setupRadioGroupRoot(def: DefHandle<RadioGroupRootProps, RadioGroupRootExposes>): void {
+  const accessible = asAccessible();
   def.anatomy.claim(RADIO_GROUP_FAMILY, { role: 'root' });
 
   const collection = asCollection();
@@ -80,9 +79,9 @@ function setupRadioGroupRoot(
   def.expose.method('focusPrev', () => focusRoving.focusPrev());
   def.expose.method('focusSelected', () => focusRoving.focusSelected());
 
-  def.a11y.role('radiogroup');
-  def.a11y.name(a11yLabel);
-  def.a11y.state('disabled', disabled);
+  accessible.role('radiogroup');
+  accessible.name(a11yLabel);
+  accessible.state('disabled', disabled);
 
   const initialContext: RadioGroupContextValue = {
     value: '',

--- a/packages/prototypes/base/src/select/content.proto.ts
+++ b/packages/prototypes/base/src/select/content.proto.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, delay, tw, type DefHandle } from '@proto.ui/core';
-import { asBoundary, asFocusRoving, asFocusScope, asOverlay } from '@proto.ui/hooks';
+import { asAccessible, asBoundary, asFocusRoving, asFocusScope, asOverlay } from '@proto.ui/hooks';
 import { useTypeaheadNavigation } from '../behaviors';
 import { asTransition } from '../tools';
 import {
@@ -32,6 +32,7 @@ function setupSelectContent(
   _options?: void,
   api?: { store: Record<string, unknown> }
 ): void {
+  const accessible = asAccessible();
   def.anatomy.claim(SELECT_FAMILY, { role: 'content' });
   def.props.define({
     side: { type: 'enum', empty: 'fallback', options: ['top', 'right', 'bottom', 'left'] },
@@ -52,9 +53,9 @@ function setupSelectContent(
 
   const contentId = def.state.string('selectContentId', '');
   const orientation = def.state.string('selectOrientation', 'vertical');
-  def.a11y.id(contentId);
-  def.a11y.role('listbox');
-  def.a11y.state('orientation', orientation);
+  accessible.id(contentId);
+  accessible.role('listbox');
+  accessible.state('orientation', orientation);
 
   const focusScope = asFocusScope<SelectContentProps>();
   focusScope.configure({ entry: 'manual', restore: 'none' });

--- a/packages/prototypes/base/src/select/item.proto.ts
+++ b/packages/prototypes/base/src/select/item.proto.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
-import { asCollectionItem } from '@proto.ui/hooks';
+import { asAccessible, asCollectionItem } from '@proto.ui/hooks';
 import { setupSelectCommand } from './command';
 import {
   notifySelectItemSnapshotChanged,
@@ -13,6 +13,7 @@ import {
 import type { SelectItemAsHookContract, SelectItemExposes, SelectItemProps } from './types';
 
 function setupSelectItem(def: DefHandle<SelectItemProps, SelectItemExposes>): void {
+  const accessible = asAccessible();
   const command = setupSelectCommand(def, 'select item');
   const active = def.state.bool('active', false);
   const selected = def.state.fromAccessibility('selected');
@@ -40,11 +41,11 @@ function setupSelectItem(def: DefHandle<SelectItemProps, SelectItemExposes>): vo
   def.expose.state('active', active);
   def.expose.state('selected', selected);
   def.expose.event('select', { payload: 'json' });
-  def.a11y.role('option');
-  def.a11y.nameFromContent();
-  def.a11y.state('selected', selected);
-  def.a11y.state('disabled', command.disabled);
-  def.a11y.action('activate', { event: 'select' });
+  accessible.role('option');
+  accessible.nameFromContent();
+  accessible.state('selected', selected);
+  accessible.state('disabled', command.disabled);
+  accessible.action('activate', { event: 'select' });
 
   const readContext = (run: any): SelectContextValue | null => {
     try {

--- a/packages/prototypes/base/src/select/trigger.proto.ts
+++ b/packages/prototypes/base/src/select/trigger.proto.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { setupSelectCommand } from './command';
 import {
@@ -14,6 +15,7 @@ import type {
 } from './types';
 
 function setupSelectTrigger(def: DefHandle<SelectTriggerProps, SelectTriggerExposes>): void {
+  const accessible = asAccessible();
   def.anatomy.claim(SELECT_FAMILY, { role: 'trigger' });
   const command = setupSelectCommand(def, 'select trigger');
   const expanded = def.state.bool('selectExpanded', false);
@@ -22,13 +24,13 @@ function setupSelectTrigger(def: DefHandle<SelectTriggerProps, SelectTriggerExpo
   const placeholder = def.state.bool('placeholder', true);
   def.expose.state('placeholder', placeholder);
 
-  def.a11y.role('combobox');
-  def.a11y.nameFromContent();
-  def.a11y.state('disabled', command.disabled);
-  def.a11y.state('expanded', expanded);
-  def.a11y.state('hasPopup', hasPopup);
-  def.a11y.relation('controls', { target: controls });
-  def.a11y.action('activate', { event: 'click' });
+  accessible.role('combobox');
+  accessible.nameFromContent();
+  accessible.state('disabled', command.disabled);
+  accessible.state('expanded', expanded);
+  accessible.state('hasPopup', hasPopup);
+  accessible.relation('controls', { target: controls });
+  accessible.action('activate', { event: 'click' });
 
   const sync = (run: any, ctx: SelectContextValue) => {
     command.syncDisabled(!!run.props.get().disabled || ctx.disabled);

--- a/packages/prototypes/base/src/separator/root.proto.ts
+++ b/packages/prototypes/base/src/separator/root.proto.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import type { DefHandle } from '@proto.ui/core';
 import { defineAsHook, definePrototype } from '@proto.ui/core';
 import type {
@@ -15,6 +16,7 @@ export type {
 } from './types';
 
 function setupSeparatorRoot(def: DefHandle<SeparatorRootProps, SeparatorRootExposes>) {
+  const accessible = asAccessible();
   // P-BASE-SEPARATOR-ORIENTATION, P-BASE-SEPARATOR-DECORATIVE
   def.props.define({
     orientation: { type: 'enum', empty: 'fallback', options: ['horizontal', 'vertical'] },
@@ -33,9 +35,9 @@ function setupSeparatorRoot(def: DefHandle<SeparatorRootProps, SeparatorRootExpo
   def.expose.state('orientation', orientation);
   def.expose.state('decorative', decorative);
   // P-BASE-SEPARATOR-DECORATIVE, P-BASE-SEPARATOR-SEMANTIC
-  def.a11y.role(role);
-  def.a11y.state('orientation', a11yOrientation);
-  def.a11y.tree({ hidden });
+  accessible.role(role);
+  accessible.state('orientation', a11yOrientation);
+  accessible.tree({ hidden });
 
   // P-BASE-SEPARATOR-ORIENTATION, P-BASE-SEPARATOR-DECORATIVE, P-BASE-SEPARATOR-SEMANTIC
   const sync = (props: Readonly<SeparatorRootProps>) => {

--- a/packages/prototypes/base/src/switch/root.proto.ts
+++ b/packages/prototypes/base/src/switch/root.proto.ts
@@ -1,9 +1,10 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
-import { asFocusable, asTrigger } from '@proto.ui/hooks';
+import { asAccessible, asFocusable, asTrigger } from '@proto.ui/hooks';
 import { SWITCH_CONTEXT, SWITCH_FAMILY } from './shared';
 import type { SwitchRootAsHookContract, SwitchRootExposes, SwitchRootProps } from './types';
 
 function setupSwitchRoot(def: DefHandle<SwitchRootProps, SwitchRootExposes>): void {
+  const accessible = asAccessible();
   // P-BASE-SWITCH-ROLE-ON-OFF-VALUE, P-BASE-SWITCH-DISPLAY-AND-INPUT
   // P-BASE-SWITCH-ROOT-SEMANTIC-OWNER, P-BASE-SWITCH-ROOT-DOMAIN-ANCHOR
   def.anatomy.claim(SWITCH_FAMILY, { role: 'root' });
@@ -53,13 +54,13 @@ function setupSwitchRoot(def: DefHandle<SwitchRootProps, SwitchRootExposes>): vo
   def.expose.event('checkedChange', { payload: 'json' });
 
   // P-BASE-SWITCH-ACCESSIBLE-ROLE
-  def.a11y.role('switch');
+  accessible.role('switch');
   // P-BASE-SWITCH-ACCESSIBLE-NAME, P-BASE-SWITCH-STABLE-LABEL
-  def.a11y.nameFromContent();
+  accessible.nameFromContent();
   // P-BASE-SWITCH-A11Y-CHECKED, P-BASE-SWITCH-A11Y-NO-MIXED
-  def.a11y.state('checked', checked);
-  def.a11y.state('disabled', disabled);
-  def.a11y.action('activate', { event: 'checkedChange' });
+  accessible.state('checked', checked);
+  accessible.state('disabled', disabled);
+  accessible.action('activate', { event: 'checkedChange' });
 
   // P-BASE-SWITCH-CONTEXT-PROVIDE, P-BASE-SWITCH-CONTEXT-VALUE
   def.context.provide(SWITCH_CONTEXT, {

--- a/packages/prototypes/base/src/switch/thumb.proto.ts
+++ b/packages/prototypes/base/src/switch/thumb.proto.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { SWITCH_CONTEXT, SWITCH_FAMILY, type SwitchContextValue } from './shared';
 import type { SwitchThumbAsHookContract, SwitchThumbExposes, SwitchThumbProps } from './types';
@@ -43,7 +44,7 @@ function setupSwitchThumb(def: DefHandle<SwitchThumbProps, SwitchThumbExposes>):
  * - P-BASE-SWITCH-THUMB-NO-VALUE-OWNER: absence of props and checkedChange is the implementation.
  * - P-BASE-SWITCH-THUMB-NO-EVENT-TARGET, P-BASE-SWITCH-THUMB-NOT-TARGET: absence of def.event usage is the implementation.
  * - P-BASE-SWITCH-THUMB-NO-FOCUS-TARGET: absence of asFocusable/focusSelf is the implementation.
- * - P-BASE-SWITCH-THUMB-PRESENTATIONAL-A11Y: absence of def.a11y control syntax is the implementation.
+ * - P-BASE-SWITCH-THUMB-PRESENTATIONAL-A11Y: absence of asAccessible() control syntax is the implementation.
  * - P-BASE-SWITCH-THUMB-NO-FORM-INTEGRATION: no form-associated props are accepted.
  * - P-BASE-SWITCH-THUMB-NO-VISUAL-VARIANT-CORE: visual parameters are owned by downstream styled prototypes.
  */

--- a/packages/prototypes/base/src/tabs/content.proto.ts
+++ b/packages/prototypes/base/src/tabs/content.proto.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, tw, type DefHandle } from '@proto.ui/core';
-import { asFocusEntry } from '@proto.ui/hooks';
+import { asAccessible, asFocusEntry } from '@proto.ui/hooks';
 import { createTabsPartId, TABS_CONTEXT, TABS_FAMILY, type TabsContextValue } from './shared';
 import type { TabsContentAsHookContract, TabsContentExposes, TabsContentProps } from './types';
 
@@ -17,6 +17,7 @@ function syncCurrentFromContext(
 }
 
 function setupTabsContent(def: DefHandle<TabsContentProps, TabsContentExposes>): void {
+  const accessible = asAccessible();
   // P-BASE-TABS-CONTENT-ROLE-PANEL, P-BASE-TABS-CONTENT-PROTOCOL-DEPENDENCY
   // P-BASE-TABS-CONTENT-CLAIM-ROLE, P-BASE-TABS-CONTENT-SAME-DOMAIN
   def.anatomy.claim(TABS_FAMILY, { role: 'content' });
@@ -52,10 +53,10 @@ function setupTabsContent(def: DefHandle<TabsContentProps, TabsContentExposes>):
 
   // P-BASE-TABS-CONTENT-A11Y-ROLE, P-BASE-TABS-CONTENT-A11Y-LABELLEDBY-TARGET
   // P-BASE-TABS-CONTENT-A11Y-HIDDEN, P-BASE-TABS-CONTENT-HIDDEN-WHEN-INACTIVE
-  def.a11y.id(contentId);
-  def.a11y.role('tabpanel');
-  def.a11y.state('hidden', hidden);
-  def.a11y.relation('labelledBy', { target: triggerId });
+  accessible.id(contentId);
+  accessible.role('tabpanel');
+  accessible.state('hidden', hidden);
+  accessible.relation('labelledBy', { target: triggerId });
 
   const syncIds = () => {
     // P-BASE-TABS-A11Y-RELATIONSHIP-TARGET

--- a/packages/prototypes/base/src/tabs/indicator.proto.ts
+++ b/packages/prototypes/base/src/tabs/indicator.proto.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { TABS_CONTEXT, TABS_FAMILY, type TabsContextValue } from './shared';
 import type {
@@ -48,7 +49,7 @@ function setupTabsIndicator(def: DefHandle<TabsIndicatorProps, TabsIndicatorExpo
  * - P-BASE-TABS-INDICATOR-NO-SELECTION-OWNER: absence of value props and valueChange is the implementation.
  * - P-BASE-TABS-INDICATOR-NO-EVENT-TARGET: absence of def.event usage is the implementation.
  * - P-BASE-TABS-INDICATOR-NO-FOCUS-TARGET: absence of asFocusable/focusSelf is the implementation.
- * - P-BASE-TABS-INDICATOR-PRESENTATIONAL-A11Y: absence of def.a11y control syntax is the implementation.
+ * - P-BASE-TABS-INDICATOR-PRESENTATIONAL-A11Y: absence of asAccessible() control syntax is the implementation.
  * - P-BASE-TABS-INDICATOR-NO-LAYOUT-MEASUREMENT: layout measurement is deferred to downstream styled prototypes.
  * - P-BASE-TABS-INDICATOR-NO-AUTO-POSITIONING: no position or transform props are accepted.
  * - P-BASE-TABS-INDICATOR-NO-VISUAL-VARIANT-CORE: visual parameters are owned by downstream styled prototypes.

--- a/packages/prototypes/base/src/tabs/list.proto.ts
+++ b/packages/prototypes/base/src/tabs/list.proto.ts
@@ -1,9 +1,10 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
-import { asFocusRoving } from '@proto.ui/hooks';
+import { asAccessible, asFocusRoving } from '@proto.ui/hooks';
 import { TABS_CONTEXT, TABS_FAMILY } from './shared';
 import type { TabsListAsHookContract, TabsListExposes, TabsListProps } from './types';
 
 function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
+  const accessible = asAccessible();
   // P-BASE-TABS-LIST-ROLE-COLLECTION, P-BASE-TABS-LIST-PROTOCOL-DEPENDENCY
   // P-BASE-TABS-LIST-CLAIM-ROLE, P-BASE-TABS-LIST-SAME-DOMAIN
   def.anatomy.claim(TABS_FAMILY, { role: 'list' });
@@ -25,9 +26,9 @@ function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
   const a11yLabel = def.state.string('a11yLabel', '');
   // P-BASE-TABS-LIST-A11Y-ROLE, P-BASE-TABS-LIST-A11Y-ORIENTATION
   // P-BASE-TABS-LIST-A11Y-LABEL
-  def.a11y.role('tablist');
-  def.a11y.name(a11yLabel);
-  def.a11y.state('orientation', orientation);
+  accessible.role('tablist');
+  accessible.name(a11yLabel);
+  accessible.state('orientation', orientation);
 
   // P-BASE-TABS-LIST-FOCUS-ROVING, P-BASE-TABS-LIST-SKIP-DISABLED
   // P-BASE-TABS-LIST-ORIENTATION-KEYS, P-BASE-TABS-LIST-HOME-END

--- a/packages/prototypes/base/src/tabs/trigger.proto.ts
+++ b/packages/prototypes/base/src/tabs/trigger.proto.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
-import { asCollectionItem, asFocusable, asTrigger } from '@proto.ui/hooks';
+import { asAccessible, asCollectionItem, asFocusable, asTrigger } from '@proto.ui/hooks';
 import { createTabsPartId, TABS_CONTEXT, TABS_FAMILY, type TabsContextValue } from './shared';
 import type { TabsTriggerAsHookContract, TabsTriggerExposes, TabsTriggerProps } from './types';
 
@@ -66,6 +66,7 @@ function resolveEnabledTriggerValue(run: any, candidate: string): string {
 }
 
 function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>): void {
+  const accessible = asAccessible();
   // P-BASE-TABS-TRIGGER-ROLE-TAB, P-BASE-TABS-TRIGGER-PROTOCOL-DEPENDENCY
   // P-BASE-TABS-TRIGGER-NO-BUTTON-DEPENDENCY
   // P-BASE-TABS-TRIGGER-ACTIVATION-REQUESTS-SELECTION
@@ -129,13 +130,13 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   // P-BASE-TABS-TRIGGER-A11Y-ROLE, P-BASE-TABS-TRIGGER-A11Y-SELECTED
   // P-BASE-TABS-TRIGGER-A11Y-DISABLED, P-BASE-TABS-TRIGGER-A11Y-CONTROLS-TARGET
   // P-BASE-TABS-TRIGGER-ACCESSIBLE-NAME
-  def.a11y.id(triggerId);
-  def.a11y.role('tab');
-  def.a11y.nameFromContent();
-  def.a11y.state('selected', selected);
-  def.a11y.state('disabled', disabled);
-  def.a11y.relation('controls', { target: contentId });
-  def.a11y.action('activate', { event: 'click' });
+  accessible.id(triggerId);
+  accessible.role('tab');
+  accessible.nameFromContent();
+  accessible.state('selected', selected);
+  accessible.state('disabled', disabled);
+  accessible.relation('controls', { target: contentId });
+  accessible.action('activate', { event: 'click' });
 
   const syncIds = () => {
     // P-BASE-TABS-A11Y-RELATIONSHIP-TARGET

--- a/packages/prototypes/base/src/textarea/root.proto.ts
+++ b/packages/prototypes/base/src/textarea/root.proto.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, type DefHandle, type RunHandle } from '@proto.ui/core';
-import { asFocusable, asTextControl } from '@proto.ui/hooks';
+import { asAccessible, asFocusable, asTextControl } from '@proto.ui/hooks';
 import { declareTextControl } from '@proto.ui/module-text-control';
 import type {
   TextareaCompositionDetail,
@@ -20,6 +20,7 @@ export type {
 } from './types';
 
 function setupTextareaRoot(def: DefHandle<TextareaRootProps, TextareaRootExposes>) {
+  const accessible = asAccessible();
   def.props.define({
     value: { type: 'string', empty: 'fallback' },
     defaultValue: { type: 'string', empty: 'fallback' },
@@ -84,12 +85,12 @@ function setupTextareaRoot(def: DefHandle<TextareaRootProps, TextareaRootExposes
   def.expose.event('compositionUpdate', { payload: 'json' });
   def.expose.event('compositionEnd', { payload: 'json' });
 
-  def.a11y.role('textbox');
-  def.a11y.name(ariaLabel);
-  def.a11y.state('disabled', disabled);
-  def.a11y.state('readOnly', readOnly);
-  def.a11y.relation('labelledBy', { target: labelledBy });
-  def.a11y.relation('describedBy', { target: describedBy });
+  accessible.role('textbox');
+  accessible.name(ariaLabel);
+  accessible.state('disabled', disabled);
+  accessible.state('readOnly', readOnly);
+  accessible.relation('labelledBy', { target: labelledBy });
+  accessible.relation('describedBy', { target: describedBy });
 
   const sync = (props: Readonly<TextareaRootProps>) => {
     const isControlled = typeof props.value === 'string';

--- a/packages/prototypes/base/src/toggle/toggle.proto.ts
+++ b/packages/prototypes/base/src/toggle/toggle.proto.ts
@@ -1,11 +1,12 @@
 import type { DefHandle } from '@proto.ui/core';
 import { defineAsHook, definePrototype } from '@proto.ui/core';
-import { asFocusable, asTrigger } from '@proto.ui/hooks';
+import { asAccessible, asFocusable, asTrigger } from '@proto.ui/hooks';
 import type { ToggleAsHookContract, ToggleExposes, ToggleProps, ToggleStateHandles } from './types';
 
 export type { ToggleProps, ToggleExposes, ToggleStateHandles, ToggleAsHookContract } from './types';
 
 function setupToggle(def: DefHandle<ToggleProps, ToggleExposes>): void {
+  const accessible = asAccessible();
   // P-BASE-TOGGLE-ROLE-ACTIVE-CONTROL, P-BASE-TOGGLE-PROTOCOL-INDEPENDENCE
   // P-BASE-TOGGLE-TRIGGER-SEMANTICS
   asTrigger();
@@ -53,13 +54,13 @@ function setupToggle(def: DefHandle<ToggleProps, ToggleExposes>): void {
   def.expose.event('activeChange', { payload: 'json' });
 
   // P-BASE-TOGGLE-ACCESSIBLE-ROLE
-  def.a11y.role('button');
+  accessible.role('button');
   // P-BASE-TOGGLE-ACCESSIBLE-NAME
-  def.a11y.nameFromContent();
+  accessible.nameFromContent();
   // P-BASE-TOGGLE-A11Y-PRESSED
-  def.a11y.state('pressed', active);
-  def.a11y.state('disabled', disabled);
-  def.a11y.action('activate', { event: 'activeChange' });
+  accessible.state('pressed', active);
+  accessible.state('disabled', disabled);
+  accessible.action('activate', { event: 'activeChange' });
 
   let controlled = false;
 

--- a/packages/prototypes/base/src/tooltip/content.proto.ts
+++ b/packages/prototypes/base/src/tooltip/content.proto.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, tw, type DefHandle, type RunHandle } from '@proto.ui/core';
-import { asOverlay } from '@proto.ui/hooks';
+import { asAccessible, asOverlay } from '@proto.ui/hooks';
 import { asTransition } from '../tools';
 import {
   createTooltipContentId,
@@ -29,10 +29,11 @@ function projectTooltipContentHandle(
 }
 
 function setupTooltipContent(def: DefHandle<TooltipContentProps, TooltipContentExposes>): void {
+  const accessible = asAccessible();
   def.anatomy.claim(TOOLTIP_FAMILY, { role: 'content' });
   const contentId = def.state.string('tooltipContentId', '');
-  def.a11y.id(contentId);
-  def.a11y.role('tooltip');
+  accessible.id(contentId);
+  accessible.role('tooltip');
 
   def.props.define({
     side: { type: 'enum', empty: 'fallback', options: ['top', 'right', 'bottom', 'left'] },

--- a/packages/prototypes/base/src/tooltip/trigger.proto.ts
+++ b/packages/prototypes/base/src/tooltip/trigger.proto.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, type DefHandle, type RunHandle } from '@proto.ui/core';
-import { asFocusable } from '@proto.ui/hooks';
+import { asAccessible, asFocusable } from '@proto.ui/hooks';
 import {
   createTooltipContentId,
   TOOLTIP_CONTEXT,
@@ -14,6 +14,7 @@ import type {
 } from './types';
 
 function setupTooltipTrigger(def: DefHandle<TooltipTriggerProps, TooltipTriggerExposes>): void {
+  const accessible = asAccessible();
   def.anatomy.claim(TOOLTIP_FAMILY, { role: 'trigger' });
   def.props.define({ disabled: { type: 'boolean', empty: 'fallback' } });
   def.props.setDefaults({ disabled: false });
@@ -26,7 +27,7 @@ function setupTooltipTrigger(def: DefHandle<TooltipTriggerProps, TooltipTriggerE
   const focused = focusable.focused;
   const focusVisible = focusable.focusVisible;
 
-  def.a11y.relation('describedBy', { target: describedBy, mode: 'append' });
+  accessible.relation('describedBy', { target: describedBy, mode: 'append' });
   def.expose.state('disabled', disabled);
   def.expose.state('hovered', hovered);
   def.expose.state('focused', focused);

--- a/packages/prototypes/brutalist/src/dialog/close-icon.proto.ts
+++ b/packages/prototypes/brutalist/src/dialog/close-icon.proto.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { definePrototype, tw } from '@proto.ui/core';
 import { asDialogClose } from '@proto.ui/prototypes-base/dialog';
 import type { BrutalistDialogCloseExposes, BrutalistDialogCloseProps } from './types';
@@ -5,13 +6,14 @@ import type { BrutalistDialogCloseExposes, BrutalistDialogCloseProps } from './t
 const dialogCloseIcon = definePrototype<BrutalistDialogCloseProps, BrutalistDialogCloseExposes>({
   name: 'brutalist-dialog-close-icon',
   setup(def) {
+    const accessible = asAccessible();
     // P-BRUTALIST-DIALOG-CLOSE-ICON-BASE-INHERITANCE: inherit Base Dialog Close (close/disabled/hovered/focusVisible) once, as precomposed close-icon variant.
     const state = asDialogClose().stateHandles;
     if (!state) throw new Error('[brutalist-dialog-close-icon] command states are required.');
     const { disabled, hovered, focusVisible } = state;
 
     // P-BRUTALIST-DIALOG-CLOSE-ICON-A11Y-NAME: a11y accessible name 'Close'.
-    def.a11y.name('Close');
+    accessible.name('Close');
     // P-BRUTALIST-DIALOG-CLOSE-ICON-VISUAL-GRAMMAR + P-BRUTALIST-DIALOG-CLOSE-ICON-PAIR-INVARIANT: fixed bg-canary/text-canary-foreground surface, square border-2 black, hard shadow-3, trailing X icon.
     def.feedback.style.use(
       tw(

--- a/packages/prototypes/brutalist/src/skeleton/root.proto.ts
+++ b/packages/prototypes/brutalist/src/skeleton/root.proto.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { definePrototype, tw } from '@proto.ui/core';
 import type { BrutalistSkeletonRootExposes, BrutalistSkeletonRootProps } from './types';
 
@@ -7,8 +8,9 @@ export const BrutalistSkeletonRoot = definePrototype<
 >({
   name: 'brutalist-skeleton-root',
   setup(def) {
+    const accessible = asAccessible();
     // P-BRUTALIST-SKELETON-DIRECT-OWNERSHIP, P-BRUTALIST-SKELETON-VISUAL-ONLY
-    def.a11y.tree({ hidden: true });
+    accessible.tree({ hidden: true });
     // P-BRUTALIST-SKELETON-CONSUMER-SIZE — the consuming composition owns dimensions.
     // P-BRUTALIST-SKELETON-VISUAL-GRAMMAR
     def.feedback.style.use(

--- a/packages/prototypes/shadcn/README.md
+++ b/packages/prototypes/shadcn/README.md
@@ -60,6 +60,7 @@ The root package export remains available for compatibility. Shadcn families do 
 ## Related Internal Packages
 
 - `@proto.ui/core`
+- `@proto.ui/hooks`
 - `@proto.ui/prototypes-base`
 
 ## License

--- a/packages/prototypes/shadcn/package.json
+++ b/packages/prototypes/shadcn/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@proto.ui/core": "workspace:*",
-    "@proto.ui/prototypes-base": "workspace:*"
+    "@proto.ui/prototypes-base": "workspace:*",
+    "@proto.ui/hooks": "workspace:*"
   },
   "devDependencies": {
     "@proto.ui/module-as-trigger": "workspace:*",

--- a/packages/prototypes/shadcn/src/dialog/close-icon.proto.ts
+++ b/packages/prototypes/shadcn/src/dialog/close-icon.proto.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { definePrototype, tw } from '@proto.ui/core';
 import { asDialogClose } from '@proto.ui/prototypes-base/dialog';
 import type { ShadcnDialogCloseExposes, ShadcnDialogCloseProps } from './types';
@@ -5,11 +6,12 @@ import type { ShadcnDialogCloseExposes, ShadcnDialogCloseProps } from './types';
 const dialogCloseIcon = definePrototype<ShadcnDialogCloseProps, ShadcnDialogCloseExposes>({
   name: 'shadcn-dialog-close-icon',
   setup(def) {
+    const accessible = asAccessible();
     const state = asDialogClose().stateHandles;
     if (!state) throw new Error('[shadcn-dialog-close-icon] command states are required.');
     const { disabled, hovered, focusVisible } = state;
 
-    def.a11y.name('Close');
+    accessible.name('Close');
     def.feedback.style.use(
       tw(
         'absolute right-4 top-4 inline-flex items-center justify-center rounded-sm opacity-70 transition-opacity outline-none ring-offset-0'

--- a/packages/runtime/src/kernel/as-hook.ts
+++ b/packages/runtime/src/kernel/as-hook.ts
@@ -221,6 +221,7 @@ export function attachAsHookRuntime<P extends PropsBaseType>(
     string,
     { order: number; state: AsHookInstanceState; mode: AsHookMode }
   >();
+  const registrationKinds = new Map<string, boolean>();
   const frameStack: EffectFrame[] = [];
   const rootStateNames = new Map<string, StateNameEntry>();
   let instanceOrder = 0;
@@ -288,6 +289,13 @@ export function attachAsHookRuntime<P extends PropsBaseType>(
   const runtime: AsHookRuntime = {
     ensureSetup,
     register: (name: string, meta: AsHookMeta) => {
+      const privileged = !!meta.privileged;
+      if (registrationKinds.has(name) && registrationKinds.get(name) !== privileged) {
+        throw new Error(
+          `[AsHook] ${name}: privileged and authored hooks cannot share a registration name.`
+        );
+      }
+      registrationKinds.set(name, privileged);
       const mode = meta.mode ?? 'once';
       const existing = instances.get(name);
 

--- a/packages/runtime/src/kernel/handles/def.ts
+++ b/packages/runtime/src/kernel/handles/def.ts
@@ -22,7 +22,6 @@ import type { ExposeEventFacade } from '@proto.ui/module-expose-event';
 import type { StateFacade } from '@proto.ui/module-state';
 import type { StateInteractionFacade } from '@proto.ui/module-state-interaction';
 import type { StateAccessibilityFacade } from '@proto.ui/module-state-accessibility';
-import type { A11yFacade } from '@proto.ui/module-a11y';
 import type { ContextFacade } from '@proto.ui/module-context';
 import { createExposeEventDeclaration, type ExposeFacade } from '@proto.ui/module-expose';
 import type { AnatomyFacade } from '@proto.ui/module-anatomy';
@@ -79,7 +78,6 @@ export const createDefHandle = <P extends PropsBaseType, E = Record<string, unkn
   const state = facades['state'] as StateFacade;
   const stateInteraction = facades['state-interaction'] as StateInteractionFacade | undefined;
   const stateAccessibility = facades['state-accessibility'] as StateAccessibilityFacade | undefined;
-  const a11y = facades['a11y'] as A11yFacade | undefined;
   const context = facades['context'] as ContextFacade;
   const expose = facades['expose'] as ExposeFacade;
   const anatomy = facades['anatomy'] as AnatomyFacade | undefined;
@@ -375,69 +373,6 @@ export const createDefHandle = <P extends PropsBaseType, E = Record<string, unkn
         return anatomy.subscribeParts(family, role, (ctx, parts) =>
           onChange(ctx as RunHandle<P>, parts)
         );
-      },
-    },
-
-    a11y: {
-      id(target) {
-        ensureSetup('def.a11y.id');
-        if (!a11y) throw new Error(`[A11y] module unavailable.`);
-        a11y.id(target);
-        recordCaptured(def, 'context', { op: 'a11y.id', target });
-      },
-      role(role) {
-        ensureSetup('def.a11y.role');
-        if (!a11y) throw new Error(`[A11y] module unavailable.`);
-        a11y.role(role);
-        recordCaptured(def, 'context', { op: 'a11y.role', role });
-      },
-      name(value) {
-        ensureSetup('def.a11y.name');
-        if (!a11y) throw new Error(`[A11y] module unavailable.`);
-        a11y.name(value);
-        recordCaptured(def, 'context', { op: 'a11y.name', value });
-      },
-      nameFromContent() {
-        ensureSetup('def.a11y.nameFromContent');
-        if (!a11y) throw new Error(`[A11y] module unavailable.`);
-        a11y.nameFromContent();
-        recordCaptured(def, 'context', { op: 'a11y.nameFromContent' });
-      },
-      description(value) {
-        ensureSetup('def.a11y.description');
-        if (!a11y) throw new Error(`[A11y] module unavailable.`);
-        a11y.description(value);
-        recordCaptured(def, 'context', { op: 'a11y.description', value });
-      },
-      state(key, handle) {
-        ensureSetup('def.a11y.state');
-        if (!a11y) throw new Error(`[A11y] module unavailable.`);
-        a11y.state(key, handle);
-        recordCaptured(def, 'state', { op: 'a11y.state', key, handle });
-      },
-      action(key, spec) {
-        ensureSetup('def.a11y.action');
-        if (!a11y) throw new Error(`[A11y] module unavailable.`);
-        a11y.action(key, spec);
-        recordCaptured(def, 'event', { op: 'a11y.action', key, spec });
-      },
-      relation(key, spec) {
-        ensureSetup('def.a11y.relation');
-        if (!a11y) throw new Error(`[A11y] module unavailable.`);
-        a11y.relation(key, spec);
-        recordCaptured(def, 'context', { op: 'a11y.relation', key, spec });
-      },
-      tree(patch) {
-        ensureSetup('def.a11y.tree');
-        if (!a11y) throw new Error(`[A11y] module unavailable.`);
-        a11y.tree(patch);
-        recordCaptured(def, 'context', { op: 'a11y.tree', patch });
-      },
-      level(value) {
-        ensureSetup('def.a11y.level');
-        if (!a11y) throw new Error(`[A11y] module unavailable.`);
-        a11y.level(value);
-        recordCaptured(def, 'context', { op: 'a11y.level', value });
       },
     },
   };

--- a/packages/runtime/test/contract/a11y.v0.contract.test.ts
+++ b/packages/runtime/test/contract/a11y.v0.contract.test.ts
@@ -6,7 +6,7 @@ import type {
   State,
 } from '@proto.ui/core';
 import { defineAsHook, definePrototype } from '@proto.ui/core';
-import { asScrollSurface } from '@proto.ui/hooks';
+import { asAccessible, asScrollSurface } from '@proto.ui/hooks';
 import { A11Y_PROJECT_CAP, type A11yPort } from '@proto.ui/module-a11y';
 import { SCROLL_SURFACE_HOST_CAP, type ScrollSurfaceHostAttachment } from '@proto.ui/module-scroll';
 import { createRuntimeSession, executeWithHost, type RuntimeHost } from '../../src';
@@ -60,8 +60,8 @@ describe('runtime contract: a11y (v0)', () => {
     const P = definePrototype({
       name: `x-a11y-heading-level-${level}`,
       setup(def) {
-        def.a11y.role('heading');
-        def.a11y.level(level);
+        asAccessible().role('heading');
+        asAccessible().level(level);
       },
     });
 
@@ -76,8 +76,8 @@ describe('runtime contract: a11y (v0)', () => {
       const P = definePrototype({
         name: 'x-a11y-invalid-static-heading-level',
         setup(def) {
-          def.a11y.role('heading');
-          def.a11y.level(level);
+          asAccessible().role('heading');
+          asAccessible().level(level);
         },
       });
 
@@ -95,8 +95,8 @@ describe('runtime contract: a11y (v0)', () => {
         name: 'x-a11y-invalid-initial-state-heading-level',
         setup(def) {
           const level = def.state.numberDiscrete('heading.level', initialLevel);
-          def.a11y.role('heading');
-          def.a11y.level(level);
+          asAccessible().role('heading');
+          asAccessible().level(level);
         },
       });
 
@@ -115,8 +115,8 @@ describe('runtime contract: a11y (v0)', () => {
         name: 'x-a11y-state-heading-level-update',
         setup(def) {
           level = def.state.numberDiscrete('heading.level', 2);
-          def.a11y.role('heading');
-          def.a11y.level(level);
+          asAccessible().role('heading');
+          asAccessible().level(level);
         },
       });
 
@@ -134,12 +134,12 @@ describe('runtime contract: a11y (v0)', () => {
     }
   );
 
-  it('A11Y-0064: captures a11y.tree declarations in an asHook result', () => {
+  it('A11Y-0064: captures the accessible child handle in an authored asHook result', () => {
     let result: any;
     const asSemanticTree = defineAsHook({
       name: 'as-semantic-tree',
       setup(def) {
-        def.a11y.tree({ mergeChildren: true });
+        asAccessible().tree({ mergeChildren: true });
       },
     });
     const P = definePrototype({
@@ -149,10 +149,12 @@ describe('runtime contract: a11y (v0)', () => {
       },
     });
 
-    executeWithHost(P as any, createHost().host as any);
-    expect(result.context).toEqual({
-      op: 'a11y.tree',
-      patch: { mergeChildren: true },
+    const runtime = executeWithHost(P as any, createHost().host as any);
+    const child = result.getAsHook('asAccessible');
+    expect(child.handle).toBe(child.result);
+    expect(typeof child.handle.tree).toBe('function');
+    expect(runtime.caps.getPort<A11yPort>('a11y')?.getSnapshot().tree).toEqual({
+      mergeChildren: true,
     });
   });
 
@@ -172,8 +174,8 @@ describe('runtime contract: a11y (v0)', () => {
       setup(def) {
         const level = asHeadingLevel().getState?.('level');
         if (!level) throw new Error('missing borrowed heading level');
-        def.a11y.role('heading');
-        def.a11y.level(level);
+        asAccessible().role('heading');
+        asAccessible().level(level);
       },
     });
 
@@ -187,8 +189,8 @@ describe('runtime contract: a11y (v0)', () => {
       name: 'x-a11y-observed-heading-level',
       setup(def) {
         const scroll = asScrollSurface();
-        def.a11y.role('heading');
-        def.a11y.level(scroll.horizontal.visibleRatio);
+        asAccessible().role('heading');
+        asAccessible().level(scroll.horizontal.visibleRatio);
       },
     });
 
@@ -205,8 +207,8 @@ describe('runtime contract: a11y (v0)', () => {
       setup(def) {
         const scroll = asScrollSurface();
         getVisibleRatio = () => scroll.getSnapshot().horizontal.visibleRatio;
-        def.a11y.role('heading');
-        def.a11y.level(scroll.horizontal.visibleRatio);
+        asAccessible().role('heading');
+        asAccessible().level(scroll.horizontal.visibleRatio);
       },
     });
 
@@ -261,8 +263,8 @@ describe('runtime contract: a11y (v0)', () => {
       name: 'x-a11y-detached-heading-level',
       setup(def) {
         level = def.state.numberDiscrete('heading.level', 2);
-        def.a11y.role('heading');
-        def.a11y.level(level);
+        asAccessible().role('heading');
+        asAccessible().level(level);
       },
     });
 
@@ -296,9 +298,9 @@ describe('runtime contract: a11y (v0)', () => {
       setup(def) {
         first = def.state.numberDiscrete('first.heading.level', 2);
         second = def.state.numberDiscrete('second.heading.level', 2);
-        def.a11y.role('heading');
-        def.a11y.level(first);
-        def.a11y.level(second);
+        asAccessible().role('heading');
+        asAccessible().level(first);
+        asAccessible().level(second);
       },
     });
 
@@ -339,8 +341,8 @@ describe('runtime contract: a11y (v0)', () => {
             level.set(0, 'reason: reentrant invalid level');
           }
         });
-        def.a11y.role('heading');
-        def.a11y.level(level);
+        asAccessible().role('heading');
+        asAccessible().level(level);
       },
     });
 
@@ -357,8 +359,8 @@ describe('runtime contract: a11y (v0)', () => {
       name: 'x-a11y-final-invalid-heading-level',
       setup(def) {
         const level = def.state.numberDiscrete('heading.level', 2);
-        def.a11y.role('heading');
-        def.a11y.level(level);
+        asAccessible().role('heading');
+        asAccessible().level(level);
         level.setDefault(0);
       },
     });
@@ -392,8 +394,8 @@ describe('runtime contract: a11y (v0)', () => {
         level.watch((_run, event) => {
           if (event.type === 'next') seen.push(event.next);
         });
-        def.a11y.role('heading');
-        def.a11y.level(level);
+        asAccessible().role('heading');
+        asAccessible().level(level);
       },
     });
 
@@ -410,8 +412,8 @@ describe('runtime contract: a11y (v0)', () => {
       name: 'x-a11y-capless-heading-level',
       setup(def) {
         level = def.state.numberDiscrete('heading.level', 2);
-        def.a11y.role('heading');
-        def.a11y.level(level);
+        asAccessible().role('heading');
+        asAccessible().level(level);
       },
     });
 
@@ -428,8 +430,8 @@ describe('runtime contract: a11y (v0)', () => {
       name: 'x-a11y-capless-invalid-heading-level-before-watch',
       setup(def) {
         const level = def.state.numberDiscrete('heading.level', 2);
-        def.a11y.role('heading');
-        def.a11y.level(level);
+        asAccessible().role('heading');
+        asAccessible().level(level);
         level.setDefault(0);
       },
     });
@@ -448,7 +450,7 @@ describe('runtime contract: a11y (v0)', () => {
       name: 'x-a11y-dynamic-role',
       setup(def) {
         role = def.state.string('role', 'dialog', { options: ['dialog', 'alertdialog'] });
-        def.a11y.role(role as any);
+        asAccessible().role(role as any);
         return (r) => r.el('div', 'dialog');
       },
     });
@@ -463,7 +465,7 @@ describe('runtime contract: a11y (v0)', () => {
     expect(ctx.snapshots.at(-1)?.role).toBe('alertdialog');
   });
 
-  it('A11Y-0100: def.a11y records semantic object IR and projects state snapshots', () => {
+  it('A11Y-0100: asAccessible() records semantic object IR and projects state snapshots', () => {
     // T-A11Y-0001-CASE-IR
     const P: Prototype<{ disabled?: boolean }> = definePrototype({
       name: 'x-a11y-ir-contract',
@@ -476,15 +478,15 @@ describe('runtime contract: a11y (v0)', () => {
         const disabled = def.state.bool('button.disabled', false);
         const id = def.state.string('button.id', 'button-a');
         const controls = def.state.string('button.controls', 'panel-a');
-        def.a11y.id(id);
-        def.a11y.role('button');
-        def.a11y.name('Save');
-        def.a11y.description('Stores changes');
-        def.a11y.state('disabled', disabled);
-        def.a11y.action('activate', { event: 'click' });
-        def.a11y.relation('controls', { target: controls });
-        def.a11y.relation('describedBy', { target: 'help-a', mode: 'append' });
-        def.a11y.tree({ mergeChildren: true });
+        asAccessible().id(id);
+        asAccessible().role('button');
+        asAccessible().name('Save');
+        asAccessible().description('Stores changes');
+        asAccessible().state('disabled', disabled);
+        asAccessible().action('activate', { event: 'click' });
+        asAccessible().relation('controls', { target: controls });
+        asAccessible().relation('describedBy', { target: 'help-a', mode: 'append' });
+        asAccessible().tree({ mergeChildren: true });
 
         def.lifecycle.onCreated((run) => {
           disabled.set(run.props.get().disabled);

--- a/packages/runtime/test/contract/as-accessible.contract.test.ts
+++ b/packages/runtime/test/contract/as-accessible.contract.test.ts
@@ -1,7 +1,7 @@
 // @ts-expect-error 0.3 removes the former public type as well as the def property.
 import type { A11yDefAPI } from '@proto.ui/core';
 import { expect, it } from 'vitest';
-import { definePrototype, type AccessibleHandle } from '@proto.ui/core';
+import { defineAsHook, definePrototype, type AccessibleHandle } from '@proto.ui/core';
 import { asAccessible } from '@proto.ui/hooks';
 import type { A11yPort } from '@proto.ui/module-a11y';
 import { executeWithHost } from '../../src';
@@ -71,3 +71,40 @@ it('shares one setup handle, composes declarations and rejects retained runtime 
   expect(accessible).not.toBe(firstHandle);
   expect(port.getSnapshot()).toEqual(before);
 });
+
+it.each(['authored-first', 'privileged-first'] as const)(
+  'rejects a privileged/authored name collision before reuse (%s)',
+  (order) => {
+    let authoredRuns = 0;
+    let returned!: AccessibleHandle;
+    const authored = defineAsHook({
+      name: 'asAccessible',
+      setup() {
+        authoredRuns += 1;
+      },
+    });
+    const P = definePrototype({
+      name: `accessible-collision-${order}`,
+      setup() {
+        if (order === 'authored-first') {
+          authored();
+          returned = asAccessible();
+        } else {
+          returned = asAccessible();
+          authored();
+        }
+      },
+    });
+    expect(() =>
+      executeWithHost(P, {
+        prototypeName: P.name,
+        getRawProps: () => ({}),
+        commit: (_children, signal) => signal?.done(),
+        schedule: (task) => task(),
+      })
+    ).toThrow(/asHook.*asAccessible.*privileged.*authored/i);
+    expect(authoredRuns).toBe(order === 'authored-first' ? 1 : 0);
+    if (order === 'authored-first') expect(returned).toBeUndefined();
+    else expect(typeof returned.role).toBe('function');
+  }
+);

--- a/packages/runtime/test/contract/as-accessible.contract.test.ts
+++ b/packages/runtime/test/contract/as-accessible.contract.test.ts
@@ -1,0 +1,73 @@
+// @ts-expect-error 0.3 removes the former public type as well as the def property.
+import type { A11yDefAPI } from '@proto.ui/core';
+import { expect, it } from 'vitest';
+import { definePrototype, type AccessibleHandle } from '@proto.ui/core';
+import { asAccessible } from '@proto.ui/hooks';
+import type { A11yPort } from '@proto.ui/module-a11y';
+import { executeWithHost } from '../../src';
+
+// T-A11Y-0001-CASE-ACCESSIBLE-HANDLE
+it('shares one setup handle, composes declarations and rejects retained runtime declarations', () => {
+  let accessible!: AccessibleHandle;
+  let oldEntry: unknown;
+  const P = definePrototype({
+    name: 'accessible-handle',
+    setup(def) {
+      oldEntry = (def as unknown as Record<string, unknown>).a11y;
+      // @ts-expect-error The removed def.a11y entry has no compatibility alias.
+      void def.a11y;
+      accessible = asAccessible();
+      expect(asAccessible()).toBe(accessible);
+      expect('dispose' in accessible).toBe(false);
+      accessible.role('button');
+      asAccessible().role('checkbox');
+      accessible.name('First');
+      asAccessible().name('Final');
+      accessible.state('checked', def.state.bool('first', false));
+      asAccessible().state('checked', def.state.bool('final', true));
+      accessible.action('activate', { event: 'first' });
+      asAccessible().action('activate', { event: 'final' });
+      accessible.relation('controls', { target: 'first' });
+      asAccessible().relation('controls', { target: 'final' });
+      accessible.tree({ hidden: true });
+      asAccessible().tree({ mergeChildren: true });
+    },
+  });
+  const host = {
+    prototypeName: P.name,
+    getRawProps: () => ({}),
+    commit: (_children: unknown, signal?: { done(): void }) => signal?.done(),
+    schedule: (task: () => void) => task(),
+  };
+  const first = executeWithHost(P, host);
+  const firstHandle = accessible;
+  const port = first.caps.getPort<A11yPort>('a11y')!;
+  expect(oldEntry).toBeUndefined();
+  expect(port.getSnapshot()).toMatchObject({
+    role: 'checkbox',
+    name: { kind: 'text', value: 'Final' },
+    states: { checked: true },
+    actions: { activate: { event: 'final' } },
+    relations: { controls: 'final' },
+    tree: { hidden: true, mergeChildren: true },
+  });
+  const before = port.getSnapshot();
+  const mutations = [
+    () => firstHandle.id('late'),
+    () => firstHandle.role('heading'),
+    () => firstHandle.name('late'),
+    () => firstHandle.nameFromContent(),
+    () => firstHandle.description('late'),
+    () => firstHandle.state('checked', {} as any),
+    () => firstHandle.action('activate'),
+    () => firstHandle.relation('controls', { target: 'late' }),
+    () => firstHandle.tree({ hidden: false }),
+    () => firstHandle.level(2),
+  ];
+  for (const mutate of mutations) expect(mutate).toThrow();
+  expect(port.getSnapshot()).toEqual(before);
+  expect(() => asAccessible()).toThrow();
+  executeWithHost(P, host);
+  expect(accessible).not.toBe(firstHandle);
+  expect(port.getSnapshot()).toEqual(before);
+});

--- a/packages/runtime/test/contract/lifecycle.module-resources.v1.contract.test.ts
+++ b/packages/runtime/test/contract/lifecycle.module-resources.v1.contract.test.ts
@@ -9,7 +9,7 @@ import {
   type A11ySemanticObjectSnapshot,
 } from '@proto.ui/core';
 import { A11Y_PROJECT_CAP } from '@proto.ui/module-a11y';
-import { asOverlay } from '@proto.ui/hooks';
+import { asAccessible, asOverlay } from '@proto.ui/hooks';
 import { EXPOSE_EVENT_SINK_CAP } from '@proto.ui/module-expose-event';
 import { EXPOSES_RECORD_SINK_CAP } from '@proto.ui/module-expose-state';
 import { EFFECTS_CAP, type FeedbackPort } from '@proto.ui/module-feedback';
@@ -147,7 +147,7 @@ describe('runtime contract: lifecycle module resource ownership (v1)', () => {
       setup(def) {
         disabled = def.state.bool('disabled', false);
         def.expose.state('disabled', disabled);
-        def.a11y.state('disabled', disabled);
+        asAccessible().state('disabled', disabled);
         return (run) => run.el('button', 'ok');
       },
     });

--- a/packages/runtime/test/contract/lifecycle.session.transitions.v1.contract.test.ts
+++ b/packages/runtime/test/contract/lifecycle.session.transitions.v1.contract.test.ts
@@ -1,3 +1,4 @@
+import { asAccessible } from '@proto.ui/hooks';
 import { describe, expect, it, vi } from 'vitest';
 import { definePrototype, type Prototype } from '@proto.ui/core';
 import { A11Y_PROJECT_CAP } from '@proto.ui/module-a11y';
@@ -37,7 +38,7 @@ const simpleProto = (callbacks: string[] = []): Prototype =>
   definePrototype({
     name: 'lifecycle-transition-matrix',
     setup(def) {
-      def.a11y.role('button');
+      asAccessible().role('button');
       def.lifecycle.onMounted(() => callbacks.push('mounted'));
       def.lifecycle.onUpdated(() => callbacks.push('updated'));
       def.lifecycle.onUnmounted(() => callbacks.push('unmounted'));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1104,6 +1104,9 @@ importers:
       '@proto.ui/core':
         specifier: workspace:*
         version: link:../../core
+      '@proto.ui/hooks':
+        specifier: workspace:*
+        version: link:../../hooks
       '@proto.ui/prototypes-base':
         specifier: workspace:*
         version: link:../base

--- a/spec/contracts/C-A11Y-0001.yaml
+++ b/spec/contracts/C-A11Y-0001.yaml
@@ -16,8 +16,8 @@ statement:
 criteria:
   - id: C-A11Y-0001-AUTHOR-HANDLE
     text:
-      en: From 0.3.0-alpha.0, asAccessible() returns the current logical instance's AccessibleHandle during setup. Repeated calls share one handle and semantic object without resetting declarations. DefHandle has no a11y property and A11yDefAPI is not exported; no compatibility alias is provided.
-      zh-CN: 从 0.3.0-alpha.0 起，asAccessible() 在 setup 返回当前逻辑实例的 AccessibleHandle。重复调用共享同一 handle 与语义对象，不重置声明。DefHandle 不再具有 a11y 属性，不再导出 A11yDefAPI，且不提供兼容别名。
+      en: From 0.3.0-alpha.0, asAccessible() returns the current logical instance's AccessibleHandle during setup. Repeated calls share one handle and semantic object without resetting declarations. DefHandle has no a11y property and A11yDefAPI is not exported; no compatibility alias is provided. A privileged/authored hook name collision must be rejected before cached handle reuse or setup suppression.
+      zh-CN: 从 0.3.0-alpha.0 起，asAccessible() 在 setup 返回当前逻辑实例的 AccessibleHandle。重复调用共享同一 handle 与语义对象，不重置声明。DefHandle 不再具有 a11y 属性，不再导出 A11yDefAPI，且不提供兼容别名。特权与 authored hook 同名冲突必须在复用缓存 handle 或跳过 setup 前被拒绝。
   - id: C-A11Y-0001-DECLARATION-LIFETIME
     text:
       en: All AccessibleHandle declaration methods are setup-only, including calls through a retained handle. The last setup declaration wins for a scalar field or the same state/action/relation key; tree patches merge by field. Runtime changes follow bound State values. The handle exposes no dispose or generic runtime mutation; view detach releases projection resources without discarding instance declarations, and remount projects current facts.

--- a/spec/contracts/C-A11Y-0001.yaml
+++ b/spec/contracts/C-A11Y-0001.yaml
@@ -14,6 +14,18 @@ statement:
 
 
 criteria:
+  - id: C-A11Y-0001-AUTHOR-HANDLE
+    text:
+      en: From 0.3.0-alpha.0, asAccessible() returns the current logical instance's AccessibleHandle during setup. Repeated calls share one handle and semantic object without resetting declarations. DefHandle has no a11y property and A11yDefAPI is not exported; no compatibility alias is provided.
+      zh-CN: 从 0.3.0-alpha.0 起，asAccessible() 在 setup 返回当前逻辑实例的 AccessibleHandle。重复调用共享同一 handle 与语义对象，不重置声明。DefHandle 不再具有 a11y 属性，不再导出 A11yDefAPI，且不提供兼容别名。
+  - id: C-A11Y-0001-DECLARATION-LIFETIME
+    text:
+      en: All AccessibleHandle declaration methods are setup-only, including calls through a retained handle. The last setup declaration wins for a scalar field or the same state/action/relation key; tree patches merge by field. Runtime changes follow bound State values. The handle exposes no dispose or generic runtime mutation; view detach releases projection resources without discarding instance declarations, and remount projects current facts.
+      zh-CN: AccessibleHandle 的所有声明方法仅限 setup，包括通过保存的 handle 调用。单值字段及相同 state/action/relation key 以 setup 最后一次声明为准；tree patch 按字段合并。runtime 变化跟随绑定的 State。handle 不提供 dispose 或通用 runtime mutation；view detach 释放投影资源但保留实例声明，remount 投影当前事实。
+  - id: C-A11Y-0001-DOMAIN-BOUNDARY
+    text:
+      en: AccessibleHandle declares host-projectable accessibility semantics, not complete accessibility certification. It does not create State ownership, keyboard or focus behavior, layout visibility, or arbitrary host targets. Anatomy and domain modules resolve structural targets; A11y expresses their relationships. Internal relation mutation ports are not author APIs.
+      zh-CN: AccessibleHandle 声明可由宿主投影的无障碍语义，不表示完整无障碍认证。它不创建 State 所有权、键盘或焦点行为、布局可见性或任意宿主 target。Anatomy 与领域模块解析结构目标，A11y 表达其关系；内部关系 mutation port 不是作者 API。
   - id: C-A11Y-0001-A
     text:
       zh-CN: a11y domain 必须输出可由 adapter 投影的 semantic object IR。
@@ -101,6 +113,9 @@ verifies:
   tests:
     - T-A11Y-0001
 revisions:
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Replaced def.a11y with the setup-only instance-scoped asAccessible handle without a compatibility alias; preserved domain ownership and existing declaration composition.
   - version: 0.1.0
     change: introduced
     summary: Introduced the minimal semantic object contract for the a11y module.

--- a/spec/modules/M-A11Y-0001.yaml
+++ b/spec/modules/M-A11Y-0001.yaml
@@ -3,7 +3,7 @@ type: module
 title: A11y module records semantic object IR
 status: draft
 since: 0.1.0
-summary: The a11y module provides the prototype author API and runtime IR storage for host-projectable accessibility semantic objects.
+summary: The a11y module provides the asAccessible author handle and runtime IR storage for host-projectable accessibility semantic objects.
 satisfies:
   contracts:
     - C-A11Y-0001
@@ -14,10 +14,14 @@ verifies:
   tests:
     - T-A11Y-0001
 sources:
+  - path: packages/hooks/src/as-accessible.ts
   - path: packages/modules/a11y/src/create.ts
   - path: packages/modules/a11y/src/types.ts
   - path: packages/modules/a11y/src/web.ts
 revisions:
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Exposed the existing instance facade through asAccessible while retaining setup guards, State observation and host projection ownership.
   - version: 0.3.0-alpha.0
     change: revised
     summary: >-

--- a/spec/prototypes/P-BASE-BUTTON.yaml
+++ b/spec/prototypes/P-BASE-BUTTON.yaml
@@ -260,14 +260,12 @@ criteria:
 openQuestions:
   - id: P-BASE-BUTTON-Q-A11Y-API
     question:
-      zh-CN: Button 的 accessible name、description、disabled reason 与 role mapping 应由 `def.a11y` 顶层 API、Button props、adapter inference 还是组合方式提供？
-      en: Should Button accessible name, description, disabled reason, and role mapping be provided by a top-level `def.a11y` API, Button props, adapter inference, or a combination?
+      zh-CN: 在 asAccessible 已提供语义声明入口的前提下，Button 是否需要额外的 accessible name、description 或原因说明 props？
+      en: With asAccessible providing semantic declarations, does Button need additional accessible-name, description or explanatory props?
     context:
-      zh-CN: 当前 Button 契约先要求可访问语义与 accessible name，但不提前固化 `label` prop 或 `def.a11y` API 形状。
-      en: The current Button contract requires accessibility semantics and accessible name without prematurely fixing a `label` prop or `def.a11y` API shape.
-    blocks:
-      - a11y module catalog
-      - def.a11y API design
+      zh-CN: 作者入口已确定为 asAccessible；独立的组件 props 设计仍等待实际需求，不阻塞当前入口迁移。
+      en: The author entry is asAccessible; separate component prop design awaits concrete use cases and does not block this migration.
+    blocks: []
   - id: P-BASE-BUTTON-Q-FORM-INTEGRATION
     question:
       zh-CN: Form 原型编目后，Button 的 `type`、`name`、`value`、`form*` 能力应以 Button 扩展、Form 协议能力，还是宿主 adapter 能力表达？

--- a/spec/prototypes/P-BASE-SWITCH.yaml
+++ b/spec/prototypes/P-BASE-SWITCH.yaml
@@ -583,6 +583,14 @@ criteria:
             - P-BASE-BUTTON-NO-VISUAL-VARIANT-CORE
             - P-BASE-BUTTON-PROP-VISUAL-DEFERRED
 openQuestions:
+  - id: P-BASE-SWITCH-Q-A11Y-API
+    question:
+      zh-CN: 在 asAccessible 已提供语义声明入口的前提下，Switch 是否需要额外的 accessible name、description 或原因说明 props？
+      en: With asAccessible providing semantic declarations, does Switch need additional accessible-name, description or explanatory props?
+    context:
+      zh-CN: 作者入口已确定为 asAccessible；独立的组件 props 设计仍等待实际需求，不阻塞当前入口迁移。
+      en: The author entry is asAccessible; separate component prop design awaits concrete use cases and does not block this migration.
+    blocks: []
   - id: P-BASE-SWITCH-Q-TRACK
     question:
       zh-CN: Switch track 是否应成为官方 anatomy role、profile recommendation、独立 part protocol，还是继续作为宿主模板内部结构？
@@ -603,16 +611,6 @@ openQuestions:
     blocks:
       - form prototype catalog
       - switch form extension design
-  - id: P-BASE-SWITCH-Q-A11Y-API
-    question:
-      zh-CN: Switch 的 accessible name、description、checked state 与 role mapping 应由 `def.a11y` 顶层 API、Switch props、adapter inference 还是组合方式提供？
-      en: Should Switch accessible name, description, checked state, and role mapping be provided by a top-level `def.a11y` API, Switch props, adapter inference, or a combination?
-    context:
-      zh-CN: 当前 Switch 契约先要求可访问语义与 checked projection，但不提前固化 `label` prop 或 `def.a11y` API 形状。
-      en: The current Switch contract requires accessibility semantics and checked projection without prematurely fixing a `label` prop or `def.a11y` API shape.
-    blocks:
-      - a11y module catalog
-      - def.a11y API design
   - id: P-BASE-SWITCH-Q-CHECKED-NAMING
     question:
       zh-CN: Base Switch 对外状态是否应长期使用 `checked`，还是在语义层区分 `checked` 与 `on`？

--- a/spec/tests/T-A11Y-0001.yaml
+++ b/spec/tests/T-A11Y-0001.yaml
@@ -6,7 +6,7 @@ since: 0.1.0
 summary: Contract tests for a11y semantic object IR, Button consumption, identity/relation projection, Web adapter projection, portable heading-level validation, role coherence, target rebinding, and cross-adapter lifecycle behavior.
 cases:
   - id: T-A11Y-0001-CASE-ACCESSIBLE-HANDLE
-    title: Shared setup handle, removed legacy entry and guarded retained declarations
+    title: Shared setup handle, removed legacy entry, guarded declarations and both name-collision orders
     covers:
       - C-A11Y-0001-AUTHOR-HANDLE
       - C-A11Y-0001-DECLARATION-LIFETIME

--- a/spec/tests/T-A11Y-0001.yaml
+++ b/spec/tests/T-A11Y-0001.yaml
@@ -5,6 +5,12 @@ status: draft
 since: 0.1.0
 summary: Contract tests for a11y semantic object IR, Button consumption, identity/relation projection, Web adapter projection, portable heading-level validation, role coherence, target rebinding, and cross-adapter lifecycle behavior.
 cases:
+  - id: T-A11Y-0001-CASE-ACCESSIBLE-HANDLE
+    title: Shared setup handle, removed legacy entry and guarded retained declarations
+    covers:
+      - C-A11Y-0001-AUTHOR-HANDLE
+      - C-A11Y-0001-DECLARATION-LIFETIME
+    expectation: same-instance-handle-with-last-setup-declaration-and-runtime-rejection
   - id: T-A11Y-0001-CASE-DYNAMIC-ROLE
     title: A semantic role may follow a state-backed fact
     covers:
@@ -77,6 +83,12 @@ cases:
       - HC-A11Y-0001-C
     expectation: portable-heading-level-setup-validation-runtime-omission-recovery-role-and-target-cleanup
 implementations:
+  - id: runtime-accessible-handle
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/as-accessible.contract.test.ts
+    required: true
+    consumesCases: [T-A11Y-0001-CASE-ACCESSIBLE-HANDLE]
   - id: runtime-a11y-contract
     kind: runtime-test
     status: passing
@@ -145,6 +157,8 @@ verifies:
   contracts:
     - id: C-A11Y-0001
       anchors:
+        - C-A11Y-0001-AUTHOR-HANDLE
+        - C-A11Y-0001-DECLARATION-LIFETIME
         - C-A11Y-0001-A
         - C-A11Y-0001-B
         - C-A11Y-0001-C
@@ -170,6 +184,9 @@ verifies:
         - HC-A11Y-0001-B
         - HC-A11Y-0001-C
 revisions:
+  - version: 0.3.0-alpha.0
+    change: revised
+    summary: Added shared AccessibleHandle, removed legacy API and retained-method setup guards; migrated existing Runtime and Adapter evidence to asAccessible.
   - version: 0.1.0
     change: introduced
     summary: Added the first a11y semantic object test mapping.


### PR DESCRIPTION
## Summary

Replace the 0.3 prototype author entry `def.a11y` with `asAccessible()` from `@proto.ui/hooks`, returning the core `AccessibleHandle`. Remove the former property and `A11yDefAPI` type without compatibility aliases. Migrate official consumers, executable evidence, author docs and draft release notes; declare Shadcn's new direct hooks dependency.

Repeated setup calls share one instance handle. Declaration methods remain setup-only even on retained handles, and dynamic facts retain State ownership. This changes the author entry, not accessibility interaction behavior or host projection policy.

## Related context

- Related integration work: #549 (same-domain Anatomy relationships) and #621 (Table / A11y graph). This PR changes their future author entry only; it does not satisfy their relationship or Table acceptance criteria and does not close either Issue. No dedicated existing Issue for the asAccessible migration was found.

- Maintainer-approved follow-up to #634; independent architecture slice.
- Draft authority: `C-A11Y-0001`, `M-A11Y-0001`, `HC-A11Y-0001`, `T-A11Y-0001`; lifecycle statuses remain unchanged, no admission proposed.
- New criteria: `C-A11Y-0001-AUTHOR-HANDLE`, `C-A11Y-0001-DECLARATION-LIFETIME`, `C-A11Y-0001-DOMAIN-BOUNDARY`.
- Evidence: `T-A11Y-0001-CASE-ACCESSIBLE-HANDLE` plus migrated existing Runtime and four Adapter tests.
- #625 remains a separate open direct-reference transport change. Its eventual integration must reconcile the same Module; this PR does not expose its internal mutation port.

## Scope boundary

The maintainer approved the name, shared setup handle and direct breaking migration on the 0.3 main line. No 0.2 backport, compatibility period, multiple-object author API, arbitrary host target, runtime mutation, disposal API or new action execution path. State, Focus, Anatomy and interaction modules retain their ownership.

## Source-of-truth alignment

- [x] Applicable spec entities were traced before implementation.
- [x] Criteria, test mappings, executable tests and reader projections changed together.
- [x] No placeholder identity or lifecycle promotion was introduced.

## Contribution provenance

- [x] This contribution includes material AI-assisted generation or transformation.
- [x] No third-party source disclosure is required.

No external implementation was copied. A coding agent traced existing repository sources, implemented the migration, updated specs/tests/docs and ran local verification. The human maintainer reviewed and approved the design and naming; independent implementation review remains pending. No external private or third-party source was supplied for this task.

## DCO

The commit includes the configured original contributor's matching Signed-off-by trailer. GitHub DCO verification remains a live check.

## Prototype website preview

- [x] A new Prototype page is not applicable: existing identities and visible behavior are preserved; bilingual author documentation is updated.
- Existing Shadcn controls browser regression consumes the migrated implementations and passed in the Web Component, React and Vue scope covered by that fixture.
- No new demo orchestration or consumer-owned behavior was introduced.

## Validation

- New handle + A11y Runtime + Vue 2 heading tests: 3 files, 39 tests passed.
- Full nonbrowser Vitest run: 455 files / 2164 tests passed, with one catalog failure caused by a new source not yet being Git-tracked. After indexing it, catalog evidence integrity passed 3/3. Existing 3 skipped files and 34 todo remain.
- Public build: 42 packages passed initially; Shadcn exposed a missing direct hooks dependency. After fixing manifest/lock/BOM, Shadcn's complete 11-package closure built successfully.
- Full workspace and docs types passed (195 Astro files, zero diagnostics); type contracts passed.
- Spec authoring against `e15a5adf`, prototype catalog, generated workspace/Agent projections, Agent checks, public-docs tests, all public manifests, release assets and all nine bundle budgets passed. Web Component measured 74767/76000 gzip bytes locally.
- Shadcn controls real-browser regression: 5/5 passed with a 60-second hook timeout.
- Not run: full browser matrix and isolated installed-consumer/release smoke. Required CI must validate the published PR head; local evidence is not complete assistive-technology certification.


### CI follow-up

The first CI test job failed because Shadcn's preserved README omitted the newly declared `@proto.ui/hooks` production dependency. Added it to Related Internal Packages; `node --test scripts/release/test/readme-metadata.test.mjs` now passes 4/4 and all 43 manifest checks pass. The initial public build, type check, release stage and installed consumer jobs passed; fresh CI must verify the follow-up head.


### Review follow-up: registration collision

Implemented the review's explicit-rejection option in Runtime registration, covering every mode before once/configure reuse. A name already registered by an authored hook cannot be reused by a privileged hook, or vice versa; a diagnostic identifies the conflicting name. Same-kind reuse remains unchanged. This deliberately rejects the mixed-name composition rather than introducing a new public lookup/namespace API; rename the authored hook to compose both.

Both requested call orders failed before the fix and pass now. Runtime/Core/Hooks regression: 64 files, 311 tests passed (existing 3 skipped files / 34 todo). Workspace types, spec authoring, catalog integrity and generated projection checks passed. New exact-head CI and independent review remain pending.
